### PR TITLE
feat(settings): Provide VSCode setting for the `catalogUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.0
 
 - Update project homepage in the marketplace to [kaoto.io](https://kaoto.io)
+- Setting to provide custom set of Catalog used by the Kaoto editor
 
 # 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - Edit Kamelet files following pattern (`*.kamelet.yaml` and `*.kamelet.yml`).
 - Edit Pipe files following pattern (`*.pipe.yaml`, `*.pipe.yml`, `*-pipe.yaml` and `*-pipe.yml`)
 - Allow to edit `*.yaml` and `*.yml` when opening through contextual menu.
+- Setting to provide custom set of catalog
 - Edit Kaoto (`*.kaoto.yaml` and `*.kaoto.yml`) files. Note that these filename extensions are not supported by Camel JBang and are merely still here to stay backward-compatible with Kaoto v1.
 
 ### Limitations

--- a/it-tests/CatalogURLSettings.test.ts
+++ b/it-tests/CatalogURLSettings.test.ts
@@ -1,0 +1,121 @@
+import { ActivityBar, after, By, TextSetting, until, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from './Util';
+import { join } from 'path';
+import { expect } from 'chai';
+
+describe('User Settings', function () {
+    this.timeout(90_000);
+
+    const WORKSPACE_FOLDER = join(__dirname, '../test Fixture with speci@l chars');
+    const CATALOG_URL = 'https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json';
+    const CATALOG_SETTINGS_ID = 'kaoto.catalog.url';
+
+    let driver: WebDriver;
+    let kaotoWebview: WebView;
+
+    const locators = {
+        CatalogDropDown: {
+            dropdown: By.xpath(`//button[@data-testid='runtime-selector-list-dropdown']`)
+        },
+        RuntimeSelector: {
+            selector: (label: string) => By.xpath(`//li[@data-testid='runtime-selector-${label}']`)
+        },
+        RuntimeSelectorItems: {
+            list: By.className('pf-v5-c-menu__list'),
+            listItem: By.className('pf-v5-c-menu__list-item'),
+            label: By.className('pf-v5-c-menu__item-text')
+        }
+    }
+
+    before(async function () {
+        this.timeout(60_000);
+        driver = VSBrowser.instance.driver;
+        await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+        await VSBrowser.instance.waitForWorkbench();
+
+        // provide the Catalog URL using Settings UI editor
+        const settings = await new Workbench().openSettings();
+        const textSetting = await driver.wait(async () => {
+            return await settings.findSetting('Url', 'Kaoto', 'Catalog') as TextSetting;
+        })
+        await textSetting.setValue(CATALOG_URL);
+        await closeEditor('Settings', true);
+
+        // close sidebar
+        await (await new ActivityBar().getViewControl('Explorer'))?.closeView();
+
+        // open the integration file using Kaoto editor
+        kaotoWebview = (await openAndSwitchToKaotoFrame(
+            WORKSPACE_FOLDER,
+            'my.camel.yaml',
+            driver,
+            true
+        )).kaotoWebview;
+        await checkTopologyLoaded(driver);
+    });
+
+    after(async function () {
+        if (kaotoWebview !== undefined) {
+            try {
+                await kaotoWebview.switchBack();
+            } catch {
+                // probably test not failed in Kaoto UI, just continue
+            }
+        }
+        resetUserSettings(CATALOG_SETTINGS_ID);
+        // the editor in this step needs to be closed using command palette
+        // because in some cases, specially on Windows, there was hover displayed which was blocking the editor close button
+        await new Workbench().executeCommand('View: Close Editor');
+    });
+
+    const runtimeSelectors = ['Main', 'Quarkus', 'SpringBoot'];
+
+    runtimeSelectors.forEach(function (runtime) {
+
+        it(`Check custom Kaoto catalog loaded - ${runtime}`, async function () {
+            this.timeout(60_000);
+
+            // expand Catalog dropdown
+            const dropdown = await driver.findElement(locators.CatalogDropDown.dropdown);
+            await dropdown.click();
+            await driver.wait(
+                until.elementLocated(locators.RuntimeSelectorItems.list
+                ), 5_000, 'Dropdown was not displayed properly!');
+
+            // get all items available for selected runtime
+            let items = await getDropdownItemsText(runtime);
+            expect(items.length).is.greaterThan(1);
+
+            // collapse catalog dropdown
+            await dropdown.click();
+            try {
+                await driver.wait(
+                    until.elementLocated(locators.RuntimeSelectorItems.list
+                    ), 5_000);
+                throw new Error('Dropdown was not closed!')
+            } catch (error) {
+                if (error.name !== 'TimeoutError') {
+                    throw new Error(error.message);
+                }
+            }
+        });
+    });
+
+
+    async function getDropdownItemsText(item: string): Promise<string[]> {
+        // expand selected runtime list
+        const parentItem = await driver.findElement(locators.RuntimeSelector.selector(item));
+        await parentItem.click();
+
+        // get all listed items
+        const items = await parentItem.findElement(locators.RuntimeSelectorItems.list).findElements(locators.RuntimeSelectorItems.listItem);
+
+        // get labels of all displayed items
+        let labels: string[] = [];
+        for (const item of items) {
+            const label = await item.findElement(locators.RuntimeSelectorItems.label).getText();
+            labels.push(label);
+        }
+        return labels;
+    }
+});

