### PR TITLE
chore: bump minimal supported VS Code from 1.74.0 to 1.95.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.5.0
 
 - `Breaking:` Remove legacy support for Kaoto v1 file patterns (*.kaoto.yaml,*.kaoto.yml)
+- `Breaking:` Bump minimal VS Code version from 1.74.0 to 1.95.0
 - Upgrade to Kaoto 2.5.0-M2
 - Add Kaoto view container with initial Help & Feedback view
 - Improve toggle source code (open/close camel file in a side textual editor) using one button

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-kaoto?style=for-the-badge" alt="Marketplace Version"/></a>
   <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.5.0--M2-orange?style=for-the-badge"></a>
-  <img src="https://img.shields.io/badge/VS%20Code-1.74.0+-blue?style=for-the-badge" alt="Visual Studio Code Support"/>
+  <img src="https://img.shields.io/badge/VS%20Code-1.95.0+-blue?style=for-the-badge" alt="Visual Studio Code Support"/>
   <a href="https://github.com/KaotoIO/vscode-kaoto/blob/main/LICENSE"><img src="https://img.shields.io/github/license/KaotoIO/vscode-kaoto?color=blue&style=for-the-badge" alt="License"/></a>
   <a href="https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen?color=yellow&style=for-the-badge" alt="Zulip"/></a></br>
   <a href="https://github.com/KaotoIO/vscode-kaoto/actions/workflows/main-kaoto.yaml"><img src="https://img.shields.io/github/actions/workflow/status/KaotoIO/vscode-kaoto/main-kaoto.yaml?style=for-the-badge&label=main%20kaoto%20ui" alt="Build with Main branch of Kaoto UI"></a>

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "main": "./dist/extension/extension.js",
   "browser": "./dist/extension/extensionWeb.js",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.95.0"
   },
   "categories": [
     "Other"
@@ -263,6 +263,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.10",
     "@types/react": "18.3.1",
+    "@types/vscode": "^1.95.0",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
     "@vscode/test-web": "^0.0.66",

--- a/src/views/providers/HelpFeedbackProvider.ts
+++ b/src/views/providers/HelpFeedbackProvider.ts
@@ -66,7 +66,7 @@ export class HelpFeedbackProvider implements TreeDataProvider<HelpFeedbackItem> 
 export class HelpFeedbackItem extends TreeItem {
     constructor(
         public readonly name: string,
-        public readonly icon: string | Uri | { light: string | Uri; dark: string | Uri } | ThemeIcon,
+        public readonly icon: string | ThemeIcon,
         public readonly url: string
     ) {
         super(name, TreeItemCollapsibleState.None);

--- a/src/views/providers/IntegrationsProvider.ts
+++ b/src/views/providers/IntegrationsProvider.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { commands, Event, EventEmitter, FileSystemWatcher, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, workspace } from 'vscode';
+import { commands, Event, EventEmitter, FileSystemWatcher, IconPath, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri, workspace } from 'vscode';
 import { basename, dirname, join, relative } from 'path';
 import { parse } from 'yaml';
 import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';
@@ -63,15 +63,15 @@ export class IntegrationsProvider implements TreeDataProvider<TreeItem> {
 		return { type: 'route', name: basename(fileName, '.camel.yaml') };
 	}
 
-	private getIcon(type: string): { dark: string, light: string } {
+	private getIcon(type: string): { light: Uri, dark: Uri } {
 		const basePath = join(this.extensionUriPath, 'icons', 'integrations');
 		switch (type) {
-			case 'kamelet': return { light: join(basePath, 'kamelets-file-icon-light.png'), dark: join(basePath, 'kamelets-file-icon-dark.png') };
-			case 'pipe': return { light: join(basePath, 'pipes-file-icon-light.png'), dark: join(basePath, 'pipes-file-icon-dark.png') };
-			case 'route': return { light: join(basePath, 'routes-file-icon-light.png'), dark: join(basePath, 'routes-file-icon-dark.png') };
-			case 'route-child': return { light: join(basePath, 'route-black.svg'), dark: join(basePath, 'route-white.svg') };
+			case 'kamelet': return { light: Uri.file(join(basePath, 'kamelets-file-icon-light.png')), dark: Uri.file(join(basePath, 'kamelets-file-icon-dark.png')) };
+			case 'pipe': return { light: Uri.file(join(basePath, 'pipes-file-icon-light.png')), dark: Uri.file(join(basePath, 'pipes-file-icon-dark.png')) };
+			case 'route': return { light: Uri.file(join(basePath, 'routes-file-icon-light.png')), dark: Uri.file(join(basePath, 'routes-file-icon-dark.png')) };
+			case 'route-child': return { light: Uri.file(join(basePath, 'route-black.svg')), dark: Uri.file(join(basePath, 'route-white.svg')) };
 			// every unknown is considered as Route integration file
-			default: return { light: join(basePath, 'routes-file-icon-light.png'), dark: join(basePath, 'routes-file-icon-light.png') };
+			default: return { light: Uri.file(join(basePath, 'routes-file-icon-light.png')), dark: Uri.file(join(basePath, 'routes-file-icon-light.png')) };
 		}
 	}
 
@@ -116,7 +116,7 @@ export class Integration extends TreeItem {
 		public readonly filepath: Uri,
 		public collapsibleState: TreeItemCollapsibleState,
 		public readonly type: string,
-		public readonly icon: { light: string | Uri; dark: string | Uri }
+		public readonly icon: string | IconPath
 	) {
 		super(filename, collapsibleState);
 		this.iconPath = icon;
@@ -141,7 +141,7 @@ export class Route extends TreeItem {
 	constructor(
 		public readonly name: string,
 		public readonly description: string,
-		public readonly icon: { light: string | Uri; dark: string | Uri }
+		public readonly icon: string | IconPath
 	) {
 		super(name || '[missing route id]', TreeItemCollapsibleState.None);
 		this.description = description;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,6 +1659,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/vscode@npm:^1.95.0":
+  version: 1.97.0
+  resolution: "@types/vscode@npm:1.97.0"
+  checksum: 10/b52333b4ab296a266af01f260759229130ecf89f1b32fc95ba68a915a93d091440205d01d53c18969af7859c417245ff326aa51b0bec66cf8784d92ddc4fe936
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:*":
   version: 8.5.10
   resolution: "@types/ws@npm:8.5.10"
@@ -9085,6 +9092,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     "@types/mocha": "npm:^10.0.10"
     "@types/react": "npm:18.3.1"
+    "@types/vscode": "npm:^1.95.0"
     "@vscode/test-cli": "npm:^0.0.10"
     "@vscode/test-electron": "npm:^2.4.1"
     "@vscode/test-web": "npm:^0.0.66"


### PR DESCRIPTION
it will allow to use newer VS Code API for upcoming Kaoto view features