### PR TITLE
feat: Keep `Kaoto backend` output log available when Kaoto backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.3.0
 
+- Keep `Kaoto backend` output log available when Kaoto backend native executable cannot be launched. It allows to have more information what can be the issue.
+
 # 0.2.0
 
 - Technical version to be able to push on Marketplace


### PR DESCRIPTION
native executable cannot be launched.

It allows to have more information what can be the issue.
for instance, when the port is already occupied:

![image](https://user-images.githubusercontent.com/1105127/205889234-e992686b-94cb-406e-8ffc-a0b64351395c.png)
