### PR TITLE
Update publisher and vs code id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-kaoto",
   "publisher": "redhat",
-  "displayName": "VSCode Kaoto",
-  "description": "Edit Kaoto files",
+  "displayName": "Kaoto",
+  "description": "Kaoto - No Code and low code Integration editor",
   "version": "0.0.0",
   "license": "Apache-2.0",
   "repository": {
@@ -13,7 +13,7 @@
     "lint": "pnpm run-script-if --bool \"$(build-env global.build.lint)\" --then \"pnpm eslint ./src --ext .ts,.tsx\"",
     "build:prod": "rimraf dist && webpack && pnpm pack:prod",
     "build:dev": "rimraf dist && webpack --env dev",
-    "pack:prod": "vsce package --githubBranch main  --yarn -o ./dist/vscode_extension_kaoto_editor_$npm_package_version.vsix",
+    "pack:prod": "vsce package --githubBranch main  --yarn -o ./dist/vscode_kaoto_$npm_package_version.vsix",
     "compile": "webpack",
     "watch": "webpack",
     "run:webmode": "pnpm vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --version=stable"

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -30,7 +30,7 @@ export function activate(context: vscode.ExtensionContext) {
   backendProxy = new VsCodeBackendProxy(context, backendI18n);
 
   KogitoVsCode.startExtension({
-    extensionName: "kie-group.vscode-extension-kaoto-editor",
+    extensionName: "redhat.vscode-kaoto",
     context: context,
     viewType: "kieKogitoWebviewEditorsKaoto",
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [


### PR DESCRIPTION
sync up references between internal and various place in package.json
and simplify name to avoid redundant VS Code mention in the Display name

fixes #10
fixes #12 