### PR TITLE
FUSETOOLS2-2272 - generate sbom on GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,17 @@ jobs:
     - name: Run UI Tests on Other OSes than Linux
       run: yarn run test:it:with-prebuilt-vsix
       if: ${{ matrix.os != 'ubuntu-latest' }}
+    - name: Generate SBOM
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        npm install -g @cyclonedx/cdxgen
+        cdxgen -o manifest.json
+    - name: Store SBOM
+      uses: actions/upload-artifact@v4
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        name: sbom
+        path: manifest.json
     - name: Archive vsix
       uses: actions/upload-artifact@v4
       if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
Use cdxgen as it is a yarn project, it comes with these limitations compared to other VS code Camel tooling project:
- mix of hierarchical and flat view of dependencies
- dev dependencies are included