### PR TITLE
fix: show warning and hide not supported buttons in virtual workspace web environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": false
+    },
+    "virtualWorkspaces": {
+      "supported": "limited",
+      "description": "In virtual workspaces, actions which requires Camel JBang CLI cannot be working because of missing Shell Execution environment."
     }
   },
   "contributes": {
@@ -203,7 +207,7 @@
         {
           "submenu": "kaoto.new.file",
           "group": "navigation@1",
-          "when": "view == kaoto.integrations"
+          "when": "view == kaoto.integrations && !virtualWorkspace"
         },
         {
           "command": "kaoto.integrations.refresh",


### PR DESCRIPTION
this will handle unsupported Web Browser environments of WEbExtension entry-point. At browser web extension the buttons  like `New File...` which requires JBang (shell execution) wont be visible in UI + there is a warning message which is visible in description of extension in Markeplace. (see https://code.visualstudio.com/api/extension-guides/virtual-workspaces#partial-and-full-support-for-virtual-workspaces)

I have tested locally and behavior is:

- Red Hat Dev Spaces in Browser --> **buttons visible and working**
- Desktop VS Code --> **buttons visible and working**
- VS Code in Browser or GitHub Codespaces --> **buttons not visible**