### PR TITLE
feat: add welcome content into Kaoto: Integrations view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add `New File...` button into `Kaoto: Integrations` view
 - Add automatically Apache Camel into JBang Trusted Sources
 - Bump Camel JBang CLI default version from 4.10.0 to 4.10.1
+- add welcome content into Kaoto: Integrations view
+  - show Open Folder when there is no workspace
+  - show New Camel File if no Camel related file is found in workspace (when Integrations view is empty)
 
 # 2.4.0
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,13 @@
         "icon": "./icons/commands/source_active.png"
       },
       {
+        "command": "kaoto.new.camel.file",
+        "title": "Camel File...",
+        "category": "Kaoto",
+        "enablement": "false",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "kaoto.camel.jbang.init.route.yaml",
         "shortTitle": "New Camel Route...",
         "title": "Create a Camel Route using YAML DSL",
@@ -207,7 +214,7 @@
         {
           "submenu": "kaoto.new.file",
           "group": "navigation@1",
-          "when": "view == kaoto.integrations && !virtualWorkspace && kaoto.jbangAvailable"
+          "when": "view == kaoto.integrations && !virtualWorkspace && kaoto.jbangAvailable && workspaceFolderCount > 0"
         },
         {
           "command": "kaoto.integrations.refresh",
@@ -221,6 +228,18 @@
         "id": "kaoto.new.file",
         "label": "New File...",
         "icon": "$(new-file)"
+      }
+    ],
+    "viewsWelcome": [
+      {
+        "view": "kaoto.integrations",
+        "contents": "In order to start with Apache Camel, you can create a standalone Camel File.\n[Camel File...](command:kaoto.new.camel.file)\nTo learn more about Apache Camel [read docs](https://camel.apache.org/docs/).",
+        "when": "!virtualWorkspace && kaoto.jbangAvailable && workspaceFolderCount > 0"
+      },
+      {
+        "view": "kaoto.integrations",
+        "contents": "You have not yet added a folder to the workspace.\n[Open Folder](command:vscode.openFolder)",
+        "when": "workspaceFolderCount == 0"
       }
     ],
     "configuration": [

--- a/src/commands/NewCamelFileCommand.ts
+++ b/src/commands/NewCamelFileCommand.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QuickPickItem, commands, window } from 'vscode';
+import { NewCamelRouteCommand } from './NewCamelRouteCommand';
+import { NewCamelKameletCommand } from './NewCamelKameletCommand';
+import { NewCamelPipeCommand } from './NewCamelPipeCommand';
+
+export class NewCamelFileCommand {
+	public static readonly ID_COMMAND_CAMEL_NEW_FILE = 'kaoto.new.camel.file';
+
+	public async create(): Promise<void> {
+		const selection = await this.showQuickPickForCamelFileType();
+		if (selection) {
+			const cmd = this.getCamelRouteCommandFromSelection(selection.label);
+			if (cmd) {
+				await commands.executeCommand(cmd);
+			}
+		}
+	}
+
+	protected async showQuickPickForCamelFileType(): Promise<QuickPickItem> {
+		const items: QuickPickItem[] = [
+			{ label: 'Camel Route', description: 'Camel Route using YAML DSL' },
+			{ label: 'Kamelet', description: 'Kamelet using YAML DSL' },
+			{ label: 'Pipe', description: 'Custom Resource Pipe using YAML DSL' },
+		];
+		return (
+			(await window.showQuickPick(items, {
+				placeHolder: 'Please select a Camel File type.',
+				title: 'New Camel File...',
+			})) || { label: 'Problem occurred: Try again.' }
+		);
+	}
+
+	protected getCamelRouteCommandFromSelection(selection: string): string | undefined {
+		switch (selection) {
+			case 'Camel Route':
+				return NewCamelRouteCommand.ID_COMMAND_CAMEL_ROUTE_YAML;
+			case 'Kamelet':
+				return NewCamelKameletCommand.ID_COMMAND_CAMEL_KAMELET_YAML;
+			case 'Pipe':
+				return NewCamelPipeCommand.ID_COMMAND_CAMEL_PIPE_YAML;
+			default:
+				break;
+		}
+		return undefined;
+	}
+}

--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -23,6 +23,7 @@ import { NewCamelKameletCommand } from '../commands/NewCamelKameletCommand';
 import { NewCamelPipeCommand } from '../commands/NewCamelPipeCommand';
 import { verifyCamelJBangTrustedSource, verifyJBangExists } from '../helpers/helpers';
 import { KaotoOutputChannel } from './KaotoOutputChannel';
+import { NewCamelFileCommand } from '../commands/NewCamelFileCommand';
 
 export class ExtensionContextHandler {
 	protected kieEditorStore: KogitoVsCode.VsCodeKieEditorStore;
@@ -99,6 +100,12 @@ export class ExtensionContextHandler {
 	}
 
 	private registerNewCamelYamlFilesCommands() {
+		// register custom command for a Camel YAML file creation (eg. used in Integrations view Welcome Content)
+		this.context.subscriptions.push(
+			vscode.commands.registerCommand(NewCamelFileCommand.ID_COMMAND_CAMEL_NEW_FILE, async () => {
+				await new NewCamelFileCommand().create();
+			}),
+		);
 		// register commands for new Camel files creation using YAML DSL - Routes, Kamelets, Pipes
 		this.context.subscriptions.push(
 			vscode.commands.registerCommand(NewCamelRouteCommand.ID_COMMAND_CAMEL_ROUTE_YAML, async () => {


### PR DESCRIPTION
- if no workspace, show Open Folder
- if existing workspace and no camel related files, show New Camel File

NO WORKSPACE
![Screenshot 2025-03-05 at 13 23 41](https://github.com/user-attachments/assets/8533c743-e81e-4929-9fc7-53b640fa0571)

NO CAMEL FILE
![Screenshot 2025-03-05 at 13 31 37](https://github.com/user-attachments/assets/6de22d32-93f1-4a14-bf85-04a6c2c0d034)
