### PR TITLE
fix: improve regex for a GAV validation of new project creation process

### DIFF
--- a/src/commands/NewCamelProjectCommand.ts
+++ b/src/commands/NewCamelProjectCommand.ts
@@ -79,7 +79,7 @@ export class NewCamelProjectCommand {
 	 * @param name
 	 * @returns string | undefined
 	 */
-	private validateGAV(name: string): string | undefined {
+	public validateGAV(name: string): string | undefined {
 		if (!name) {
 			return 'Please provide a GAV for the new project following groupId:artifactId:version pattern.';
 		}
@@ -95,22 +95,22 @@ export class NewCamelProjectCommand {
 			return 'The groupId cannot start with a .';
 		}
 		for (const groupIdSubPart of groupIdSplit) {
-			const regExpSearch = /^[a-z]\w*$/.exec(groupIdSubPart);
+			const regExpSearch = /^(?!\.)[a-z0-9]+(\.[a-z0-9]+)*$/.exec(groupIdSubPart);
 			if (regExpSearch === null || regExpSearch.length === 0) {
-				return `Invalid subpart of groupId: ${groupIdSubPart}} . It must follow groupId:artifactId:version pattern with groupId subpart separated by dot needs to follow this specific pattern: [a-zA-Z]\\w*`;
+				return `Invalid subpart of groupId: '${groupIdSubPart}'. The groupId is expected to follow the Java package naming conventions.`;
 			}
 		}
 
 		const artifactId = gavs[1];
-		const regExpSearchArtifactId = /^[a-zA-Z]\w*$/.exec(artifactId);
+		const regExpSearchArtifactId = /^(?!-)[a-z0-9]+(-[a-z0-9]+)*$/.exec(artifactId);
 		if (regExpSearchArtifactId === null || regExpSearchArtifactId.length === 0) {
-			return `Invalid artifactId: ${artifactId}} . It must follow groupId:artifactId:version pattern with artifactId specific pattern: [a-zA-Z]\\w*`;
+			return `Invalid artifactId: '${artifactId}'. The identifiers should only consist of lowercase letters, digits, and hyphens.`;
 		}
 
 		const version = gavs[2];
-		const regExpSearch = /^\d[\w-.]*$/.exec(version);
+		const regExpSearch = /^(\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+(-\d+)?)?(\+[A-Za-z0-9]+)?)$/.exec(version);
 		if (regExpSearch === null || regExpSearch.length === 0) {
-			return `Invalid version: ${version} . It must follow groupId:artifactId:version pattern with version specific pattern: \\d[\\w-.]*`;
+			return `Invalid version: '${version}'. The version is expected be compliant with Semantic Versioning 1.0.0.`;
 		}
 		return undefined;
 	}

--- a/src/test/ValidateNewProjectGAV.test.ts
+++ b/src/test/ValidateNewProjectGAV.test.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { NewCamelProjectCommand } from '../commands/NewCamelProjectCommand';
+
+suite('New Camel Project GAV Validation', function () {
+	const command = new NewCamelProjectCommand();
+
+	/**
+	 * Helper function to validate test cases.
+	 * @param {string[]} validCases - Array of valid GAV strings.
+	 * @param {string[]} invalidCases - Array of invalid GAV strings.
+	 */
+	function runValidationTests(validCases: string[], invalidCases: string[]) {
+		validCases.forEach((gav) => {
+			test(`Valid: ${gav}`, function () {
+				expect(command.validateGAV(gav)).to.be.undefined;
+			});
+		});
+		invalidCases.forEach((gav) => {
+			test(`Invalid: ${gav}`, function () {
+				expect(command.validateGAV(gav)).to.not.be.undefined;
+			});
+		});
+	}
+
+	suite('General GAV Validation', function () {
+		runValidationTests(
+			['com.test:demo:1.0-SNAPSHOT', 'com:demo:1.0-SNAPSHOT', 'com.test:demo:1.0'],
+			[
+				'',
+				'invalid',
+				'invalid:invalid',
+				'invalid:with space:1.0-SNAPSHOT',
+				'with space:invalid:1.0-SNAPSHOT',
+				'invalid:invalid:1.0- with space',
+				'.invalid:valid:1.0-SNAPSHOT',
+				'%invalid:valid:1.0-SNAPSHOT',
+				'va.lid:%invalid:1.0-SNAPSHOT',
+				'va.lid:valid:1.0-%invalid',
+			],
+		);
+	});
+
+	suite('Group ID Validation', function () {
+		runValidationTests(
+			['com.test:demo:1.0-SNAPSHOT', 'org.apache.maven:demo:1.0', 'io.github.project:demo:2.3.4'],
+			['.com.test:demo:1.0', 'com..example:demo:1.0', 'com.Example:demo:1.0', 'com.example.:demo:1.0'],
+		);
+	});
+
+	suite('Artifact ID Validation', function () {
+		runValidationTests(
+			['com.test:demo:1.0', 'com.test:my-library:1.2.3', 'org.apache.maven:plugin:3.5.0'],
+			['com.test:Demo:1.0', 'com.test:my_library:1.2.3', 'com.test:lib$:1.0', 'com.test:lib-:1.0'],
+		);
+	});
+
+	suite('Version Validation', function () {
+		runValidationTests(
+			[
+				'com.test:demo:1.0',
+				'com.test:demo:1.2.3',
+				'com.test:demo:1.0-SNAPSHOT',
+				'com.test:demo:2.3.4-beta',
+				'com.test:demo:3.1.4-alpha-2',
+				'com.test:demo:1.2.3+dfc0c87',
+				'com.test:demo:2.3.4+15433',
+			],
+			['com.test:demo:1', 'com.test:demo:1.', 'com.test:demo:1.0.', 'com.test:demo:1.0+', 'com.test:demo:v1.0', 'com.test:demo:1.0--SNAPSHOT'],
+		);
+	});
+});


### PR DESCRIPTION
from now it should be more compliant with common maven project conventions for GAV

groupId - The is expected to follow the Java package naming conventions
artifactId - The identifiers should only consist of lowercase letters, digits, and hyphens
version - The version is expected be compliant with Semantic Versioning 1.0.0