### PR TITLE
FUSETOOLS2-2176 - upgrade CI to use Node 18.15.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18.15.x'
         cache: 'yarn'
     - name: yarn
       run: yarn --network-timeout 1000000

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -27,7 +27,7 @@ jobs:
         repository: KaotoIO/kaoto-ui
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18.15.x'
     - name: Kaoto-ui build
       working-directory: kaoto-ui
       run: |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 def installBuildRequirements(){
-	def nodeHome = tool 'nodejs-lts-16'
+	def nodeHome = tool 'nodejs-lts'
 	env.PATH="${env.PATH}:${nodeHome}/bin"
 	sh "npm install --global yarn"
 }


### PR DESCRIPTION
* Node 16 is EOL
* Newer version of Node 18 are nto working with  vscode-extension-tester