### PR TITLE
test: add dynamic wait for extension activation after each vscode window reload

### DIFF
--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -1,7 +1,7 @@
 import { By, EditorView, until, VSBrowser, WebDriver, WebView, logging, InputBox } from 'vscode-extension-tester';
 import { assert } from 'chai';
 import * as path from 'path';
-import { checkEmptyCanvasLoaded, checkTopologyLoaded, openAndSwitchToKaotoFrame } from './Util';
+import { checkEmptyCanvasLoaded, checkTopologyLoaded, openAndSwitchToKaotoFrame, openResourcesAndWaitForActivation } from './Util';
 import { waitUntil } from 'async-wait-until';
 import * as fs from 'fs-extra';
 
@@ -14,7 +14,7 @@ describe('Kaoto basic development flow', function () {
 	let globalKaotoWebView: WebView;
 
 	before(async function () {
-		await VSBrowser.instance.openResources(workspaceFolder);
+		await openResourcesAndWaitForActivation(workspaceFolder);
 		const logger = logging.getLogger('webdriver');
 		logger.setLevel(logging.Level.DEBUG);
 		fs.copySync(path.join(workspaceFolder, 'empty.camel.yaml'), path.join(workspaceFolder, 'empty_copy.camel.yaml'));

--- a/it-tests/ContextualMenuOpen.test.ts
+++ b/it-tests/ContextualMenuOpen.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'vscode-extension-tester';
 import { assert, expect } from 'chai';
 import * as path from 'path';
-import { checkEmptyCanvasLoaded, switchToKaotoFrame } from './Util';
+import { checkEmptyCanvasLoaded, openResourcesAndWaitForActivation, switchToKaotoFrame } from './Util';
 
 describe('Contextual menu opening', function () {
 	this.timeout(60_000);
@@ -61,7 +61,7 @@ describe('Contextual menu opening', function () {
 
 	it('Open Camel file with name my.yaml opens with text editor by default', async function () {
 		const filePath = path.join(workspaceFolder, 'my.yaml');
-		await VSBrowser.instance.openResources(filePath);
+		await openResourcesAndWaitForActivation(filePath);
 		const editor = new TextEditor();
 		expect(await editor.getTextAtLine(1)).contains('- route:');
 		await editor.save();

--- a/it-tests/OpenTextualEditorCommand.test.ts
+++ b/it-tests/OpenTextualEditorCommand.test.ts
@@ -1,7 +1,8 @@
-import { EditorView, TextEditor, VSBrowser } from 'vscode-extension-tester';
+import { EditorView, TextEditor } from 'vscode-extension-tester';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as os from 'os';
+import { openResourcesAndWaitForActivation } from './Util';
 
 describe('Toggle Source Code', function () {
 	this.timeout(30_000);
@@ -12,7 +13,7 @@ describe('Toggle Source Code', function () {
 	let editorView: EditorView;
 
 	before(async function () {
-		await VSBrowser.instance.openResources(path.join(WORKSPACE_FOLDER, CAMEL_FILE));
+		await openResourcesAndWaitForActivation(path.join(WORKSPACE_FOLDER, CAMEL_FILE));
 		editorView = new EditorView();
 	});
 

--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -1,5 +1,5 @@
 import { ActivityBar, after, By, Key, TextSetting, until, VSBrowser, WebDriver, WebElement, WebView, Workbench } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
+import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, openResourcesAndWaitForActivation, resetUserSettings } from '../Util';
 import { join } from 'path';
 import { expect } from 'chai';
 
@@ -43,8 +43,7 @@ describe('User Settings', function () {
 	before(async function () {
 		this.timeout(60_000);
 		driver = VSBrowser.instance.driver;
-		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
-		await VSBrowser.instance.waitForWorkbench();
+		await openResourcesAndWaitForActivation(WORKSPACE_FOLDER);
 
 		// provide the Catalog URL using Settings UI editor
 		const settings = await new Workbench().openSettings();

--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -1,5 +1,5 @@
 import { ActivityBar, after, By, ComboSetting, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
+import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, openResourcesAndWaitForActivation, resetUserSettings } from '../Util';
 import { join } from 'path';
 import { expect } from 'chai';
 
@@ -23,8 +23,7 @@ describe('User Settings', function () {
 	before(async function () {
 		this.timeout(60_000);
 		driver = VSBrowser.instance.driver;
-		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
-		await VSBrowser.instance.waitForWorkbench();
+		await openResourcesAndWaitForActivation(WORKSPACE_FOLDER);
 
 		// provide the Node Label using Settings UI editor
 		const settings = await new Workbench().openSettings();

--- a/it-tests/views/01_KaotoViewBasic.test.ts
+++ b/it-tests/views/01_KaotoViewBasic.test.ts
@@ -15,7 +15,8 @@
  */
 import { expect } from 'chai';
 import { join } from 'path';
-import { ActivityBar, SideBarView, ViewControl, ViewItem, ViewSection, VSBrowser } from 'vscode-extension-tester';
+import { ActivityBar, SideBarView, ViewControl, ViewItem, ViewSection } from 'vscode-extension-tester';
+import { openResourcesAndWaitForActivation } from '../Util';
 
 describe('Kaoto View Container', function () {
 	this.timeout(30_000);
@@ -26,7 +27,7 @@ describe('Kaoto View Container', function () {
 	let kaotoView: SideBarView | undefined;
 
 	before(async function () {
-		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+		await openResourcesAndWaitForActivation(WORKSPACE_FOLDER);
 	});
 
 	after(async function () {

--- a/it-tests/views/IntegrationsView.test.ts
+++ b/it-tests/views/IntegrationsView.test.ts
@@ -15,8 +15,8 @@
  */
 import { expect } from 'chai';
 import { join, sep } from 'path';
-import { ActivityBar, EditorView, SideBarView, TreeItem, ViewControl, ViewSection, VSBrowser } from 'vscode-extension-tester';
-import { checkTopologyLoaded, switchToKaotoFrame } from '../Util';
+import { ActivityBar, EditorView, SideBarView, TreeItem, ViewControl, ViewSection } from 'vscode-extension-tester';
+import { checkTopologyLoaded, openResourcesAndWaitForActivation, switchToKaotoFrame } from '../Util';
 
 describe('Integrations View', function () {
 	this.timeout(60_000);
@@ -30,7 +30,7 @@ describe('Integrations View', function () {
 	let labels: string[];
 
 	before(async function () {
-		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+		await openResourcesAndWaitForActivation(WORKSPACE_FOLDER);
 
 		kaotoViewContainer = await new ActivityBar().getViewControl('Kaoto');
 		kaotoView = await kaotoViewContainer?.openView();

--- a/it-tests/views/IntegrationsViewNewFile.test.ts
+++ b/it-tests/views/IntegrationsViewNewFile.test.ts
@@ -35,7 +35,7 @@ import {
 	WebDriver,
 	WebElement,
 } from 'vscode-extension-tester';
-import { switchToKaotoFrame } from '../Util';
+import { openResourcesAndWaitForActivation, switchToKaotoFrame } from '../Util';
 
 describe('Integrations View', function () {
 	this.timeout(180_000);
@@ -50,8 +50,7 @@ describe('Integrations View', function () {
 
 	before(async function () {
 		driver = VSBrowser.instance.driver;
-		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
-		await VSBrowser.instance.waitForWorkbench();
+		await openResourcesAndWaitForActivation(WORKSPACE_FOLDER);
 
 		kaotoViewContainer = await new ActivityBar().getViewControl('Kaoto');
 		kaotoView = await kaotoViewContainer?.openView();


### PR DESCRIPTION
Hopefully this will improve the tests were flaky from time to time.