### PR TITLE
Change port of embedded Kaoto backend to 8097

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.6.0
 
+- Change default port of emebedded Kaoto backend from `8081` to `8097`
+
 # 0.5.0
 
 - Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v1.0.0) to 1.0.0 and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.0.0) to 1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ The command `Developer: Toggle Developer Tools` gives access to classic develope
 If you'd like to test latest Kaoto backend and not rely on a released version, follow these steps:
 
 * In `src/extension.ts`, comment call to `await warmupKaotoBackend()` in `activate` method.
-* Start Kaoto backend the way you prefer on `localhost:8081`. For instance [in dev mode](https://github.com/KaotoIO/kaoto-backend#running-the-dev-mode), from kaoto-backend repository, call `mvn quarkus:dev -pl api`.
+* Start Kaoto backend the way you prefer on `localhost:8097`. For instance [in dev mode](https://github.com/KaotoIO/kaoto-backend#running-the-dev-mode), from kaoto-backend repository, call `mvn quarkus:dev -pl api -Dquarkus.http.port=8097`.
 * Wait that the Kaoto backend ends to warmup all catalogs (usually takes less than 5 seconds)
 * In `Run and debug` perspective, call the `Run Extension` launch configuration
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kaoto UI is embedded in version 1.0.0. Kaoto backend is launched natively using 
 ## Limitations
 
 - Requires `Amd64` architecture
-- Port 8081 must be available
+- Port 8097 must be available
 - Kaoto files are always written and overwritten with Linux-style end of line
 - Unsupported elements by Kaoto are removed from the files when opening them. The editor will open in dirty state in this case.
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -71,7 +71,7 @@ export async function activate(context: vscode.ExtensionContext) {
   async function warmupKaotoBackend() {
     kaotoBackendOutputChannel = vscode.window.createOutputChannel(`Kaoto backend`);
     const nativeExecutable = context.asAbsolutePath(path.join("binaries", getBinaryName()));
-    backendProcess = child_process.spawn(nativeExecutable);
+    backendProcess = child_process.spawn(nativeExecutable, ['-Dquarkus.http.port=8097']);
     backendProcess.on("close", (code, _signal) => {
       if (kaotoBackendOutputChannel) {
         kaotoBackendOutputChannel.append(`Kaoto backend process closed with code: ${code}\n`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,7 +137,7 @@ const commonConfig = (env) => {
     },
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.KAOTO_API': JSON.stringify("http://localhost:8081"),
+        'process.env.KAOTO_API': JSON.stringify("http://localhost:8097"),
         'KAOTO_VERSION': JSON.stringify(kaotoUIpkg.version),
       }),
       new webpack.container.ModuleFederationPlugin({


### PR DESCRIPTION
8081 port is the default one for Quarkus applications causing often port conflicts.
To mitigate this problem changed the port to 8097.

plan is to pick a free port dynamically in another iteration, see #60 

fix #253