### PR TITLE
Avoid wipeout of content on restart with opened editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Keep `Kaoto backend` output log available when Kaoto backend native executable cannot be launched. It allows to have more information what can be the issue.
 - Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v0.6.1) to 0.6.1 and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v0.6.2) to 0.6.2
 - Open Kaoto editor by default for `*.camel.(yaml|yml)` files
+- Avoid wipeout of content on restart with opened editors #144
 
 # 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@kie-tools-core/workspace": "^0.26.0",
     "@patternfly/react-core": "4.267.6",
     "@redhat-developer/vscode-redhat-telemetry": "^0.5.4",
+    "async-wait-until": "^2.0.12",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,11 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+async-wait-until@^2.0.12:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/async-wait-until/-/async-wait-until-2.0.12.tgz#8a94683bf29e74642a8bcbb9385f6ea330d4383f"
+  integrity sha512-SXy/vDs6UPJMG6YeEYOQ4ilA/JnGxk187KPGqFx9O+qVxsjkSl+jH+3P50qSNyMpEmDgr8qOFGOKCJckWb1i7A==
+
 async@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"


### PR DESCRIPTION
The problem is that if the catalogs are not warmed up on first requests from kaoto UI, the content is wiped out because Kaoto backend seems to not waiting for the Catalog to be warmed up before returning an answer and consequently it is providing an empty results as it knows nothing of the content.

Not found an easy way to provide a non-regression test as it requires a restart of VS Code (but maybe we can find some alternatives, reload of workspaces/resources? the thing is that it requires the extension to be deactivated and reactivated so that the kaoto backend shut down) reported #147 - In fact, by side effect,  in case of regression it fails because it will cause curren tUi tests to fail with a timeout. It will be the case if they stay with a timeout which is lower than the tiemout used waiting for the warmed up of the Kaoto backend

fixes #44