### PR TITLE
Automatically start Kaoto backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Create and edit kaoto files.
 ## Features
 
 - Create and edit Kaoto (`.kaoto.yaml` and `.kaoto.yml`) files.
+
+## Prerequisites
+
+- `docker` must be available on system path


### PR DESCRIPTION
- starting it using a docker image
- not handling failure
- not handling occupied port
- stopping the container when extension is deactivated
- currently starting only when editor is opening because the extension
is activated only when the editor is opening. For the future, we will
need to pre-fetch the image sooner.
- using latest image for now, using a tag will be a lot better in the
future

fixes #2