--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -1,6 +1,8 @@
 import { assert } from 'chai';
 import * as path from 'path';
-import { By, CustomEditor, until, VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
+import * as fs from 'node:fs';
+import * as os from 'os';
+import { By, CustomEditor, EditorView, ModalDialog, TextEditor, until, VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
 
 export async function openAndSwitchToKaotoFrame(
   workspaceFolder: string,
@@ -46,4 +48,37 @@ export async function checkEmptyCanvasLoaded(driver: WebDriver) {
 
 export async function checkTopologyLoaded(driver: WebDriver) {
   await driver.wait(until.elementLocated(By.xpath("//div[@data-test-id='topology']")));
+}
+
+// Enforce same default storage setup as ExTester - see https://github.com/redhat-developer/vscode-extension-tester/wiki/Test-Setup#useful-env-variables
+export const storageFolder = process.env.TEST_RESOURCES ? process.env.TEST_RESOURCES : `${os.tmpdir()}/test-resources`;
+
+/**
+ * Reset user setting to default value by deleting item in settings.json.
+ *
+ * @param id ID of setting to reset.
+ */
+export function resetUserSettings(id: string): void {
+	const settingsPath = path.resolve(storageFolder, 'settings', 'User', 'settings.json');
+	const reset = fs.readFileSync(settingsPath, 'utf-8').replace(new RegExp(`"${id}.*`), '').replace(/,(?=[^,]*$)/, '');
+	fs.writeFileSync(settingsPath, reset, 'utf-8');
+}
+
+/**
+ * Close editor with handling of 'Save/Don't Save' Modal dialog.
+ *
+ * @param title Title of opened active editor.
+ * @param save true/false
+ */
+export async function closeEditor(title: string, save?: boolean) {
+	const dirty = await new TextEditor().isDirty();
+	await new EditorView().closeEditor(title);
+	if (dirty) {
+		const dialog = new ModalDialog();
+		if (save) {
+			await dialog.pushButton('Save');
+		} else {
+			await dialog.pushButton('Don\'t Save');
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,12 @@
             "telemetry"
           ],
           "scope": "window"
+        },
+        "kaoto.catalog.url": {
+          "type": "string",
+          "default": null,
+          "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json`. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/catalogs).",
+          "scope": "window"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/kaoto": "2.0.0",
+    "@kaoto/kaoto": "2.1.0-RC3",
     "@kie-tools-core/backend": "0.32.0",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/i18n": "0.32.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "kaoto.catalog.url": {
           "type": "string",
           "default": null,
-          "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json`. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/catalogs).",
+          "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json`. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/kaoto/tree/main/packages/catalog-generator). It requires to reopen the kaoto editors to be effective.",
           "scope": "window"
         }
       }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -22,6 +22,7 @@ import * as KogitoVsCode from "@kie-tools-core/vscode-extension/dist";
 import { getRedHatService, TelemetryService } from "@redhat-developer/vscode-redhat-telemetry";
 import * as vscode from "vscode";
 import { KAOTO_FILE_PATH_GLOB } from "./helpers";
+import { VSCodeKaotoChannelApiProducer } from './../webview/VSCodeKaotoChannelApiProducer';
 
 let backendProxy: VsCodeBackendProxy;
 let telemetryService: TelemetryService;
@@ -47,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       }),
     ]),
+    channelApiProducer: new VSCodeKaotoChannelApiProducer(),
     backendProxy: backendProxy,
   });
 

