### PR TITLE
493 quick action to opentextual editor to the side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Enable `nodeLabel` setting to configure the node label used in the Kaoto editor
 - Upgrade Kaoto 2.2.0-RC4
-- Provide command `Open Camel file with textual editor on the side` when Kaoto editor is active
+- Provide command and quick action `Open Camel file with textual editor on the side` when Kaoto editor is active
 - Provide shortcut `Ctrl+k v` to open textual editor to the side when kaoto editor is active
 
 # 1.2.0

--- a/it-tests/OpenTextualEditorCommand.test.ts
+++ b/it-tests/OpenTextualEditorCommand.test.ts
@@ -6,6 +6,7 @@ import {
 } from 'vscode-extension-tester';
 import { expect } from 'chai';
 import * as path from 'path';
+import * as os from 'os';
 
 describe('Open Textual editor to the side', function () {
   this.timeout(20_000);
@@ -22,15 +23,41 @@ describe('Open Textual editor to the side', function () {
   });
 
   it('Use command from palette', async function () {
-    const filePath = path.join(workspaceFolder, 'my.camel.yaml');
-    await VSBrowser.instance.openResources(filePath);
-    const editorView = new EditorView();
-    expect(await editorView.getEditorGroups()).to.have.length(1);
+    const editorView = await openFileInKaotoEditor(workspaceFolder);
 
     await new Workbench().executeCommand('Open Camel file with textual editor on the side');
 
-    expect(await editorView.getEditorGroups()).to.have.length(2);
-    const editor = new TextEditor(await editorView.getEditorGroup(1));
-    expect(await editor.getTextAtLine(1)).contains('- route:');
+    await checkTextualEditorIsOpenedOnTheSide(editorView);
+  });
+
+  it('Use quick action', async function () {
+    const editorView = await openFileInKaotoEditor(workspaceFolder);
+
+    let actionTitle;
+    if(os.platform() === 'darwin') {
+      actionTitle = 'Open Camel file with textual editor on the side (⌘K V)';
+    } else {
+      actionTitle = 'Open Camel file with textual editor on the side (Ctrl+K V)';
+    }
+    await (await editorView.getAction(actionTitle))?.click();
+
+    await checkTextualEditorIsOpenedOnTheSide(editorView);
   });
 });
+
+async function checkTextualEditorIsOpenedOnTheSide(editorView: EditorView) {
+  const driver = VSBrowser.instance.driver;
+  await driver.wait(async() => {
+    return (await editorView.getEditorGroups()).length === 2;
+  }, 5000, 'The second editor group has not opened');
+  const editor = new TextEditor(await editorView.getEditorGroup(1));
+  expect(await editor.getTextAtLine(1)).contains('- route:');
+}
+
+async function openFileInKaotoEditor(workspaceFolder: string) {
+  const filePath = path.join(workspaceFolder, 'my.camel.yaml');
+  await VSBrowser.instance.openResources(filePath);
+  const editorView = new EditorView();
+  expect(await editorView.getEditorGroups()).to.have.length(1);
+  return editorView;
+}

--- a/package.json
+++ b/package.json
@@ -90,8 +90,10 @@
       {
         "command": "kaoto.open.textualeditor",
         "title": "Open Camel file with textual editor on the side",
+        "shortTitle": "Show source",
         "enablement": "activeCustomEditorId == webviewEditorsKaoto",
-        "category": "Camel"
+        "category": "Camel",
+        "icon": "$(go-to-file)"
       }
     ],
     "keybindings": {
@@ -105,6 +107,13 @@
         {
           "command": "kaoto.open",
           "when": "false"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "kaoto.open.textualeditor",
+          "when": "activeCustomEditorId == webviewEditorsKaoto",
+          "group": "navigation" 
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
based on https://github.com/KaotoIO/vscode-kaoto/pull/627

fixes #493 

![quickactionToShowSource](https://github.com/user-attachments/assets/4fa782f7-d275-4eef-9c8d-47aa3bd6033e)
