### PR TITLE
Adapt test to newly published example of catalog set

### DIFF
--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -82,7 +82,7 @@ describe('User Settings', function () {
         await new Workbench().executeCommand('View: Close Editor');
     });
 
-    const runtimeSelectors = ['Main', 'Quarkus', 'SpringBoot'];
+    const runtimeSelectors = ['Main', 'Quarkus', 'Spring Boot'];
 
     runtimeSelectors.forEach(function (runtime) {
 
@@ -120,10 +120,6 @@ describe('User Settings', function () {
         // select Main > Camel Main *redhat*
         const parentItem = await dropdown.findElement(locators.RuntimeSelector.selector('Main'));
         await parentItem.click();
-
-        // get items and click on last which is currently always the 'redhat' one
-        const items = await parentItem.findElement(locators.RuntimeSelectorItems.list).findElements(locators.RuntimeSelectorItems.listItem);
-        await items.at(-1)?.click();
 
         // it needs some time to start loading a new catalog
         await driver.sleep(1_000);


### PR DESCRIPTION
* SpringBoot renamed to Spring Boot
* Red Hat catalogs are now the first catalog and no more the last

there were these tests on error:
```
  1) User Settings
       Check custom Kaoto catalog loaded - SpringBoot:
     NoSuchElementError: no such element: Unable to locate element: {"method":"xpath","selector":"//li[@data-testid='runtime-selector-SpringBoot']"}
  (Session info: chrome=124.0.6367.243)
      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:521:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:514:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:446:28)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Driver.execute (node_modules/selenium-webdriver/lib/webdriver.js:744:17)

  2) User Settings
       Select 'redhat' catalog and check new components are available:
     TimeoutError: Dropdown was not displayed properly!
Wait timed out after 5175ms
      at /home/runner/work/vscode-kaoto/vscode-kaoto/vscode-kaoto/node_modules/selenium-webdriver/lib/webdriver.js:923:22
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
 ```