### PR TITLE
Adapt way to provide KAOTO_API url

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -138,7 +138,8 @@ const commonConfig = (env) => {
     },
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.KAOTO_API': JSON.stringify("http://localhost:8097"),
+        'KAOTO_API': JSON.stringify("http://localhost:8097"),
+        'process.env.KAOTO_API': JSON.stringify("http://localhost:8097"), // to remove with Kaoto 1.1.0
         'KAOTO_VERSION': JSON.stringify(kaotoUIpkg.version),
       }),
       new webpack.container.ModuleFederationPlugin({


### PR DESCRIPTION
keeping the old way too as it is not part of a released version yet

relates to KaotoIO/kaoto-standalone#32