### PR TITLE
Add Camel extensions as dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
       with:
         node-version: 20
         cache: 'yarn'
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: "temurin"
     - name: yarn
       run: yarn --network-timeout 1000000
     - name: yarn build:dev
@@ -66,21 +71,21 @@ jobs:
       with:
         name: 'vscode-kaoto-vsix'
         path: '*.vsix'
-    - name: Store VS Code logs
+    - name: Store UI Tests VS Code logs
       uses: actions/upload-artifact@v4
       if: always()
       with:
         name: vscode-logs-${{ matrix.os }}
         path: test-resources/settings/logs
-    - name: Store VS Code Logs
+    - name: Store Unit Tests VS Code Logs
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || cancelled() || success()
       with:
         name: ${{ matrix.os }}-test-logs
         path: .vscode-test/user-data/logs/*
     - name: Store VS Code UI Tests screenshots on failure
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || cancelled()
       with:
         name: ui-test-screenshots-${{ matrix.os }}
         path: test-resources/screenshots

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
-	workspaceFolder: './test Fixture with speci@l chars',
+	workspaceFolder: './test-WorkspaceWithAYamlFile',
 	mocha: {
 		ui: 'tdd',
 		color: true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.5.0
+
 - Upgrade to Kaoto 2.5.0-M2
+- Add VS Code Language Support and Debug Adapter for Camel as extension dependencies. It allows to have several general Camel features such as Run/debug/Create/Export.
 
 # 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 - Setting to provide custom set of catalog
 - Edit Kaoto (`*.kaoto.yaml` and `*.kaoto.yml`) files. Note that these filename extensions are not supported by Camel JBang and are merely still here to stay backward-compatible with Kaoto v1.
 
+### Requirements
+
+Java 17+ must be available on the system path.
+
 ### Limitations
 
 - Kaoto files are always written and overwritten with `Linux-style` end of line (EOL).

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources 'out/**/*.test.js' --open_resource './test Fixture with speci@l chars'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
+  "extensionDependencies": [
+    "redhat.vscode-apache-camel",
+    "redhat.vscode-debug-adapter-apache-camel"
+  ],
   "dependencies": {
     "@kaoto/kaoto": "2.5.0-M2",
     "@kie-tools-core/backend": "0.32.0",

--- a/test-WorkspaceWithAYamlFile/my.camel.yaml
+++ b/test-WorkspaceWithAYamlFile/my.camel.yaml
@@ -1,0 +1,9 @@
+- route:
+    id: camelroute51
+    from:
+      id: timerID
+      uri: timer:demo
+      parameters: {}
+      steps:
+        - log:
+            message: my message logged


### PR DESCRIPTION
It allows to have several general Camel features such as Run/debug/Create/Export for users which are installing VS Code Kaoto extension only.