### PR TITLE
Provide keyboard shortcut to open text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Enable `nodeLabel` setting to configure the node label used in the Kaoto editor
 - Upgrade Kaoto 2.2.0-RC3
 - Provide command `Open Camel file with textual editor on the side` when Kaoto editor is active
+- Provide shortcut `Ctrl+k v` to open textual editor to the side when kaoto editor is active
 
 # 1.2.0
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,12 @@
         "category": "Camel"
       }
     ],
+    "keybindings": {
+      "command": "kaoto.open.textualeditor",
+      "key": "ctrl+k v",
+      "mac": "cmd+k v",
+      "when": "activeCustomEditorId == webviewEditorsKaoto"
+    },
     "menus": {
       "commandPalette": [
         {


### PR DESCRIPTION
fixes #494

Ctrl+k v is the shortcut used to "show preview" in several extensions. To "show source", I found no extensions with a pre-defined shortcut. I think we can reuse it as it is qknd of the "opposite" and the enablement will cover different cases withotu overlapping