### PR TITLE
Use VS Code 1.85.2 to play UI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest,  windows-latest]
 
     env:
+      CODE_VERSION: "1.85.2"
       TEST_RESOURCES: test-resources
 
     steps:

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -16,6 +16,7 @@ jobs:
         os: [ubuntu-latest]
 
     env:
+      CODE_VERSION: "1.85.2"
       TEST_RESOURCES: test-resources
 
     steps:


### PR DESCRIPTION
to avoid problems between VS Code extension tester and 1.86.x