### PR TITLE
Upgrading version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+- Technical version to be able to push on Marketplace
+
 # 0.1.0
 
 - Initial version: Open a Kaoto file, edit it and save it inside VS Code.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "redhat",
   "displayName": "Kaoto",
   "description": "Kaoto - No Code and low code Integration editor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "preview": true,
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
the 0.1.0 cannot be pushed to Microsoft Marketplace due to previous issue during development. Upgrading to 0.2.0 and will do a release with 0.2.0

