### PR TITLE
Change implementation of VS Code Channel editor API to have it

### DIFF
--- a/src/extension/ClasspathRootFinder.ts
+++ b/src/extension/ClasspathRootFinder.ts
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * 
+ * @param camelRouteFile 
+ * @returns The classpath root for the corresponding Camel Route file.
+ *          In Maven-based project, it is searching for the closest src/main/resources folder.
+ *          If not found, it supposed that it is a Camel JBang project and so that it is a flat classpath, using the paren tfolder of the Camel route.
+ */
+export function findClasspathRoot(camelRouteFile: vscode.Uri): string {
+    const camelRoutePath = camelRouteFile.fsPath;
+    const folderClasspathPattern = `src${path.sep}main${path.sep}resources`;
+    const indexOfClasspath = camelRoutePath.lastIndexOf(folderClasspathPattern);
+    let classpathRoot: string;
+    if (indexOfClasspath !== -1) {
+      classpathRoot = camelRoutePath.substring(0, indexOfClasspath + folderClasspathPattern.length);
+    } else {
+      // In non Maven based project, we consider the folder at same level than Camel route to be the classpath route
+      classpathRoot = path.dirname(camelRouteFile.fsPath);
+    }
+    return classpathRoot;
+  }

--- a/src/test/ClasspathRootFinder.test.ts
+++ b/src/test/ClasspathRootFinder.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License", destination); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { assert } from 'chai';
+import { findClasspathRoot } from '../extension/ClasspathRootFinder';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+suite('Classpath root finder', () => {
+    test('Find src/main/resources', async() => {
+        const camelRoute = vscode.Uri.file('/tmp/fake/src/main/resources/camel/Camelroute.camel.yaml');
+        const classpathRoot = findClasspathRoot(camelRoute);
+        assert.equal(classpathRoot, `${path.sep}tmp${path.sep}fake${path.sep}src${path.sep}main${path.sep}resources`);
+    });
+
+    test('Find parent folder of Camel route when no src/main/resources on the path', async() => {
+        const camelRoute = vscode.Uri.file('/tmp/fake/camel/Camelroute.camel.yaml');
+        const classpathRoot = findClasspathRoot(camelRoute);
+        assert.equal(classpathRoot, `${path.sep}tmp${path.sep}fake${path.sep}camel`);
+    });
+})


### PR DESCRIPTION
compatible with Maven based projects

basically looking for classpath root src/main/resources if there is some for the xsl file. And using a relative path to the .kaoto file for the xsd file
![demoWithMavenBased](https://github.com/user-attachments/assets/cfe1d17b-47e1-4825-b3d4-ad05da75ecd2)
