### PR TITLE
Launch test on CI on MacOS latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11,  windows-latest]
+        os: [ubuntu-latest, macos-latest,  windows-latest]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
currently 12 instead of 11.

It should be more stable now after other improvements

fixes #125