### PR TITLE
Start docker image sooner

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "No Code Integration"
   ],
   "activationEvents": [
-    "onCustomEditor:webviewEditorsKaoto"
+    "onCustomEditor:webviewEditorsKaoto",
+    "workspaceContains:**/*.kaoto.yaml",
+    "workspaceContains:**/*.kaoto.yml",
+    "onStartupFinished"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
It will mitigate the case of Kaoto backend not yet ready when opening a Kaoto file.
Previously, it was starting it only when the Kaoto editor was opened. Now it is starting when it detects a Kaoto file in workspace or when all other extensions with high priority have activated.

fixes #34

Signed-off-by: Aurélien Pupier <apupier@redhat.com>