### PR TITLE
Open *.camel.(yaml|yml) files by default with kaoto editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Keep `Kaoto backend` output log available when Kaoto backend native executable cannot be launched. It allows to have more information what can be the issue.
 - Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v0.6.1) to 0.6.1 and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v0.6.2) to 0.6.2
+- Open Kaoto editor by default for `*.camel.(yaml|yml)` files
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## Features
 
 - Edit Kaoto (`*.kaoto.yaml` and `*.kaoto.yml`) files.
+- Edit Camel files following pattern (`*.camel.yaml` and `*.camel.yml`). Beware that the unsupported elements by Kaoto are removed from the file.
 
 ![Create file named demo.kaoto.yaml, it opens automatically, then add 2 steps in embedded Kaoto UI and save the editor](images/basicDemo.gif)
 
@@ -28,6 +29,7 @@ Kaoto UI is embedded in version 0.6.1. Kaoto backend is launched natively using 
 - Requires `Amd64` architecture
 - Port 8081 must be available
 - Kaoto files are always written and overwritten with Linux-style end of line
+- Unsupported elements by Kaoto are removed from the files when opening them. The editor will open in dirty state in this case.
 
 ## Data and Telemetry
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "onCustomEditor:webviewEditorsKaoto",
     "workspaceContains:**/*.kaoto.yaml",
     "workspaceContains:**/*.kaoto.yml",
+    "workspaceContains:**/*.camel.yaml",
+    "workspaceContains:**/*.camel.yml",
     "onStartupFinished"
   ],
   "capabilities": {
@@ -88,7 +90,7 @@
         "displayName": "Kaoto Editor",
         "selector": [
           {
-            "filenamePattern": "*.{kaoto.yaml,kaoto.yml}"
+            "filenamePattern": "*.{kaoto,camel}.{yaml,yml}"
           }
         ]
       }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -78,7 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
     editorEnvelopeLocator: new EditorEnvelopeLocator("vscode", [
       new EnvelopeMapping({
         type: "kaoto",
-        filePathGlob: "**/*.kaoto.+(yml|yaml)",
+        filePathGlob: "**/*.+(kaoto|camel).+(yml|yaml)",
         resourcesPathPrefix: "dist/webview/editors/kaoto",
         envelopeContent: {
           type: EnvelopeContentType.PATH,

--- a/test Fixture with speci@l chars/my.camel.yaml
+++ b/test Fixture with speci@l chars/my.camel.yaml
@@ -1,0 +1,5 @@
+- from:
+    uri: timer:demo
+    steps:
+    - log:
+        message: my message logged


### PR DESCRIPTION
fixes #117

![OpenCamelRouteWithCamelFilenamePatternBydefaultWithKaoto](https://user-images.githubusercontent.com/1105127/220872333-ff61398c-c9c0-483b-8475-e32b8c21790f.gif)
