### PR TITLE
Remove limitation to have port 8081 available

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Kaoto UI is embedded in version 1.0.0. Kaoto backend is launched natively using 
 ## Limitations
 
 - Requires `Amd64` architecture
-- Port 8081 must be available
 - Kaoto files are always written and overwritten with Linux-style end of line
 - Unsupported elements by Kaoto are removed from the files when opening them. The editor will open in dirty state in this case.
 

--- a/src/webview/KaotoEditorEnvelopeApp.ts
+++ b/src/webview/KaotoEditorEnvelopeApp.ts
@@ -1,10 +1,11 @@
 import { KaotoEditorFactory } from "@kaoto/kaoto-ui/dist/lib/kogito-integration";
 import * as EditorEnvelope from "@kie-tools-core/editor/dist/envelope";
+import { kaotoBackendPort } from "./../extension/extension";
 
 declare const acquireVsCodeApi: any;
 
 EditorEnvelope.init({
   container: document.getElementById("envelope-app")!,
   bus: acquireVsCodeApi(),
-  editorFactory: new KaotoEditorFactory(),
+  editorFactory: new KaotoEditorFactory(`http://localhost:${kaotoBackendPort}`),
 });


### PR DESCRIPTION
it is delegating the choice of the port to Quarkus framework.

fixes #60

TODO:
- find a way to tell Kaoto UI to use this port
- remove hardcoded port in webpack.config.js
- provide test occupying port 8081