### PR TITLE
Add Camel extensions as dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,21 +66,21 @@ jobs:
       with:
         name: 'vscode-kaoto-vsix'
         path: '*.vsix'
-    - name: Store VS Code logs
+    - name: Store UI Tests VS Code logs
       uses: actions/upload-artifact@v4
       if: always()
       with:
         name: vscode-logs-${{ matrix.os }}
         path: test-resources/settings/logs
-    - name: Store VS Code Logs
+    - name: Store Unit Tests VS Code Logs
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || cancelled()
       with:
         name: ${{ matrix.os }}-test-logs
         path: .vscode-test/user-data/logs/*
     - name: Store VS Code UI Tests screenshots on failure
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || cancelled()
       with:
         name: ui-test-screenshots-${{ matrix.os }}
         path: test-resources/screenshots

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         path: test-resources/settings/logs
     - name: Store Unit Tests VS Code Logs
       uses: actions/upload-artifact@v4
-      if: failure() || cancelled()
+      if: failure() || cancelled() || success()
       with:
         name: ${{ matrix.os }}-test-logs
         path: .vscode-test/user-data/logs/*

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from '@vscode/test-cli';
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
 	workspaceFolder: './test Fixture with speci@l chars',
-	launchArgs: '--verbose',
+	launchArgs: ['--verbose'],
 	mocha: {
 		ui: 'tdd',
 		color: true,

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from '@vscode/test-cli';
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
 	workspaceFolder: './test Fixture with speci@l chars',
+	launchArgs: '--verbose',
 	mocha: {
 		ui: 'tdd',
 		color: true,

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from '@vscode/test-cli';
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
 	workspaceFolder: './test-WorkspaceWithAYamlFile',
-	// launchArgs: ['--verbose'],
+	launchArgs: ['--verbose'],
 	mocha: {
 		ui: 'tdd',
 		color: true,

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from '@vscode/test-cli';
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
 	workspaceFolder: './test-WorkspaceWithAYamlFile',
-	launchArgs: ['--verbose'],
+	// launchArgs: ['--verbose'],
 	mocha: {
 		ui: 'tdd',
 		color: true,

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
-	workspaceFolder: './test Fixture with speci@l chars',
+	workspaceFolder: './test-WorkspaceWithAYamlFile',
 	launchArgs: ['--verbose'],
 	mocha: {
 		ui: 'tdd',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 2.5.0
 - Upgrade to Kaoto 2.5.0-M2
 
+- Add VS Code Language Support and Debug Adapter for Camel as extension dependencies. It allows to have several general Camel features such as Run/debug/Create/Export.
+
 # 2.4.0
 
 - Fix Kaoto Datamapper editor on Windows (issue when attaching an xsd)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
+  "extensionDependencies": [
+    "redhat.vscode-apache-camel",
+    "redhat.vscode-debug-adapter-apache-camel"
+  ],
   "dependencies": {
     "@kaoto/kaoto": "2.5.0-M2",
     "@kie-tools-core/backend": "0.32.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
+  "extensionDependencies": [
+    "redhat.vscode-apache-camel"
+  ],
   "dependencies": {
     "@kaoto/kaoto": "2.5.0-M2",
     "@kie-tools-core/backend": "0.32.0",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,6 @@
     "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
-  "extensionDependencies": [
-    "redhat.vscode-apache-camel",
-    "redhat.vscode-debug-adapter-apache-camel"
-  ],
   "dependencies": {
     "@kaoto/kaoto": "2.5.0-M2",
     "@kie-tools-core/backend": "0.32.0",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -28,7 +28,7 @@ let backendProxy: VsCodeBackendProxy;
 let telemetryService: TelemetryService;
 
 export async function activate(context: vscode.ExtensionContext) {
-  console.info("Kaoto Editor extension is alive.");
+  console.warn("Kaoto Editor extension is alive.");
 
   const backendI18n = new I18n(backendI18nDefaults, backendI18nDictionaries, vscode.env.language);
   backendProxy = new VsCodeBackendProxy(context, backendI18n);

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -24,6 +24,6 @@ suite('Extension is activated', () => {
         assert.isNotNull(extension, 'VS Code Kaoto not found');
         await waitUntil(() => {
             return extension?.isActive;
-        }, 10000, 1000);
+        }, 20000, 1000);
     });
 })

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -28,8 +28,10 @@ suite('Extension is activated', () => {
             return extension?.isActive;
         }, 20000, 1000);
         } catch {
+            console.log('Kaoto extension not activated after 20s');
             try {
-                await extension?.activate();
+                const debugAdapterExtension = await vscode.extensions.getExtension('redhat.vscode-debug-adapter-apache-camel');
+                await debugAdapterExtension?.activate();
             } catch (err) {
                 console.log(err);
                 throw err;

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -16,11 +16,14 @@
  */
 import { assert } from 'chai';
 import * as vscode from 'vscode';
