### PR TITLE
feat(vscode): Provide SettingsAdapter for VSCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.3.0
 
+- Upgrade Kaoto 2.2.0-RC3
+
 # 1.2.0
 
 - Update project homepage in the marketplace to [kaoto.io](https://kaoto.io)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-kaoto?style=for-the-badge" alt="Marketplace Version"/></a>
-  <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.1.0-orange?style=for-the-badge"></a>
+  <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.2.0-RC3-orange?style=for-the-badge"></a>
   <img src="https://img.shields.io/badge/VS%20Code-1.74.0+-blue?style=for-the-badge" alt="Visual Studio Code Support"/>
   <a href="https://github.com/KaotoIO/vscode-kaoto/blob/main/LICENSE"><img src="https://img.shields.io/github/license/KaotoIO/vscode-kaoto?color=blue&style=for-the-badge" alt="License"/></a>
   <a href="https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen?color=yellow&style=for-the-badge" alt="Zulip"/></a></br>
@@ -43,7 +43,7 @@
 
 ### Embedded
 
-- [Kaoto 2 release](https://github.com/KaotoIO/kaoto) in version [2.1.0](https://github.com/KaotoIO/kaoto/releases/tag/2.1.0).
+- [Kaoto 2 release](https://github.com/KaotoIO/kaoto) in version [2.2.0-RC3](https://github.com/KaotoIO/kaoto/releases/tag/2.2.0-RC3).
 
 ### Issues
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/kaoto": "2.1.0",
+    "@kaoto/kaoto": "2.2.0-RC3",
     "@kie-tools-core/backend": "0.32.0",
     "@kie-tools-core/editor": "0.32.0",
     "@kie-tools-core/i18n": "0.32.0",

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -1,8 +1,19 @@
+import { KaotoEditorChannelApi } from '@kaoto/kaoto';
+import { ISettingsModel, NodeLabelType, SettingsModel } from '@kaoto/kaoto/models';
 import { DefaultVsCodeKieEditorChannelApiImpl } from '@kie-tools-core/vscode-extension/dist/DefaultVsCodeKieEditorChannelApiImpl';
 import * as vscode from 'vscode';
 
-export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelApiImpl {
-    async getCatalogURL(): Promise<string | undefined> {
-        return await vscode.workspace.getConfiguration('kaoto').get('catalog.url');
-    }
+export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelApiImpl implements KaotoEditorChannelApi {
+  async getCatalogURL(): Promise<string | undefined> {
+    return await vscode.workspace.getConfiguration('kaoto').get('catalog.url');
+  }
+
+  async getVSCodeKaotoSettings(): Promise<ISettingsModel> {
+    const settingsModel: ISettingsModel = {
+      catalogUrl: vscode.workspace.getConfiguration('kaoto').get<string | null>('catalog.url') ?? '',
+      nodeLabel: NodeLabelType.Description,
+    };
+
+    return new SettingsModel(settingsModel);
+  }
 }

--- a/tsconfig.it-tests.json
+++ b/tsconfig.it-tests.json
@@ -1,7 +1,8 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "CommonJS",
+		"moduleResolution": "Node",
 		"declaration": false,
 		"declarationMap": false,
 		"resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
 	  "downlevelIteration": true,
 	  "skipLibCheck": true,
 	  "jsx": "react-jsx",
-	  "moduleResolution":"Node",
+	  "moduleResolution":"Bundler",
 	  "esModuleInterop": true
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,32 +245,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto-next/uniforms-patternfly@npm:^0.6.10":
-  version: 0.6.10
-  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.10"
+"@kaoto-next/uniforms-patternfly@npm:^0.6.15":
+  version: 0.6.16
+  resolution: "@kaoto-next/uniforms-patternfly@npm:0.6.16"
   dependencies:
     invariant: ^2.2.4
     lodash: ^4.17.21
     react: ^18.2.0
     react-dom: ^18.2.0
     uniforms: 4.0.0-alpha.5
-  checksum: 3d8565d4ce5a9eaa4a6c6128bc7c8a93d6f473c73713279971054ec2fda816e5c8a0d3871717caef31c61c3ef71b6855a9030836ff6dae46459cb3fd8ed4ec43
+  checksum: 8a01f068ef797b01c34457921aecbd144e33049f998c62e70c7d9fc73bb875f1266f6420a0fd0bda4090333d634672f8a8c88542e5d122355c3bdfddc966bbf7
   languageName: node
   linkType: hard
 
-"@kaoto/kaoto@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@kaoto/kaoto@npm:2.1.0"
+"@kaoto/kaoto@npm:2.2.0-RC3":
+  version: 2.2.0-RC3
+  resolution: "@kaoto/kaoto@npm:2.2.0-RC3"
   dependencies:
-    "@kaoto-next/uniforms-patternfly": ^0.6.10
+    "@kaoto-next/uniforms-patternfly": ^0.6.15
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/notifications": 0.32.0
-    "@patternfly/patternfly": 5.2.1
-    "@patternfly/react-code-editor": 5.1.0
-    "@patternfly/react-core": 5.2.2
-    "@patternfly/react-icons": 5.2.1
-    "@patternfly/react-table": 5.2.2
-    "@patternfly/react-topology": 5.2.1
+    "@patternfly/patternfly": 5.3.1
+    "@patternfly/react-code-editor": 5.3.4
+    "@patternfly/react-core": 5.3.4
+    "@patternfly/react-icons": 5.3.2
+    "@patternfly/react-table": 5.3.4
+    "@patternfly/react-topology": 5.4.0-prerelease.11
     "@types/uuid": ^10.0.0
     ajv: ^8.12.0
     ajv-draft-04: ^1.0.0
@@ -295,7 +295,7 @@ __metadata:
     uuid: ^10.0.0
     yaml: ^2.3.2
     zustand: ^4.3.9
-  checksum: 8782c216aae9922b679d1f46a9849f33620401edb1da3fb3bbc659f6deba16f63e0d35a33923296786df2749792dbfdcb38ec50b25e0bed604f28e6ea0ffbc64
+  checksum: de0ad2b00c4b1f8fdcc8cfed08201c583a76c704f69a9e038b3842ca0a91adbf71101c73e8db1e144b91d97d6083b7d78a8209d6fb28c7054860a25ad0655725
   languageName: node
   linkType: hard
 
@@ -7998,7 +7998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vscode-kaoto@workspace:."
   dependencies:
-    "@kaoto/kaoto": 2.1.0
+    "@kaoto/kaoto": 2.2.0-RC3
     "@kie-tools-core/backend": 0.32.0
     "@kie-tools-core/editor": 0.32.0
     "@kie-tools-core/i18n": 0.32.0


### PR DESCRIPTION
### Context
This commit adds a new `getVSCodeKaotoSettings` method to the `VSCodeKaotoEditorChannelApi` class to build the Settings model.

It also deprecates the existing `getCatalogURL` method as the new way to go is using the settings adapter from now on.

### Note
This PR needs to be merged after: https://github.com/KaotoIO/kaoto/pull/1264

relates: https://issues.redhat.com/browse/KTO-441
relates: https://github.com/KaotoIO/kaoto/pull/1221
relates: https://github.com/KaotoIO/kaoto/pull/1264