### PR TITLE
Force cross-spawn 7.0.5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,8 @@
     "@patternfly/react-icons": "5.4.0",
     "@patternfly/react-table": "5.4.0",
     "@patternfly/react-topology": "5.4.0",
-    "dset": "^3.1.4"
+    "dset": "^3.1.4",
+    "cross-spawn": "^7.0.5"
   },
   "packageManager": "yarn@4.4.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,14 +2875,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
+"cross-spawn@npm:^7.0.5":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
   dependencies:
     path-key: "npm:^3.1.0"
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
-  checksum: 10/e1a13869d2f57d974de0d9ef7acbf69dc6937db20b918525a01dacb5032129bd552d290d886d981e99f1b624cb03657084cc87bd40f115c07ecf376821c729ce
+  checksum: 10/0d52657d7ae36eb130999dffff1168ec348687b48dd38e2ff59992ed916c88d328cf1d07ff4a4a10bc78de5e1c23f04b306d569e42f7a2293915c081e4dfee86
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
on other projects it was automatically updated when integrating VS Code Red Hat telemetry with the latest version but not on this one. i do not know why (maybe yarn is not resolving the same way?)