+import { waitUntil } from 'async-wait-until';
 
 suite('Extension is activated', () => {
-    test('Extension is activated', async() => {
+    test('Kaoto Extension is activated when the workspace used for tests contains yaml files', async() => {
         const extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
         assert.isNotNull(extension, 'VS Code Kaoto not found');
-        assert.isTrue(extension?.isActive, 'VS Code Kaoto is not activated despite the workspace used for tests contains yaml files');
+        await waitUntil(() => {
+            return extension?.isActive;
+        }, 10000, 1000);
     });
 })

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -18,25 +18,25 @@ import { assert } from 'chai';
 import * as vscode from 'vscode';
 import { waitUntil } from 'async-wait-until';
 
-suite('Extension is activated', () => {
+suite.only('Extension is activated', () => {
     test('Kaoto Extension is activated when the workspace used for tests contains yaml files', async() => {
         let extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
         assert.isNotNull(extension, 'VS Code Kaoto not found');
-        try {
+      //  try {
         await waitUntil(async() => {
             extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
             return extension?.isActive;
         }, 20000, 1000);
-        } catch {
-            console.log('Kaoto extension not activated after 20s');
-            try {
-                const debugAdapterExtension = await vscode.extensions.getExtension('redhat.vscode-debug-adapter-apache-camel');
-                await debugAdapterExtension?.activate();
-            } catch (err) {
-                console.log(err);
-                throw err;
-            }
-        }
+        // } catch {
+        //     console.log('Kaoto extension not activated after 20s');
+        //     try {
+        //         const debugAdapterExtension = await vscode.extensions.getExtension('redhat.vscode-debug-adapter-apache-camel');
+        //         await debugAdapterExtension?.activate();
+        //     } catch (err) {
+        //         console.log(err);
+        //         throw err;
+        //     }
+        // }
     }
 );
 })

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -22,9 +22,19 @@ suite('Extension is activated', () => {
     test('Kaoto Extension is activated when the workspace used for tests contains yaml files', async() => {
         let extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
         assert.isNotNull(extension, 'VS Code Kaoto not found');
+        try {
         await waitUntil(async() => {
             extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
             return extension?.isActive;
         }, 20000, 1000);
-    });
+        } catch {
+            try {
+                await extension?.activate();
+            } catch (err) {
+                console.log(err);
+                throw err;
+            }
+        }
+    }
+);
 })

--- a/src/test/activation.test.ts
+++ b/src/test/activation.test.ts
@@ -20,9 +20,10 @@ import { waitUntil } from 'async-wait-until';
 
 suite('Extension is activated', () => {
     test('Kaoto Extension is activated when the workspace used for tests contains yaml files', async() => {
-        const extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
+        let extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
         assert.isNotNull(extension, 'VS Code Kaoto not found');
-        await waitUntil(() => {
+        await waitUntil(async() => {
+            extension = await vscode.extensions.getExtension('redhat.vscode-kaoto');
             return extension?.isActive;
         }, 20000, 1000);
     });

--- a/test-WorkspaceWithAYamlFile/my.camel.yaml
+++ b/test-WorkspaceWithAYamlFile/my.camel.yaml
@@ -1,0 +1,9 @@
+- route:
+    id: camelroute51
+    from:
+      id: timerID
+      uri: timer:demo
+      parameters: {}
+      steps:
+        - log:
+            message: my message logged


### PR DESCRIPTION
It allows to have several general Camel features such as Run/debug/Create/Export for users which are installing VS Code Kaoto extension only.