### PR TITLE
Increase timeout for test execution to make it pass on Jenkins CI

### DIFF
--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import * as path from 'path';
 
 describe('Kaoto basic development flow', function () {
-	this.timeout(25000);
+	this.timeout(50000);
 
 	const workspaceFolder = path.join(__dirname, '../test Fixture with speci@l chars');
 


### PR DESCRIPTION
Kaoto 0.6.1 is taking more time to start
