### PR TITLE
Upgrade to Kaoto Backend 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.3.0
 
 - Keep `Kaoto backend` output log available when Kaoto backend native executable cannot be launched. It allows to have more information what can be the issue.
-- Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v0.6.1) and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v0.6.1) to 0.6.1
+- Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v0.6.1) to 0.6.1 and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v0.6.2) to 0.6.2
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Versions under the hood
 
-Kaoto UI is embedded in version 0.6.1. Kaoto backend is launched natively using version 0.6.1.
+Kaoto UI is embedded in version 0.6.1. Kaoto backend is launched natively using version 0.6.2.
 
 ## Limitations
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -19,7 +19,7 @@ const downloadKaotoBackendNativeExecutable = (backendVersion, platform, extensio
 	downloadFile(`https://github.com/KaotoIO/kaoto-backend/releases/download/${backendVersion}/kaoto-${platform}`, `./binaries/kaoto-${platform}${extension}`);
 }
 
-const backendVersion = "v0.6.1";
+const backendVersion = "v0.6.2";
 downloadKaotoBackendNativeExecutable(backendVersion, 'linux-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'macos-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'windows-amd64', '.exe');


### PR DESCRIPTION
fixes #128
fixes #126 

it introduces long delay to add a step #132 but it avoids infinite loop of #126 so i guess, it become a slightly better state if merging