### PR TITLE
747 fix: support xsd in Kaoto DataMapper on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.4.0
 
+- Fix Kaoto Datamapper editor on Windows (issue when attaching an xsd)
+
 # 2.3.0
 
 - Introduced a `Kaoto` output channel. It is initially used to log message of exceptions.

--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -205,7 +205,10 @@ async function addXsdForSource(driver: WebDriver, kaotoWebview: WebView) {
   await xsdInputbox.confirm();
   await kaotoWebview.switchToFrame();
 
-  //TODO: check content is loaded
+  await driver.wait(
+    until.elementLocated(By.xpath('//div[starts-with(@data-testid, "node-source-field-shiporder-")]'))
+    , 5000
+    , 'Root of the imported xsd is not displayed in the UI');
 }
 
 async function openDataMapperEditor(driver: WebDriver) {
@@ -220,16 +223,15 @@ async function openDataMapperEditor(driver: WebDriver) {
 async function deleteDataMapperStep(driver: WebDriver, workspaceFolder: string) {
   await checkStepWithTestIdOrNodeLabelPresent(driver, 'custom-node__kaoto-datamapper', 'kaoto-datamapper');
   const kaotoNodeConfigured = await driver.findElement(By.css('g[data-testid^="custom-node__kaoto-datamapper"],g[data-testid="custom-node__route.from.steps.0.kaoto-datamapper"]'));
-  await kaotoNodeConfigured.click();
-  await driver.wait(
-    until.elementLocated(By.css('button[data-testid="step-toolbar-button-delete"]'))
-  );
-  await (await driver.findElement(By.css('button[data-testid="step-toolbar-button-delete"]'))).click();
-  await driver.wait(
-    until.elementLocated(By.css('button[data-testid="action-confirmation-modal-btn-del-step-and-file"]'))
-  );
-  await (await driver.findElement(By.css('button[data-testid="action-confirmation-modal-btn-del-step-and-file"]'))).click();
 
+  await driver.actions().contextClick(kaotoNodeConfigured).perform();
+
+  await driver.wait(
+    until.elementLocated(By.className('pf-v5-c-dropdown pf-m-expanded'))
+  );
+  await (await driver.findElement(By.xpath("//*[@data-testid='context-menu-item-delete']"))).click();
+
+  await (await driver.findElement(By.css('button[data-testid="action-confirmation-modal-btn-del-step-and-file"]'))).click();
   await waitUntil(() => {
     const filesAfterDeletion = fs.readdirSync(workspaceFolder);
     const xslFilesAfterDeletion = filesAfterDeletion.filter(file => file.endsWith('.xsl'));

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -158,7 +158,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
         kaotoMetadataFile = await this.findKaotoMetadataToCreate();
       }
       return await vscode.window.showQuickPick(files.map((f) => {
-        return path.relative(path.dirname(kaotoMetadataFile.fsPath), f.path);
+        return path.relative(path.dirname(kaotoMetadataFile.fsPath), f.fsPath);
       }), options as vscode.QuickPickOptions);
     } catch (ex) {
       const errorMessage = `Cannot get a user selection: ${ex.message}`;


### PR DESCRIPTION
based on https://github.com/KaotoIO/vscode-kaoto/pull/749

fix #747 

* The fix consists in using fsPath of the vscode.URI
* Added the UI test part to check source xsd correctly loaded
* Note that the contextual menu to delete the step in tests is used
instead of the toolbar (which is more modern) as the delete button
toolbar is not visible enough to be clickable

we can notice that the added test is failing without the fix https://github.com/KaotoIO/vscode-kaoto/pull/750