### PR TITLE
fix: allow to run integrations with a same name simultaneously

### DIFF
--- a/src/tasks/CamelRunJBangTask.ts
+++ b/src/tasks/CamelRunJBangTask.ts
@@ -20,7 +20,7 @@ import { basename, dirname } from 'path';
 
 export class CamelRunJBangTask extends CamelJBangTask {
 	private constructor(shellExecution: ShellExecution, filePath: string, port?: number) {
-		super(TaskScope.Workspace, `Running - ${basename(filePath)}`, shellExecution, undefined, undefined, port);
+		super(TaskScope.Workspace, `Running - ${basename(filePath)}::${port}`, shellExecution, undefined, undefined, port);
 
 		this.isBackground = true;
 	}

--- a/src/views/deploymentTreeItems/ParentItem.ts
+++ b/src/views/deploymentTreeItems/ParentItem.ts
@@ -16,10 +16,18 @@
 import { ThemeIcon, TreeItem, TreeItemCollapsibleState } from 'vscode';
 
 export class ParentItem extends TreeItem {
-	constructor(label: string, state: TreeItemCollapsibleState, contextValue: string, description?: string) {
+	private readonly _port: number;
+
+	constructor(label: string, state: TreeItemCollapsibleState, contextValue: string, port: number, description?: string, tooltip?: string) {
 		super(label, state);
 		this.iconPath = ThemeIcon.File;
 		this.contextValue = contextValue;
 		this.description = description;
+		this.tooltip = tooltip;
+		this._port = port;
+	}
+
+	public get port(): number {
+		return this._port;
 	}
 }


### PR DESCRIPTION
the current behavior is wrong because when you run same integration multiple times it will merge all routes under one integrations which is not right

BEFORE:
![image](https://github.com/user-attachments/assets/7e6f16af-b474-45f4-bce4-1632fdc1cc71)


---
after this change it behaves as `camel run` itself. Camel JBang allows you to run more times same integrations, each is run with unique PID. In VS Code instead of PID we are atm binding to a console port which is generated unique for each run through UI

AFTER:
![image](https://github.com/user-attachments/assets/a1e9f5cc-334b-481e-b684-3fea6fce3bc5)

also adding a path of an associated running integration file into hover
![image](https://github.com/user-attachments/assets/aafe68d4-63ba-4dd3-a844-495eda400d63)

