### PR TITLE
Provide Jenkins job config to publish a release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,3 +122,27 @@ The command `Developer: Toggle Developer Tools` gives access to classic develope
 `yarn run test-it`
 
 It is launching UI tests. Beware that it can take several minutes to start. Stay tuned for improvements to come later.
+
+## How to provide a new release version on VS Code Marketplace
+
+* Check that the version in package.json has not been published yet
+    * If already published:
+        * Update version in `package.json`
+        * Push changes in a Pull Request
+        * Wait for Pull Request to be merged
+* Check build is working fine on [GitHub Actions](https://github.com/KaotoIO/vscode-kaoto/actions) and [Jenkins CI](https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-kaoto-release/)
+* Check that someone listed as _submitter_ in Jenkinsfile is available
+* Create a tag
+* Push the tag to vscode-kaoto repository
+* Start build on [Jenkins CI](https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-kaoto-release/) with _publishToMarketPlace_ and _publishToOVSX_ parameters checked
+* When the build hits the _Publish to Marketplace_ step, it will wait for an approval
+* It is possible to check that the produced vsix is valid by using the one pushed in [Jboss download area](https://download.jboss.org/jbosstools/vscode/snapshots/vscode-kaoto/)
+* For someone in _submitter_ list:
+  * Ensure you are logged in
+  * Go to the console log of the build and click `Proceed`
+* Wait few minutes and check that it has been published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto) and [Open VSX Marketplace](https://open-vsx.org/extension/redhat/vscode-kaoto)
+* Keep build forever on Jenkins CI for later reference and edit build information to indicate the version
+* Prepare next iteration:
+    * Update version in `package.json`
+    * Push changes in a Pull Request
+    * Follow Pull Request until it is approved/merged

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+#!/usr/bin/env groovy
+
+def installBuildRequirements(){
+	def nodeHome = tool 'nodejs-lts'
+	env.PATH="${env.PATH}:${nodeHome}/bin"
+	sh "npm install --global yarn"
+	sh "yarn global add vsce"
+	sh "yarn global add webpack-cli"
+	sh "yarn global add webpack"
+	sh "yarn global add webpack-merge"
+}
+
+node('rhel8'){
+
+	stage 'Checkout vscode-kaoto code'
+	deleteDir()
+	git branch: 'main', url: 'https://github.com/KaotoIO/vscode-kaoto.git'
+
+	stage 'install vscode-kaoto build requirements'
+	installBuildRequirements()
+
+	stage 'Build vscode-kaoto'
+	sh "yarn"
+	sh "yarn build:dev"
+
+	stage('Test') {
+		wrap([$class: 'Xvnc']) {
+			sh "yarn test:it"
+		}
+	}
+
+	stage 'Package vscode-kaoto'
+	def packageJson = readJSON file: 'package.json'
+	sh "vsce package --yarn -o vscode-kaoto-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
+
+	stage 'Upload vscode-kaoto to staging'
+	def vsix = findFiles(glob: '**.vsix')
+	sh "sftp -C ${UPLOAD_LOCATION}/snapshots/vscode-kaoto/ <<< \$'put -p \"${vsix[0].path}\"'"
+	stash name:'vsix', includes:vsix[0].path
+}
+
+node('rhel8'){
+	if(publishToMarketPlace.equals('true')){
+		timeout(time:5, unit:'DAYS') {
+			input message:'Approve deployment?', submitter: 'apupier, jraez, mariasde, ryordan, mmelko'
+		}
+
+		stage 'Publish to Marketplaces'
+		unstash 'vsix';
+		def vsix = findFiles(glob: '**.vsix')
+		// VS Code Marketplace
+		withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
+			sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
+		}
+
+		// Open-vsx Marketplace
+		sh "npm install -g ovsx"
+		withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
+			sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
+		}
+		archive includes:"**.vsix"
+
+		stage ('Promote the build to stable') {
+			vsix = findFiles(glob: '**.vsix')
+			sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-kaoto/ <<< \$'put -p \"${vsix[0].path}\"'"
+		}
+	}
+}


### PR DESCRIPTION
part of #4

works with https://gitlab.cee.redhat.com/codeready-studio/cci-config/-/merge_requests/653

~~The job was working with locally built Jenkins instance but I'm unable to restart it. I stopped ti to have a completely clean one. So cannot show proof it is working :'-(~~
Can be seen here http://10.39.192.130:8080/job/Fuse/job/VSCode/job/vscode-kaoto-release/1/ (with Red Hat VPN and as long as I keep the instance running on my local machine). the job parameters has been slightly modified to be able to run. We will need this branch to be merged before it works on official jenkins. 

it is mostly aligned from VS Code Yaml https://github.com/redhat-developer/vscode-yaml/blob/main/Jenkinsfile . the difference is that I removed the pre-release part as [it is not working](https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Adapters/job/VSCode/job/vscode-yaml-release/19524/). We can get back to it later. And removed the specific platform  part as we do not have ones yet, can wait for a second iteration.

Note: The pre-release part not working has published a [pre-release with a wrong number on VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto), so I might need to increment the version for the first release. Not sure though as we will upload with a specific build id. To be tested at the release time. (we can see that is a pre-release only inside VS Code when trying to install, the VS Code marketplace UI is always behind in terms of functionalities)

