### PR TITLE
Fix Jenkinsfile for Node 18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def installBuildRequirements(){
 	sh "npm install --global yarn"
 }
 
-node('rhel9'){
+node('rhel8'){
 
 	stage 'Checkout vscode-kaoto code'
 	deleteDir()
@@ -20,11 +20,12 @@ node('rhel9'){
 	sh "yarn build:dev"
 	sh "yarn build:prod"
 
-	stage('Test') {
-		wrap([$class: 'Xvnc']) {
-			sh "yarn test:it"
-		}
-	}
+// Because vscode-extension-tester requires Node 18.15.x, we cannot play tests on Jenkins for now. they are played on GitHub Actions
+//	stage('Test') {
+//		wrap([$class: 'Xvnc']) {
+//			sh "yarn test:it"
+//		}
+//	}
 
 	stage 'Package vscode-kaoto'
 	def packageJson = readJSON file: 'package.json'


### PR DESCRIPTION
- rhel 9 is configured with ipv6 on jenkins, we need ipv4 so back to rhel 8
- vscode-extension-tester requires Node 18.15.x, we cannot play tests on Jenkins for now. they are played on GitHub Actions
see this build https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-kaoto-release/154/ with these modifications