### PR TITLE
removed the test for a specific number of tabs

### DIFF
--- a/it-tests/SwitchBetweenTabs.test.ts
+++ b/it-tests/SwitchBetweenTabs.test.ts
@@ -45,7 +45,6 @@ describe('Switching between editor tabs', function () {
 
 	it('Open "my.camel.yaml" file and check "Design" tab is active by default', async function () {
 		kaotoWebview = (await openAndSwitchToKaotoFrame(WORKSPACE_FOLDER, 'my.camel.yaml', driver, true)).kaotoWebview;
-		expect(await getTabsCount()).to.equal(3);
 		expect(await getActiveTabName()).to.equal('Design');
 	});
 
@@ -69,11 +68,6 @@ describe('Switching between editor tabs', function () {
 
 	async function getTabsWebElements(): Promise<WebElement[]> {
 		return await driver.findElement(By.className(locators.EditorTabs.tabsList)).findElements(By.className(locators.EditorTabs.tabsItem));
-	}
-
-	async function getTabsCount(): Promise<number> {
-		await driver.wait(until.elementLocated(By.className(locators.EditorTabs.tabsList)), 5_000, 'Editor tabs are not displayed properly!');
-		return (await getTabsWebElements()).length;
 	}
 
 	async function getActiveTabName(): Promise<string> {


### PR DESCRIPTION
This test will break with every change to the number of tabs in the editor. IMO it should be fully removed.