### PR TITLE
fix(build): Remove sass-loader warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "path-browserify": "^1.0.1",
     "rimraf": "^6.0.1",
     "sass": "^1.83.1",
-    "sass-loader": "^13.0.2",
+    "sass-loader": "^16.0.4",
     "source-map-loader": "4.0.1",
     "style-loader": "3.3.3",
     "ts-loader": "9.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,19 +7695,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-loader@npm:^13.0.2":
-  version: 13.3.3
-  resolution: "sass-loader@npm:13.3.3"
+"sass-loader@npm:^16.0.4":
+  version: 16.0.4
+  resolution: "sass-loader@npm:16.0.4"
   dependencies:
     neo-async: "npm:^2.6.2"
   peerDependencies:
-    fibers: ">= 3.1.0"
+    "@rspack/core": 0.x || 1.x
     node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
     sass: ^1.3.0
     sass-embedded: "*"
     webpack: ^5.0.0
   peerDependenciesMeta:
-    fibers:
+    "@rspack/core":
       optional: true
     node-sass:
       optional: true
@@ -7715,7 +7715,9 @@ __metadata:
       optional: true
     sass-embedded:
       optional: true
-  checksum: 10/a8a8519add9f0bb2d3d1b834dbf30b1b67e22833425755a56640cc20845107850adfc6f243cdab07a5cb26ec964513b950a02dca7b1d5b3cf3659c89bf1988eb
+    webpack:
+      optional: true
+  checksum: 10/16e3552e04301864d59d99f1c90952e0c97cfa793a38a551b6dc19e49a9c0779ec8b3dd8ab39bc79cc4401972f13e8d5baaf577c96ea39911db5866a0b4bdcdd
   languageName: node
   linkType: hard
 
@@ -8939,7 +8941,7 @@ __metadata:
     react-monaco-editor: "npm:0.56.2"
     rimraf: "npm:^6.0.1"
     sass: "npm:^1.83.1"
-    sass-loader: "npm:^13.0.2"
+    sass-loader: "npm:^16.0.4"
     source-map-loader: "npm:4.0.1"
     style-loader: "npm:3.3.3"
     ts-loader: "npm:9.4.4"


### PR DESCRIPTION
### Context
Currently, when building `vscode-kaoto`, there are warnings about `sass-loader` using deprecated APIs.

```
WARNING in ./node_modules/@kie-tools-core/editor/dist/envelope/styles.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./node_modules/@kie-tools-core/editor/dist/envelope/styles.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api
```

The fix is to update `sass-loader` to `v16`