### PR TITLE
fix(test): Updated xpath which points to the correct FlowsMenu HTML element

### DIFF
--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -175,6 +175,6 @@ async function checkStepWithTestIdPresent(driver: WebDriver, testId: string) {
 
 async function checkIntegrationNameInTopBarLoaded(driver: WebDriver, name: string) {
   await driver.wait(
-    until.elementLocated(By.xpath(`//span[@data-testid='flows-list-route-id' and text()='${name}']`)
+    until.elementLocated(By.xpath(`//span[@data-testid='flows-list-route-id' and contains(., '${name}')]`)
     ), 5_000, `Unable to locate integration name '${name} in top bar!'`);
 }


### PR DESCRIPTION
### Description
Fixes #580 

Because of [this](https://github.com/KaotoIO/kaoto/commit/7277d49aeda6c5acf6cb3779a3e53d922c9715fe) latest change in Kaoto, the Integration tests were failing.  This PR fixes those tests.