### PR TITLE
feat(settings): Wire up `nodeLabel` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.3.0
 
+- Enable `nodeLabel` setting to configure the node label used in the Kaoto editor
 - Upgrade Kaoto 2.2.0-RC3
 
 # 1.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-kaoto?style=for-the-badge" alt="Marketplace Version"/></a>
-  <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.2.0-RC3-orange?style=for-the-badge"></a>
+  <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.2.0--RC3-orange?style=for-the-badge"></a>
   <img src="https://img.shields.io/badge/VS%20Code-1.74.0+-blue?style=for-the-badge" alt="Visual Studio Code Support"/>
   <a href="https://github.com/KaotoIO/vscode-kaoto/blob/main/LICENSE"><img src="https://img.shields.io/github/license/KaotoIO/vscode-kaoto?color=blue&style=for-the-badge" alt="License"/></a>
   <a href="https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen?color=yellow&style=for-the-badge" alt="Zulip"/></a></br>

--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -1,12 +1,12 @@
 import { ActivityBar, after, By, TextSetting, until, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from './Util';
+import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
 import { join } from 'path';
 import { expect } from 'chai';
 
 describe('User Settings', function () {
     this.timeout(90_000);
 
-    const WORKSPACE_FOLDER = join(__dirname, '../test Fixture with speci@l chars');
+    const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars');
     const CATALOG_URL = 'https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json';
     const CATALOG_SETTINGS_ID = 'kaoto.catalog.url';
 

--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -1,0 +1,73 @@
+import { ActivityBar, after, By, ComboSetting, TextSetting, until, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
+import { join } from 'path';
+import { expect } from 'chai';
+
+describe('User Settings', function () {
+    this.timeout(90_000);
+
+    const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars');
+    const LABEL_SETTINGS_ID = 'kaoto.nodeLabel';
+
+    let driver: WebDriver;
+    let kaotoWebview: WebView;
+
+    const locators = {
+        TimerComponent: {
+            timer: By.xpath(`//\*[name()='g' and starts-with(@data-id,'timer')]`),
+            label: By.xpath(`//\*[name()='g' and starts-with(@class,'pf-topology__node__label')]`)
+        }
+    }
+
+    before(async function () {
+        this.timeout(60_000);
+        driver = VSBrowser.instance.driver;
+        await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+        await VSBrowser.instance.waitForWorkbench();
+
+        // provide the Node Label using Settings UI editor
+        const settings = await new Workbench().openSettings();
+        const textSetting = await driver.wait(async () => {
+            return await settings.findSetting('Node Label', 'Kaoto') as ComboSetting;
+        })
+        await textSetting.setValue('id');
+        await driver.sleep(1_000); // stabilize tests which are sometimes failing on macOS CI
+        await closeEditor('Settings', true);
+
+        // close sidebar
+        await (await new ActivityBar().getViewControl('Explorer'))?.closeView();
+
+        // open the integration file using Kaoto editor
+        kaotoWebview = (await openAndSwitchToKaotoFrame(
+            WORKSPACE_FOLDER,
+            'my.camel.yaml',
+            driver,
+            true
+        )).kaotoWebview;
+        await checkTopologyLoaded(driver);
+    });
+
+    after(async function () {
+        if (kaotoWebview !== undefined) {
+            try {
+                await kaotoWebview.switchBack();
+            } catch {
+                // probably test not failed in Kaoto UI, just continue
+            }
+        }
+        resetUserSettings(LABEL_SETTINGS_ID);
+        // the editor in this step needs to be closed using command palette
+        // because in some cases, specially on Windows, there was hover displayed which was blocking the editor close button
+        await new Workbench().executeCommand('View: Close Editor');
+    });
+
+    it(`Check 'id' Node Label is used instead of default 'description'`, async function () {
+        this.timeout(60_000);
+
+        const timer = await driver.findElement(locators.TimerComponent.timer).findElement(locators.TimerComponent.label);
+        const label = await timer.getText();
+
+        expect(label).to.be.equal('timerID');
+    });
+
+});

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "compile": "webpack",
     "watch": "webpack --env dev",
     "run:webmode": "yarn vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --open-devtools ./resources",
-    "test:it": "yarn build:test:it && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources 'out/*.test.js' --open_resource './test Fixture with speci@l chars'",
-    "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/*.test.js' --open_resource './test Fixture with speci@l chars'",
+    "test:it": "yarn build:test:it && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
+    "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,16 @@
           "default": null,
           "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json`. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/kaoto/tree/main/packages/catalog-generator). It requires to reopen the kaoto editors to be effective.",
           "scope": "window"
+        },
+        "kaoto.nodeLabel": {
+          "type": "string",
+          "default": "description",
+          "markdownDescription": "Node label, which will be used for nodes in the canvas. Can be either `description` or `id`. If `description` is selected, it will be displayed only if it is available, otherwise `id` will be displayed by default.",
+          "enum": [
+            "description",
+            "id"
+          ],
+          "scope": "window"
         }
       }
     },

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -9,9 +9,12 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
   }
 
   async getVSCodeKaotoSettings(): Promise<ISettingsModel> {
+    const catalogUrl = await vscode.workspace.getConfiguration('kaoto').get<Promise<string | null>>('catalog.url');
+    const nodeLabel = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeLabelType | null>>('nodeLabel');
+
     const settingsModel: ISettingsModel = {
-      catalogUrl: vscode.workspace.getConfiguration('kaoto').get<string | null>('catalog.url') ?? '',
-      nodeLabel: NodeLabelType.Description,
+      catalogUrl: catalogUrl ?? '',
+      nodeLabel: nodeLabel ?? NodeLabelType.Description,
     };
 
     return new SettingsModel(settingsModel);

--- a/test Fixture with speci@l chars/my.camel.yaml
+++ b/test Fixture with speci@l chars/my.camel.yaml
@@ -1,7 +1,9 @@
 - route:
     id: camelroute51
     from:
+      id: timerID
       uri: timer:demo
+      parameters: {}
       steps:
-      - log:
-          message: my message logged
+        - log:
+            message: my message logged


### PR DESCRIPTION
### Context
This commit wires up the `nodeLabel` setting so the user can choose what label a node shows.

### Screenshot
#### kaoto > nodeLabel
![Screenshot from 2024-07-30 13-37-35](https://github.com/user-attachments/assets/9ef38ec6-c8aa-4a39-8dbb-638c8f7515a7)

#### Using IDs for nodes
![Screenshot from 2024-07-30 13-37-52](https://github.com/user-attachments/assets/7dc63e11-20d0-4541-b66e-11ac669df29b)

relates: https://issues.redhat.com/browse/KTO-441
relates: https://github.com/KaotoIO/kaoto/pull/1221
relates: https://github.com/KaotoIO/kaoto/pull/1264