### PR TITLE
feat: add Stop and Logs action buttons into Kaoto: Deployments view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     - create new Camel Route using XML DSL
     - list XML files with route elements
 - Add `Deployments` view into Kaoto view container which displays all local running integrations
+- Add `Stop` and `Follow Logs` action buttons into Deployments view
 
 # 2.4.0
 

--- a/it-tests/views/06_DeploymentsViewLogsAndStop.test.ts
+++ b/it-tests/views/06_DeploymentsViewLogsAndStop.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { join } from 'path';
+import {
+	ActivityBar,
+	after,
+	before,
+	BottomBarPanel,
+	EditorView,
+	SideBarView,
+	TreeItem,
+	ViewControl,
+	ViewSection,
+	VSBrowser,
+	WebDriver,
+} from 'vscode-extension-tester';
+import { getTreeItem, killTerminal, waitUntilTerminalHasText } from '../Util';
+
+describe('Deployments View', function () {
+	this.timeout(600_000); // 10 minutes
+
+	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars', 'kaoto-view');
+
+	let driver: WebDriver;
+	let kaotoViewContainer: ViewControl | undefined;
+	let kaotoView: SideBarView | undefined;
+	let deploymentsSection: ViewSection | undefined;
+	let integrationsSection: ViewSection | undefined;
+
+	before(async function () {
+		driver = VSBrowser.instance.driver;
+		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+		await VSBrowser.instance.waitForWorkbench();
+
+		kaotoViewContainer = await new ActivityBar().getViewControl('Kaoto');
+		kaotoView = await kaotoViewContainer?.openView();
+		deploymentsSection = await kaotoView?.getContent().getSection('Deployments');
+		integrationsSection = await kaotoView?.getContent().getSection('Integrations');
+	});
+
+	after(async function () {
+		await kaotoViewContainer?.closeView();
+		await new EditorView().closeAllEditors();
+		await killTerminal();
+	});
+
+	const parameters = [
+		{ label: 'sample2', file: 'sample2.camel.yaml', message: 'Hello World' },
+		{ label: 'kaoto', file: 'kaoto.camel.xml', message: 'Hello Camel' },
+	];
+
+	parameters.forEach((p) => {
+		it(`run '${p.file}' integration`, async function () {
+			const item = await getTreeItem(driver, integrationsSection, p.file);
+			const run = await item?.getActionButton('Run');
+			await run?.click();
+		});
+
+		it(`check '${p.file}' is running`, async function () {
+			const item1 = await getTreeItem(driver, deploymentsSection, p.label, 30_000);
+			expect(item1).to.not.be.undefined;
+		});
+	});
+
+	it(`hide terminal`, async function () {
+		await new BottomBarPanel().toggle(false);
+	});
+
+	parameters.forEach((p) => {
+		it(`show logs for '${p.file}'`, async function () {
+			const item = await getTreeItem(driver, deploymentsSection, p.label);
+			const logs = await item?.getActionButton('Follow Logs');
+			await logs?.click();
+
+			await waitUntilTerminalHasText(driver, [p.message], 2_000, 30_000);
+		});
+
+		it(`stop running '${p.file}'`, async function () {
+			const item = await getTreeItem(driver, deploymentsSection, p.label);
+			const stop = await item?.getActionButton('Stop');
+			await stop?.click();
+			await waitUntilTerminalHasText(driver, ['Routes stopped', 'shutdown in'], 2_000, 30_000);
+		});
+
+		it(`check '${p.file}' is not running`, async function () {
+			const integrationStopped = await driver.wait(
+				async function () {
+					try {
+						const item = (await deploymentsSection?.findItem(p.label)) as TreeItem;
+						if (item) {
+							return false;
+						} else {
+							return true;
+						}
+					} catch (error) {
+						return true;
+					}
+				},
+				5_000,
+				`${p.label} is still found within ${await deploymentsSection?.getTitle()} view!`,
+			);
+			expect(integrationStopped).to.be.true;
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -189,6 +189,18 @@
         "title": "Refresh",
         "category": "Kaoto",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "kaoto.deployments.stop",
+        "title": "Stop",
+        "category": "Kaoto",
+        "icon": "$(circle-slash)"
+      },
+      {
+        "command": "kaoto.deployments.logs",
+        "title": "Follow Logs",
+        "category": "Kaoto",
+        "icon": "$(terminal)"
       }
     ],
     "keybindings": {
@@ -256,6 +268,14 @@
         {
           "command": "kaoto.integrations.delete",
           "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.stop",
+          "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.logs",
+          "when": "false"
         }
       ],
       "editor/title": [
@@ -319,6 +339,16 @@
           "command": "kaoto.camel.jbang.export",
           "when": "view == kaoto.integrations && viewItem == integration && !virtualWorkspace && kaoto.jbangAvailable",
           "group": "inline@3"
+        },
+        {
+          "command": "kaoto.deployments.stop",
+          "group": "inline@1",
+          "when": "view == kaoto.deployments && viewItem == parent-localhost"
+        },
+        {
+          "command": "kaoto.deployments.logs",
+          "group": "inline@2",
+          "when": "view == kaoto.deployments && viewItem == parent-localhost"
         }
       ]
     },

--- a/src/helpers/CamelJBang.ts
+++ b/src/helpers/CamelJBang.ts
@@ -98,6 +98,10 @@ export class CamelJBang {
 		);
 	}
 
+	public stop(name: string): ShellExecution {
+		return new ShellExecution(this.jbang, [...this.defaultJbangArgs, 'stop', name]);
+	}
+
 	private getKubernetesRunArguments(): string[] {
 		const kubernetesRunArgs = workspace.getConfiguration().get('kaoto.camelJBang.KubernetesRunArguments') as string[];
 		if (kubernetesRunArgs) {

--- a/src/tasks/CamelStopJBangTask.ts
+++ b/src/tasks/CamelStopJBangTask.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TaskRevealKind, TaskScope } from 'vscode';
+import { CamelJBangTask } from './CamelJBangTask';
+import { CamelJBang } from '../helpers/CamelJBang';
+
+export class CamelStopJBangTask extends CamelJBangTask {
+	constructor(name: string) {
+		super(TaskScope.Workspace, `Stop - ${name}`, new CamelJBang().stop(name), true, TaskRevealKind.Silent);
+	}
+}


### PR DESCRIPTION
adding `Stop` and `Follow Logs` buttons

<img width="314" alt="image" src="https://github.com/user-attachments/assets/9cf5a6e5-d99b-464f-8eae-9e1bc2fb0bd6" />


REPORTED upstream issue - https://issues.apache.org/jira/browse/CAMEL-21921