### PR TITLE
chore: Incorporate kaoto-ui monorepo changes

### DIFF
--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -32,10 +32,10 @@ jobs:
       working-directory: kaoto-ui
       run: |
         yarn
-        yarn build:lib
+        yarn workspace @kaoto/kaoto-ui run build:lib
     - name: yarn link kaoto-ui
       working-directory: vscode-kaoto
-      run: yarn link ../kaoto-ui
+      run: yarn link ../kaoto-ui/packages/kaoto-ui
     - name: yarn build:dev
       working-directory: vscode-kaoto
       run: yarn build:dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,11 @@ If you'd like to test latest Kaoto UI and not rely on a released version, follow
 
 * In `kaoto-ui` local clone folder:
   * `yarn`
-  * `yarn build:lib`
+  * `yarn workspace @kaoto/kaoto-ui run build:lib`
 * Open VS Code on `vscode-kaoto` local clone folder
 * `yarn`
-* `yarn link` _\<kaoto-ui local clone folder uri>_
-  * i.e. `yarn link ~/repositories/kaoto-ui`
+* `yarn link` _\<kaoto-ui local clone folder uri>/packages/kaoto-ui_
+  * i.e. `yarn link ~/repositories/kaoto-ui/packages/kaoto-ui`
 * `yarn build:dev`
 * In `Run and debug` perspective, call the `Run Extension` launch configuration
 * In the new VS Code opened (which has `[Extension Development host]` in window title),
@@ -115,8 +115,8 @@ If you'd like to test latest Kaoto UI and not rely on a released version, follow
   * Open the file
 
 To return to the default Kaoto UI version, just write on `vscode-kaoto` local clone folder:
-* `yarn unlink` _\<kaoto-ui local clone folder uri>_
-  * i.e. `yarn unlink ~/repositories/kaoto-ui`
+* `yarn unlink` _\<kaoto-ui local clone folder uri>/packages/kaoto-ui_
+  * i.e. `yarn unlink ~/repositories/kaoto-ui/packages/kaoto-ui`
 
 More information about [linking](https://yarnpkg.com/cli/link) and [unlinking](https://yarnpkg.com/cli/unlink) local packages with [yarn](https://yarnpkg.com/)
 


### PR DESCRIPTION
### Context
After `kaoto-ui` repository turned into a `monorepo`, we need to update the command used to link the `vscode-kaoto` repository and the `kaoto-ui` one.

Relates to this pull request: https://github.com/KaotoIO/kaoto-ui/pull/2158
fixes: https://github.com/KaotoIO/kaoto-ui/issues/2159