### PR TITLE
Throw error when trying to download non existing Kaoto backend binary

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,17 +2,33 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 
+class HTTPResponseError extends Error {
+	constructor(response) {
+		super(`${response.status} ${response.statusText} - ${response.url}`);
+	}
+}
+
+const checkStatus = (response) => {
+	if (response.ok) {
+		return response;
+	} else {
+		throw new HTTPResponseError(response);
+	}
+}
+
 const downloadFile = (async (url, filePath) => {
   console.log(`Will fetch backend binary from ${url} into ${path.resolve(filePath)}`);
   const res = await fetch(url);
-  const fileStream = fs.createWriteStream(filePath);
-  await new Promise((resolve, reject) => {
-      res.body.pipe(fileStream);
-      res.body.on("error", reject);
-      fileStream.on("finish", resolve);
-  });
-  console.log(`Binary downloaded ${path.resolve(filePath)}`)
-  fs.chmodSync(filePath, "766");
+  if(checkStatus(res)) {
+    const fileStream = fs.createWriteStream(filePath);
+    await new Promise((resolve, reject) => {
+        res.body.pipe(fileStream);
+        res.body.on("error", reject);
+        fileStream.on("finish", resolve);
+    });
+    console.log(`Binary downloaded ${path.resolve(filePath)}`)
+    fs.chmodSync(filePath, "766");
+  }
 });
 
 const downloadKaotoBackendNativeExecutable = (backendVersion, platform, extension) => {


### PR DESCRIPTION
Before

- we spotted situation when there was missing backend binary for windows architecture and it lead to invisible flakiness because inside binaries of vscode kaoto extension the `kaoto-windows-amd64.exe` existed, but it was just created by our code and empty

After

- there will be from now check and error thrown when url we are trying to reachout with backend binaries is valid or not


Example of error in case there is not binary file available
```
➤ YN0000: ┌ Resolution step
➤ YN0060: │ @kaoto/kaoto-ui@npm:1.1.0-M3 [9fe6b] provides monaco-editor (p45f69) with version 0.40.0, which doesn't satisfy what react-monaco-editor requests
➤ YN0002: │ @kaoto/kaoto-ui@npm:1.1.0-M3 [9fe6b] doesn't provide prop-types (pefe68), requested by react-router-last-location
➤ YN0060: │ @kaoto/kaoto-ui@npm:1.1.0-M3 [9fe6b] provides react-monaco-editor (pcc593) with version 0.53.0, which doesn't satisfy what @patternfly/react-code-editor requests
➤ YN0002: │ @kaoto/kaoto-ui@npm:1.1.0-M3 [9fe6b] doesn't provide webpack (p607fd), requested by monaco-editor-webpack-plugin
➤ YN0002: │ @kaoto/kaoto-ui@npm:1.1.0-M3 [9fe6b] doesn't provide zone.js (pccc01), requested by @opentelemetry/instrumentation-user-interaction
➤ YN0002: │ uniforms-bridge-json-schema@npm:3.10.2 doesn't provide react (pda7a1), requested by uniforms
➤ YN0060: │ vscode-kaoto@workspace:. provides react (p88b3b) with version 18.2.0, which doesn't satisfy what @kaoto/kaoto-ui and some of its descendants request
➤ YN0060: │ vscode-kaoto@workspace:. provides react-dom (p520b4) with version 18.2.0, which doesn't satisfy what @kaoto/kaoto-ui and some of its descendants request
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 266ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 706ms
➤ YN0000: ┌ Link step
➤ YN0007: │ playwright@npm:1.35.0 must be built because it never has been before or the last one failed
➤ YN0007: │ keytar@npm:7.9.0 must be built because it never has been before or the last one failed
➤ YN0007: │ core-js@npm:2.6.12 must be built because it never has been before or the last one failed
➤ YN0007: │ vscode-kaoto@workspace:. must be built because it never has been before or the last one failed
➤ YN0009: │ vscode-kaoto@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/62/s2x_1lt97wsb60lh2vgvv3gc0000gn/T/xfs-fdd5267b/build.log)
➤ YN0000: └ Completed in 35s 515ms
➤ YN0000: Failed with errors in 36s 634ms
```

logs with details are saved in tmp .log file - `➤ YN0009: │ vscode-kaoto@workspace:. couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/62/s2x_1lt97wsb60lh2vgvv3gc0000gn/T/xfs-fdd5267b/build.log)`
```
# This file contains the result of Yarn building a package (vscode-kaoto@workspace:.)
# Script name: postinstall

Will fetch backend binary from https://github.com/KaotoIO/kaoto-backend/releases/download/v1.1.0-M2/kaoto-linux-amd64 into /Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/binaries/kaoto-linux-amd64
Will fetch backend binary from https://github.com/KaotoIO/kaoto-backend/releases/download/v1.1.0-M2/kaoto-macos-amd64 into /Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/binaries/kaoto-macos-amd64
Will fetch backend binary from https://github.com/KaotoIO/kaoto-backend/releases/download/v1.1.0-M2/kaoto-windows-amd64 into /Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/binaries/kaoto-windows-amd64.exe
/Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/scripts/postinstall.js:15
		throw new HTTPResponseError(response);
		      ^

HTTPResponseError: 404 Not Found - https://github.com/KaotoIO/kaoto-backend/releases/download/v1.1.0-M2/kaoto-windows-amd64
    at checkStatus (/Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/scripts/postinstall.js:15:9)
    at downloadFile (/Users/djelinek/development/repositories/fusetools-next/vscode-kaoto/scripts/postinstall.js:22:6)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

```