### PR TITLE
FUSETOOLS2-2522 - add conditional wait for the ActivityBar available

### DIFF
--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -58,6 +58,18 @@ describe('User Settings', function () {
 		await driver.sleep(1_000); // stabilize tests which are sometimes failing on macOS CI
 		await closeEditor('Settings', true);
 
+		await driver.wait(
+			async () => {
+				try {
+					await new ActivityBar();
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			5_000,
+			'The activityBar is not reachable after 5 seconds. Maybe the modal dialog has not been successfully closed previously?',
+		);
 		// close sidebar
 		await (await new ActivityBar().getViewControl('Explorer'))?.closeView();
 


### PR DESCRIPTION
the step before there is a modal dialog, in case it takes few seconds to close, the ActivityBar might not be reachable.