### PR TITLE
Use an Output channel to log errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.4.0
 
+- Introduced a `Kaoto` output channel. It is initially used to log message of exceptions.
+
 # 1.3.0
 
 - Enable `nodeLabel` setting to configure the node label used in the Kaoto editor

--- a/src/KaotoOutputChannelManager.ts
+++ b/src/KaotoOutputChannelManager.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscode from "vscode";
+
+let kaotoOutputChannel: vscode.OutputChannel;
+
+function getKaotoOutputChannel() :vscode.OutputChannel {
+    if (kaotoOutputChannel === undefined) {
+        kaotoOutputChannel = vscode.window.createOutputChannel('Kaoto');
+    }
+    return kaotoOutputChannel;
+}
+
+export function logInKaotoOutputChannel(errorMessage :string, exception :any) {
+    getKaotoOutputChannel().appendLine(errorMessage);
+    if (exception instanceof Error) {
+      getKaotoOutputChannel().appendLine(exception.message);
+    }
+}

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -11,6 +11,7 @@ import { JavaCodeCompletionApi } from '@kie-tools-core/vscode-java-code-completi
 import * as vscode from 'vscode';
 import { VsCodeKieEditorCustomDocument } from '@kie-tools-core/vscode-extension/dist/VsCodeKieEditorCustomDocument';
 import * as path from 'path';
+import { logInKaotoOutputChannel } from './../KaotoOutputChannelManager';
 
 export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelApiImpl implements KaotoEditorChannelApi {
 
@@ -57,7 +58,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
         const kaotoMetadataFileContent = new TextDecoder().decode(await vscode.workspace.fs.readFile(kaotoMetadatafile));
         return JSON.parse(kaotoMetadataFileContent)[key]; // in case the key i snot present, should we look to other potential .kaoto files that could contain the information?
       } catch (ex){
-        // TODO: log somewhere that we cannot retrieve the metadata
+        logInKaotoOutputChannel(`Error when trying to get Metadata for key: ${key}`, ex);
         // Should we look to other potential .kaoto files and ignore one which is invalid?
         return undefined; // or should we throw a specific exception?
       }
@@ -112,8 +113,9 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
       const targetFile = path.resolve(path.dirname(this.currentEditedDocument.uri.fsPath), relativePath);
       return new TextDecoder().decode(await vscode.workspace.fs.readFile(vscode.Uri.file(targetFile)));
     } catch (ex) {
-      vscode.window.showErrorMessage(`Cannot retrieve content of ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`);
-      // TODO log the exception somewhere
+      const errorMessage= `Cannot retrieve content of ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`;
+      vscode.window.showErrorMessage(errorMessage);
+      logInKaotoOutputChannel(errorMessage, ex);
       return undefined;
     }
   }
@@ -123,8 +125,9 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
       const targetFile = path.resolve(path.dirname(this.currentEditedDocument.uri.fsPath), relativePath);
       await vscode.workspace.fs.writeFile(vscode.Uri.file(targetFile), new TextEncoder().encode(content));
     } catch (ex) {
-      vscode.window.showErrorMessage(`Cannot write content of ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`);
-      // TODO log the exception somewhere
+      const errorMessage = `Cannot write content of ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`;
+      vscode.window.showErrorMessage(errorMessage);
+      logInKaotoOutputChannel(errorMessage, ex);
       return undefined;
     }
   }
@@ -135,8 +138,9 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
       await vscode.workspace.fs.delete(vscode.Uri.file(targetFile));
       return true;
     } catch (ex) {
-      vscode.window.showErrorMessage(`Cannot delete ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`);
-      // TODO log the exception somewhere
+      const errorMessage = `Cannot delete ${relativePath} relatively to ${this.currentEditedDocument.uri.fsPath}`;
+      vscode.window.showErrorMessage(errorMessage);
+      logInKaotoOutputChannel(errorMessage, ex);
       return false;
     }
   }
@@ -158,8 +162,9 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
         return path.relative(path.dirname(this.currentEditedDocument.uri.fsPath), f.path);
       }), options as vscode.QuickPickOptions);
     } catch (ex) {
-      vscode.window.showErrorMessage(`Cannot get a user selection: ${ex.message}`);
-      // TODO log the exception somewhere
+      const errorMessage = `Cannot get a user selection: ${ex.message}`;
+      vscode.window.showErrorMessage(errorMessage);
+      logInKaotoOutputChannel(errorMessage, ex);
       return undefined;
     }
   }


### PR DESCRIPTION
fixes #679

for instance:

![image](https://github.com/user-attachments/assets/0482989f-92fa-4acb-a22f-3f3038946aaa)
