### PR TITLE
Fix step extension loading

### DIFF
--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -1,6 +1,7 @@
-import { By, CustomEditor, EditorView,  until,  VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
+import { By, EditorView,  until,  VSBrowser, WebDriver } from 'vscode-extension-tester';
 import { assert } from 'chai';
 import * as path from 'path';
+import { openAndSwitchToKaotoFrame } from './Util';
 
 describe('Kaoto basic development flow', function () {
 	this.timeout(25000);
@@ -36,22 +37,6 @@ describe('Kaoto basic development flow', function () {
 		assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty after everything has loaded.');
 	});
 });
-
-async function openAndSwitchToKaotoFrame(workspaceFolder: string, fileNameToOpen: string, driver: WebDriver) {
-	await VSBrowser.instance.openResources(path.join(workspaceFolder, fileNameToOpen));
-	const kaotoEditor = new CustomEditor();
-	assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
-	const kaotoWebview = new WebView();
-	await driver.wait(async () => {
-		try {
-			await kaotoWebview.switchToFrame();
-			return true;
-		} catch {
-			return false;
-		}
-	});
-	return { kaotoWebview, kaotoEditor };
-}
 
 async function checkEmptyCanvasLoaded(driver: WebDriver) {
 	await driver.wait(until.elementLocated(By.xpath("//div[text()='ADD A STEP']")));

--- a/it-tests/StepExtensionLoading.test.ts
+++ b/it-tests/StepExtensionLoading.test.ts
@@ -1,0 +1,32 @@
+import { By, EditorView,  until,  VSBrowser, WebDriver } from 'vscode-extension-tester';
+import * as path from 'path';
+import { openAndSwitchToKaotoFrame } from './Util';
+
+describe('Step extension loading test', function () {
+	this.timeout(25000);
+
+	const workspaceFolder = path.join(__dirname, '../test Fixture with speci@l chars');
+
+	let driver: WebDriver;
+
+	before(async function() {
+		this.timeout(20000);
+		driver = VSBrowser.instance.driver;
+		await VSBrowser.instance.openResources(workspaceFolder);
+	});
+
+	afterEach(async function() {
+		const editorView = new EditorView();
+		await editorView.closeAllEditors();
+	});
+
+	it('Open "choice.camel.yaml" file and check Step extension is loading', async function () {
+		const { kaotoWebview, kaotoEditor } = await openAndSwitchToKaotoFrame(workspaceFolder, 'choice.camel.yaml', driver);
+		const stepChoiceXpath = By.xpath("//div[@data-testid='viz-step-choice']");
+		await driver.wait(until.elementLocated(stepChoiceXpath));
+		await (await driver.findElement(stepChoiceXpath)).click();
+		await driver.wait(until.elementLocated(By.xpath("//button[@data-testid='choice-add-when-button']")));
+		await kaotoWebview.switchBack();
+	});
+
+});

--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -1,0 +1,19 @@
+import { assert } from 'chai';
+import * as path from 'path';
+import { CustomEditor, VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
+
+export async function openAndSwitchToKaotoFrame(workspaceFolder: string, fileNameToOpen: string, driver: WebDriver) {
+	await VSBrowser.instance.openResources(path.join(workspaceFolder, fileNameToOpen));
+	const kaotoEditor = new CustomEditor();
+	assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
+	const kaotoWebview = new WebView();
+	await driver.wait(async () => {
+		try {
+			await kaotoWebview.switchToFrame();
+			return true;
+		} catch {
+			return false;
+		}
+	});
+	return { kaotoWebview, kaotoEditor };
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "displayName": "Kaoto",
   "description": "Kaoto - No Code and low code Integration editor",
   "version": "0.3.0",
+  "federatedModuleName": "kaoto",
   "preview": true,
   "license": "Apache-2.0",
   "repository": {
@@ -25,7 +26,7 @@
     "compile": "webpack",
     "watch": "webpack --env dev",
     "run:webmode": "yarn vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --open-devtools ./resources",
-    "test:it": "yarn test:it:clean && tsc --project tsconfig.it-tests.json --skipLibCheck --sourceMap true && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources out/*.test.js",
+    "test:it": "tsc --project tsconfig.it-tests.json --skipLibCheck --sourceMap true && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources 'out/*.test.js'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {

--- a/test Fixture with speci@l chars/choice.camel.yaml
+++ b/test Fixture with speci@l chars/choice.camel.yaml
@@ -1,0 +1,13 @@
+- from:
+    uri: direct:start
+    steps:
+    - choice:
+        when:
+        - simple: demo
+          steps:
+          - log:
+              message: in the when
+        otherwise:
+          steps:
+          - log:
+              message: in the otherwise

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,12 @@
+const { dependencies, federatedModuleName } = require('./package.json');
 const { merge } = require("webpack-merge");
 const webpack = require('webpack');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const path = require("path");
 const BG_IMAGES_DIRNAME = "bgimages";
+
+let deps = {};
+Object.keys(dependencies).forEach((key) => { deps[key] = { eager: true } });
 
 function posixPath(pathStr) {
   return pathStr.split(path.sep).join(path.posix.sep);
@@ -132,6 +136,14 @@ const commonConfig = (env) => {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.KAOTO_API': JSON.stringify("http://localhost:8081")
+      }),
+      new webpack.container.ModuleFederationPlugin({
+        name: federatedModuleName,
+        filename: 'remoteEntry.js',
+        library: { type: 'var', name: federatedModuleName },
+        shared: {
+          ...deps
+        }
       })
     ],
     externals: {


### PR DESCRIPTION
the trick is that the libraries were not visible to Step Extensions
because it is using micro-frontend patterns an it requires module
federation.

This commit is picking all dependencies and using them in federated
module with an `eager` state to true. This is not optimal. it can
potentially cause performance issue but none are visible currently (and
at least it is still better than crashing the editor when there is the
need for a step extension)

fixes https://github.com/KaotoIO/vscode-kaoto/issues/157

note: need to enclose the glob pattern for launching multiple tests