### PR TITLE
Adapt UI tests to label modification on Kaoto main branch

### DIFF
--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -67,7 +67,7 @@ describe('User Settings', function () {
         const timer = await driver.findElement(locators.TimerComponent.timer).findElement(locators.TimerComponent.label);
         const label = await timer.getText();
 
-        expect(label).to.be.equal('timerID');
+        expect(label.split('\n')).to.contains('timerID');
     });
 
 });


### PR DESCRIPTION
it displays now both description or id and the component name, see https://github.com/KaotoIO/kaoto/pull/1560