### PR TITLE
No more need to align webpack with Kaoto

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - dependency-name: "@types/react"
       - dependency-name: "*-browserify"
       - dependency-name: "*-loader"
-      - dependency-name: "webpack*"
       - dependency-name: "monaco-editor"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
given that kaoto moved to Vite instead of webpack