### PR TITLE
The current kaoto-ui main branch requires a more recent backend than the

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
   console.info("Kaoto Editor extension is alive.");
 
   const kaotoBackendOutputChannel = vscode.window.createOutputChannel(`Kaoto backend`);
-  const backendProcess = child_process.spawnSync("docker", ["run", "--rm", "-d", "-p", "8081:8081", "kaotoio/backend"]);
+  const backendProcess = child_process.spawnSync("docker", ["run", "--rm", "-d", "-p", "8081:8081", "kaotoio/backend:main"]);
   handlePotentialErrorOnKaotoBackendStart(backendProcess, kaotoBackendOutputChannel);
   const filteredOutput = backendProcess.output.filter((s) => {
       return s !== undefined && s !== null && s.length > LENGTH_OF_DOCKER_CONTAINER_ID;


### PR DESCRIPTION
latest tag

using main tag

It remains up to the end-user to update their local image of main. Until there is tagged version of kaoto-ui, I think it is better to use this one. It might break but at least it will allow to detect it sooner.