### PR TITLE
Upgrade Kaoto backend from 1.2.0 to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.9.0
 
-- Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v1.3.0) to 1.3.0
+- Upgrade embedded Kaoto [UI](https://github.com/KaotoIO/kaoto-ui/releases/tag/v1.3.0) and [backend](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.3.0) to 1.3.0
 
 # 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 ### Embedded
 
 - [Kaoto UI](https://github.com/KaotoIO/kaoto-ui) in version [1.3.0](https://github.com/KaotoIO/kaoto-ui/releases/tag/v1.3.0).
-- [Kaoto Backend](https://github.com/KaotoIO/kaoto-backend) in version [1.2.0](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.2.0).
+- [Kaoto Backend](https://github.com/KaotoIO/kaoto-backend) in version [1.3.0](https://github.com/KaotoIO/kaoto-backend/releases/tag/v1.3.0).
 
 ### Issues
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -35,7 +35,7 @@ const downloadKaotoBackendNativeExecutable = (backendVersion, platform, extensio
 	downloadFile(`https://github.com/KaotoIO/kaoto-backend/releases/download/${backendVersion}/kaoto-${platform}`, `./binaries/kaoto-${platform}${extension}`);
 }
 
-const backendVersion = "v1.2.0";
+const backendVersion = "v1.3.0";
 downloadKaotoBackendNativeExecutable(backendVersion, 'linux-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'macos-amd64', '');
 downloadKaotoBackendNativeExecutable(backendVersion, 'windows-amd64', '.exe');


### PR DESCRIPTION
to be tested when Kaoto backend 1.3.0 release is done (native binaries published)