### PR TITLE
Upgrade kaoto backend to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.7.0
 
+- Upgrade embedded Kaoto [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.0.1) to 1.0.1
+
 # 0.6.0
 
 - Change default port of emebedded Kaoto backend from `8081` to `8097`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 ### Embedded
 
 - [Kaoto UI](https://github.com/KaotoIO/kaoto-ui) in version [1.0.0](https://github.com/KaotoIO/kaoto-ui/releases/tag/v1.0.0).
-- [Kaoto Backend](https://github.com/KaotoIO/kaoto-backend) in version [1.0.0](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.0.0).
+- [Kaoto Backend](https://github.com/KaotoIO/kaoto-backend) in version [1.0.1](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.0.1).
 
 ### Issues
 
@@ -55,7 +55,7 @@ Something is not working properly? In that case, feel free to [open issues, add 
 
 ### Get Involved
 
-If you'd like to help us get better, we appriciate it!
+If you'd like to help us get better, we appreciate it!
 Check out our [Contribution Guide](CONTRIBUTING.md) on how to do that.
 
 ### Data and Telemetry

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -19,7 +19,7 @@ const downloadKaotoBackendNativeExecutable = (backendVersion, platform, extensio
 	downloadFile(`https://github.com/KaotoIO/kaoto-backend/releases/download/${backendVersion}/kaoto-${platform}`, `./binaries/kaoto-${platform}${extension}`);
 }
 
-const backendVersion = "v1.0.0";
+const backendVersion = "v1.0.1";
 downloadKaotoBackendNativeExecutable(backendVersion, 'linux-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'macos-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'windows-amd64', '.exe');


### PR DESCRIPTION
Despite new backend 1.0.1 and the v2 endpoints, the UI tests are not passing with main branch of Kaoto UI.
I think they need to be adapted as the dom has been surely modified for some pieces.
We can still merge the backend upgrade, it will help to work on adapting the test to new UI from main branch to prepare later integration of next release