### PR TITLE
Adapt test to container in Kaoto

### DIFF
--- a/it-tests/PropertyPanelLoading.test.ts
+++ b/it-tests/PropertyPanelLoading.test.ts
@@ -29,7 +29,7 @@ describe('Property panel loading test', function () {
       driver,
       true
     )).kaotoWebview;
-    const stepWhenXpath = By.xpath(`//\*[name()='g' and starts-with(@data-testid,'custom-node__when')]`)
+    const stepWhenXpath = By.xpath(`//*[name()='g' and starts-with(@data-testid,'custom-node__when')]|//*[name()='foreignObject' and @data-nodelabel='when']/div/div`)
     await driver.wait(until.elementLocated(stepWhenXpath), 5_000);
     await (await driver.findElement(stepWhenXpath)).click();
     await driver.wait(


### PR DESCRIPTION
- keep xpath selector `//*[name()='g' and starts-with(@data-testid,'custom-node__when')]` until we have a release of Kaoto with new changes
- requires to 2 div level because the foreignObject and the first div are not clickable Element

fixes #631