### PR TITLE
build(jenkins): Re-enable tests to run during Jenkins jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,11 @@ node('rhel8'){
 	sh "yarn build:dev"
 	sh "yarn build:prod"
 
-// Because vscode-extension-tester requires Node 18.15.x, we cannot play tests on Jenkins for now. they are played on GitHub Actions
-//	stage('Test') {
-//		wrap([$class: 'Xvnc']) {
-//			sh "yarn test:it"
-//		}
-//	}
+	stage('Test') {
+		wrap([$class: 'Xvnc']) {
+			sh "yarn test:it"
+		}
+	}
 
 	stage 'Package vscode-kaoto'
 	def packageJson = readJSON file: 'package.json'


### PR DESCRIPTION
Successful execution with `Test` step - https://studio-jenkins-csb-codeready.apps.ocp-c1.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-kaoto-release/250