### PR TITLE
Use native library for Linux AMD 64 instead of Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Prerequisites
 
-- `docker` must be available on system path
+- Must be running on Linux
 
 ## Features
 
@@ -17,13 +17,12 @@
 
 ## Versions under the hood
 
-Kaoto UI is embedded in version 0.4.1. Kaoto backend is launched through `docker` using tag 0.4.0.
+Kaoto UI is embedded in version 0.4.1. Kaoto backend is launched natively using tag 0.4.0.
 
 ## Limitations
 
-- It is working only on Linux. The docker image used is not multi-arch.
-- `Deploy` button in Kaoto Editor is not working
-- The first time, the UI of the editor can take several minutes to load. It is the time to download a Docker image.
+- It is working only on Linux
+- Port 8081 must be available
 
 ## Data and Telemetry
 

--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as path from 'path';
 
 describe('Kaoto basic development flow', function () {
-	this.timeout(120000);
+	this.timeout(25000);
 
 	const workspaceFolder = path.join(__dirname, '../test Fixture with speci@l chars');
 
@@ -21,7 +21,6 @@ describe('Kaoto basic development flow', function () {
 	});
 
 	it('Open "empty.kaoto.yaml" file and check Kaoto UI is loading', async function () {
-		this.timeout(60000);
 		await VSBrowser.instance.openResources(path.join(workspaceFolder, 'empty.kaoto.yaml'));
 		const kaotoEditor = new CustomEditor();
 		assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
@@ -33,7 +32,7 @@ describe('Kaoto basic development flow', function () {
 			} catch {
 				return false;
 			}
-		}, 50000); // if it is the first load, it can take a lot of time as it downloads the docker image
+		});
 		await checkPartOfTopBarLoaded(driver);
 		await checkCanvasLoaded(driver);
 		await kaotoWebview.switchBack();


### PR DESCRIPTION
fixes #82

- it is a lot faster, especially the very first startup!
- same limitations than before with Docker images
- ninary is currently pushed, will  be improved with #84 