--- a/src/webview/KaotoEditorEnvelopeApp.ts
+++ b/src/webview/KaotoEditorEnvelopeApp.ts
@@ -1,12 +1,13 @@
-import { KaotoEditorFactory } from '@kaoto/kaoto';
-import { Editor, EditorFactory, KogitoEditorChannelApi } from '@kie-tools-core/editor/dist/api';
+import { Editor, EditorFactory } from '@kie-tools-core/editor/dist/api';
 import { NoOpKeyboardShortcutsService } from "@kie-tools-core/keyboard-shortcuts/dist/envelope";
 import * as EditorEnvelope from '@kie-tools-core/editor/dist/envelope';
+import { KaotoEditorChannelApi, KaotoEditorFactory } from '@kaoto/kaoto';
+
 declare const acquireVsCodeApi: any;
 
 EditorEnvelope.init({
   container: document.getElementById('envelope-app')!,
   bus: acquireVsCodeApi(),
-  editorFactory: new KaotoEditorFactory() as unknown as EditorFactory<Editor, KogitoEditorChannelApi>,
+  editorFactory: new KaotoEditorFactory() as unknown as EditorFactory<Editor, KaotoEditorChannelApi> ,
   keyboardShortcutsService: new NoOpKeyboardShortcutsService()
 });

