### PR TITLE
fix(backend): Fix Kaoto backend CORS issues

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -63,15 +63,15 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand('kaoto.open', (uri: vscode.Uri) => {
     vscode.commands.executeCommand('vscode.openWith', uri, 'webviewEditorsKaoto');
   });
-  
-  const redhatService = await getRedHatService(context);  
+
+  const redhatService = await getRedHatService(context);
   telemetryService = await redhatService.getTelemetryService();
   telemetryService.sendStartupEvent();
 
   async function warmupKaotoBackend() {
     kaotoBackendOutputChannel = vscode.window.createOutputChannel(`Kaoto backend`);
     const nativeExecutable = context.asAbsolutePath(path.join("binaries", getBinaryName()));
-    backendProcess = child_process.spawn(nativeExecutable, ['-Dquarkus.http.port=8097']);
+    backendProcess = child_process.spawn(nativeExecutable, ['-Dquarkus.http.port=8097', '-Dquarkus.http.cors.origins=/^vscode-webview://.*/']);
     backendProcess.on("close", (code, _signal) => {
       if (kaotoBackendOutputChannel) {
         kaotoBackendOutputChannel.append(`Kaoto backend process closed with code: ${code}\n`);
@@ -131,7 +131,7 @@ export function deactivate() {
     backendProcess.kill();
   }
   backendProxy?.stopServices();
-  
+
   if (kaotoBackendOutputChannel != undefined) {
     kaotoBackendOutputChannel.dispose();
     kaotoBackendOutputChannel = undefined;


### PR DESCRIPTION
### Context
With the recent upgrade from Kaoto Backend to Quarkus 3.2, it seems that now the CORS configuration are more restricted.

### Fix
The fix is to allow origins from the `vscode-webview://` schema

### How to test?
1. Download the pull request branch
2. Update the backend version to at least `v1.1.0-M2`
3. Run the extension, the UI should load properly