### PR TITLE
build: Use for testing the latest (max) VS Code version supported by ExTester

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest,  windows-latest]
 
     env:
-      CODE_VERSION: "1.85.2"
+      CODE_VERSION: max
       TEST_RESOURCES: test-resources
 
     steps:

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest]
 
     env:
-      CODE_VERSION: "1.85.2"
+      CODE_VERSION: max
       TEST_RESOURCES: test-resources
 
     steps:


### PR DESCRIPTION
currently it is VS Code 1.86.1, and in future it should be always the latest VS Code verssion which was tested that EWxTester is working with that version