--- a/src/webview/VSCodeKaotoChannelApiProducer.ts
+++ b/src/webview/VSCodeKaotoChannelApiProducer.ts
@@ -1,0 +1,26 @@
+import { BackendProxy } from "@kie-tools-core/backend/dist/api";
+import { KogitoEditorChannelApi } from "@kie-tools-core/editor/dist/api";
+import { I18n } from "@kie-tools-core/i18n/dist/core";
+import { NotificationsChannelApi } from "@kie-tools-core/notifications/dist/api";
+import { VsCodeKieEditorChannelApiProducer } from "@kie-tools-core/vscode-extension/dist/VsCodeKieEditorChannelApiProducer";
+import { VsCodeKieEditorController } from "@kie-tools-core/vscode-extension/dist/VsCodeKieEditorController";
+import { VsCodeI18n } from "@kie-tools-core/vscode-extension/dist/i18n";
+import { JavaCodeCompletionApi } from "@kie-tools-core/vscode-java-code-completion/dist/api";
+import { ResourceContentService, WorkspaceChannelApi } from "@kie-tools-core/workspace/dist/api";
+import { VSCodeKaotoEditorChannelApi } from "./VSCodeKaotoEditorChannelApi";
+
+export class VSCodeKaotoChannelApiProducer implements VsCodeKieEditorChannelApiProducer {
+
+    get(editor: VsCodeKieEditorController, resourceContentService: ResourceContentService, workspaceApi: WorkspaceChannelApi, backendProxy: BackendProxy, notificationsApi: NotificationsChannelApi, javaCodeCompletionApi: JavaCodeCompletionApi, viewType: string, i18n: I18n<VsCodeI18n>): KogitoEditorChannelApi {
+        return new VSCodeKaotoEditorChannelApi(
+            editor,
+            resourceContentService,
+            workspaceApi,
+            backendProxy,
+            notificationsApi,
+            javaCodeCompletionApi,
+            viewType,
+            i18n,
+            );
+    }
+}

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -1,0 +1,8 @@
+import { DefaultVsCodeKieEditorChannelApiImpl } from '@kie-tools-core/vscode-extension/dist/DefaultVsCodeKieEditorChannelApiImpl';
+import * as vscode from 'vscode';
+
+export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelApiImpl {
+    async getCatalogURL(): Promise<string | undefined> {
+        return await vscode.workspace.getConfiguration('kaoto').get('catalog.url');
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -251,9 +251,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/kaoto@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@kaoto/kaoto@npm:2.0.0"
+"@kaoto/kaoto@npm:2.1.0-RC3":
+  version: 2.1.0-RC3
+  resolution: "@kaoto/kaoto@npm:2.1.0-RC3"
   dependencies:
     "@kaoto-next/uniforms-patternfly": ^0.6.10
     "@kie-tools-core/editor": 0.32.0
@@ -264,10 +264,10 @@ __metadata:
     "@patternfly/react-icons": 5.2.1
     "@patternfly/react-table": 5.2.2
     "@patternfly/react-topology": 5.2.1
-    "@types/uuid": ^9.0.2
+    "@types/uuid": ^10.0.0
     ajv: ^8.12.0
     ajv-draft-04: ^1.0.0
-    ajv-formats: ^2.1.1
+    ajv-formats: ^3.0.0
     clsx: ^2.1.0
     html-to-image: ^1.11.11
     lodash.clonedeep: ^4.5.0
@@ -284,11 +284,11 @@ __metadata:
     simple-zustand-devtools: ^1.1.0
     uniforms: 4.0.0-alpha.5
     uniforms-bridge-json-schema: 4.0.0-alpha.5
-    usehooks-ts: ^2.15.1
-    uuid: ^9.0.0
+    usehooks-ts: ^3.0.0
+    uuid: ^10.0.0
     yaml: ^2.3.2
     zustand: ^4.3.9
-  checksum: ddfeae836b570a096324c217ec7c56e8efe3c50f7b7e58e55e30e5adc00683cfe39d6d30a79ce1b45aac8b5b41d5d90fac65e2825d12ca1d82f65a5dae6672c2
+  checksum: 2753f769b73be15714017d1d8c68d0f4e77aebd098f669bac3b5b75dabb5355954b104a147c395415c1910e4ed0b5e040e110cfca1c34a58a9f92e6fbbbe75d2
   languageName: node
   linkType: hard
 
@@ -1229,10 +1229,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.2":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
+"@types/uuid@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@types/uuid@npm:10.0.0"
+  checksum: e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
   languageName: node
   linkType: hard
 
@@ -1696,6 +1696,20 @@ __metadata:
     ajv:
       optional: true
   checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
+"ajv-formats@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: f4e1fe232d67fcafc02eafe373a7a9962351e0439dd0736647ca75c93c3da23b430b6502c255ab4315410ae330d4f3013ac9fe226c40b2524ca93a58e786d086
   languageName: node
   linkType: hard
 
@@ -7823,14 +7837,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"usehooks-ts@npm:^2.15.1":
-  version: 2.16.0
-  resolution: "usehooks-ts@npm:2.16.0"
+"usehooks-ts@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "usehooks-ts@npm:3.1.0"
   dependencies:
     lodash.debounce: ^4.0.8
   peerDependencies:
     react: ^16.8.0  || ^17 || ^18
-  checksum: 43f23923dd0ea4bf4401cada035301572ea3f251ec045a48640180255437c0c5424edf71a24666ff9ceafbc6adc39b0faf7000eab673e84411868165740f0906
+  checksum: 4f850c0c5ab408afa52fa2ea2c93c488cd7065c82679eb1fb62cba12ca4c57ff62d52375acc6738823421fe6579ce3adcea1e2dc345ce4f549c593d2e51455b3
   languageName: node
   linkType: hard
 
@@ -7845,6 +7859,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "uuid@npm:10.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
   languageName: node
   linkType: hard
 
@@ -7924,7 +7947,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vscode-kaoto@workspace:."
   dependencies:
-    "@kaoto/kaoto": 2.0.0
+    "@kaoto/kaoto": 2.1.0-RC3
     "@kie-tools-core/backend": 0.32.0
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/i18n": 0.32.0


### PR DESCRIPTION
### Based on https://github.com/KaotoIO/vscode-kaoto/pull/596 from @apupier 

### Context
Add a ´catalogUrl´ setting to point to a specific kaoto catalog version

### Note
In this PR we're updating the ´@kaoto/kaoto´ version to ´2.1.0-RC3´ so we can handle the case of an empty `catalogUrl`