### PR TITLE
issue-463: Add a badge to show the kaoto version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <h1 align="center">
-  <img src="./images/logo-kaoto-dark.png">
+  <img src="./images/logo-kaoto-dark.png" alt="Kaoto">
 </h1>
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-kaoto?style=for-the-badge" alt="Marketplace Version"/></a>
+  <a href="https://github.com/KaotoIO/kaoto-next/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FKaotoIO%2Fvscode-kaoto%2Fmain%2Fpackage.json&query=%24.dependencies%5B'%40kaoto-next%2Fui'%5D&style=for-the-badge&label=Kaoto%20UI&color=orange"></a>
   <img src="https://img.shields.io/badge/VS%20Code-1.46.0+-blue?style=for-the-badge" alt="Visual Studio Code Support"/>
   <a href="https://github.com/KaotoIO/vscode-kaoto/blob/main/LICENSE"><img src="https://img.shields.io/github/license/KaotoIO/vscode-kaoto?color=blue&style=for-the-badge" alt="License"/></a>
   <a href="https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen?color=yellow&style=for-the-badge" alt="Zulip"/></a></br>


### PR DESCRIPTION
nicely done using Dynamic JSON badge - https://shields.io/badges/dynamic-json-badge

it is pulling info from package.json in main (https://raw.githubusercontent.com/KaotoIO/vscode-kaoto/main/package.json)

<img width="1022" alt="Screenshot 2024-01-26 at 13 42 15" src="https://github.com/KaotoIO/vscode-kaoto/assets/18696866/f5b7b25f-94e5-4903-8bc1-d4905a6b8ff9">
