### PR TITLE
Stabilize tests by avoiding some notifications popup

### DIFF
--- a/test Fixture with speci@l chars/.vscode/settings.json
+++ b/test Fixture with speci@l chars/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "git.openRepositoryInParentFolders": "never",
+    "redhat.telemetry.enabled": false,
+}


### PR DESCRIPTION

the goal is to avoid this kind of notifications: ![Kaoto basic development flow Open empty camel yaml file, check Kaoto UI is loading, add a step and save](https://user-images.githubusercontent.com/1105127/225673979-3098afe6-5419-4802-8b1b-6445e524e14a.png)
