### PR TITLE
fix(Settings): Use default Settings from Kaoto

### DIFF
--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -151,10 +151,11 @@ async function createNewRoute(driver: WebDriver) {
 
 async function addActiveMQStep(driver: WebDriver) {
   await driver.wait(
-    until.elementLocated(By.xpath('//*[@data-type="node"]//*[@class="pf-topology__node__action-icon"]'))
+    until.elementLocated(By.css('g[data-testid^="custom-node__timer"]'))
   );
-  const threeDotsIconOfOneOfTheSteps = (await driver.findElements(By.xpath('//*[@data-type="node"]//*[@class="pf-topology__node__action-icon"]')))[1];
-  await threeDotsIconOfOneOfTheSteps.click();
+
+  const canvasNode = await driver.findElement(By.css('g[data-testid^="custom-node__timer"]'));
+  await driver.actions().contextClick(canvasNode).perform();
 
   await driver.wait(
     until.elementLocated(By.className('pf-v5-c-dropdown pf-m-expanded'))

--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -14,8 +14,8 @@ describe('User Settings', function () {
 
     const locators = {
         TimerComponent: {
-            timer: By.xpath(`//\*[name()='g' and starts-with(@data-id,'timer')]`),
-            label: By.xpath(`//\*[name()='g' and starts-with(@class,'pf-topology__node__label')]`)
+            timer: `g[data-id^='timer'][data-kind='node']`,
+            label: `.custom-node__label`,
         }
     }
 
@@ -64,7 +64,7 @@ describe('User Settings', function () {
     it(`Check 'id' Node Label is used instead of default 'description'`, async function () {
         this.timeout(60_000);
 
-        const timer = await driver.findElement(locators.TimerComponent.timer).findElement(locators.TimerComponent.label);
+        const timer = await driver.findElement(By.css(`${locators.TimerComponent.timer} ${locators.TimerComponent.label}`));
         const label = await timer.getText();
 
         expect(label.split('\n')).to.contains('timerID');

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -1,18 +1,18 @@
 import { KaotoEditorChannelApi } from '@kaoto/kaoto';
 import { ISettingsModel, NodeLabelType, SettingsModel } from '@kaoto/kaoto/models';
 import { BackendProxy } from '@kie-tools-core/backend/dist/api';
-import { NotificationsChannelApi } from "@kie-tools-core/notifications/dist/api";
-import { ResourceContentService, WorkspaceChannelApi } from "@kie-tools-core/workspace/dist/api";
 import { I18n } from '@kie-tools-core/i18n/dist/core';
+import { NotificationsChannelApi } from "@kie-tools-core/notifications/dist/api";
 import { DefaultVsCodeKieEditorChannelApiImpl } from '@kie-tools-core/vscode-extension/dist/DefaultVsCodeKieEditorChannelApiImpl';
 import { VsCodeI18n } from '@kie-tools-core/vscode-extension/dist/i18n';
 import { VsCodeKieEditorController } from '@kie-tools-core/vscode-extension/dist/VsCodeKieEditorController';
-import { JavaCodeCompletionApi } from '@kie-tools-core/vscode-java-code-completion/dist/api';
-import * as vscode from 'vscode';
 import { VsCodeKieEditorCustomDocument } from '@kie-tools-core/vscode-extension/dist/VsCodeKieEditorCustomDocument';
+import { JavaCodeCompletionApi } from '@kie-tools-core/vscode-java-code-completion/dist/api';
+import { ResourceContentService, WorkspaceChannelApi } from "@kie-tools-core/workspace/dist/api";
 import * as path from 'path';
-import { logInKaotoOutputChannel } from './../KaotoOutputChannelManager';
+import * as vscode from 'vscode';
 import { findClasspathRoot } from '../extension/ClasspathRootFinder';
+import { logInKaotoOutputChannel } from './../KaotoOutputChannelManager';
 
 export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelApiImpl implements KaotoEditorChannelApi {
 
@@ -40,7 +40,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
     const catalogUrl = await vscode.workspace.getConfiguration('kaoto').get<Promise<string | null>>('catalog.url');
     const nodeLabel = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeLabelType | null>>('nodeLabel');
 
-    const settingsModel: ISettingsModel = {
+    const settingsModel: Partial<ISettingsModel> = {
       catalogUrl: catalogUrl ?? '',
       nodeLabel: nodeLabel ?? NodeLabelType.Description,
     };


### PR DESCRIPTION
### Context
From the Kaoto side, we have default settings in the
[settings.model.ts](https://github.com/KaotoIO/kaoto/blob/9ee3368e0e488853f61a84fa4e16bedadc801fda/packages/ui/src/models/settings/settings.model.ts#L23-L25) file.

### Changes
This commit uses that and only overrides what needs to be changed in terms of the `catalogUrl` and the `nodeLabel`.

### Notes
Once the VS Code setting for the new property `nodeToolbarTrigger` is merged, we can add it also to the VS Code settings object.