### PR TITLE
feat: add start/stop/resume/suspend buttons on a 'route' level in Deployments view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     - list XML files with route elements
 - Add `Deployments` view into Kaoto view container which displays all local running integrations
 - Add `Stop` and `Follow Logs` action buttons into Deployments view
+- Add `Start/Stop/Suspend/Resume` action button on `route` level within Deployments view
 
 # 2.4.0
 

--- a/it-tests/views/07_DeploymentsViewRoutesManipulaton.test.ts
+++ b/it-tests/views/07_DeploymentsViewRoutesManipulaton.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { join } from 'path';
+import { ActivityBar, after, before, EditorView, SideBarView, ViewControl, ViewItemAction, ViewSection, VSBrowser, WebDriver } from 'vscode-extension-tester';
+import { getTreeItem, killTerminal, waitUntilTerminalHasText } from '../Util';
+
+describe('Deployments View', function () {
+	this.timeout(600_000); // 10 minutes
+
+	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars', 'kaoto-view');
+
+	let driver: WebDriver;
+	let kaotoViewContainer: ViewControl | undefined;
+	let kaotoView: SideBarView | undefined;
+	let deploymentsSection: ViewSection | undefined;
+	let integrationsSection: ViewSection | undefined;
+
+	before(async function () {
+		driver = VSBrowser.instance.driver;
+		await VSBrowser.instance.openResources(WORKSPACE_FOLDER);
+		await VSBrowser.instance.waitForWorkbench();
+
+		kaotoViewContainer = await new ActivityBar().getViewControl('Kaoto');
+		kaotoView = await kaotoViewContainer?.openView();
+		deploymentsSection = await kaotoView?.getContent().getSection('Deployments');
+		integrationsSection = await kaotoView?.getContent().getSection('Integrations');
+	});
+
+	after(async function () {
+		await kaotoViewContainer?.closeView();
+		await new EditorView().closeAllEditors();
+		await killTerminal(); // kill sample2
+		await killTerminal(); // kill kaoto
+	});
+
+	const parameters = [
+		{ label: 'sample2', file: 'sample2.camel.yaml', message: 'Hello World', route: 'route-1151' },
+		{ label: 'kaoto', file: 'kaoto.camel.xml', message: 'Hello Camel', route: 'route-1643' },
+	];
+
+	const routeManipulations = [
+		{ state: 'Stopped', button: 'Stop', allowedButtons: ['Start'] },
+		{ state: 'Started', button: 'Start', allowedButtons: ['Suspend', 'Stop'] },
+		{ state: 'Suspended', button: 'Suspend', allowedButtons: ['Resume', 'Stop'] },
+		{ state: 'Started', button: 'Resume', allowedButtons: ['Suspend', 'Stop'] },
+	];
+
+	parameters.forEach((p) => {
+		describe(`Manipulate '${p.file}' routes`, function () {
+			it(`run '${p.file}' integration`, async function () {
+				const item = await getTreeItem(driver, integrationsSection, p.file);
+				const run = await item?.getActionButton('Run');
+				await run?.click();
+			});
+
+			it(`check '${p.file}' is running`, async function () {
+				const integration = await getTreeItem(driver, deploymentsSection, p.label, 30_000);
+				expect(integration).to.not.be.undefined;
+			});
+
+			routeManipulations.forEach((rm) => {
+				it(`click '${rm.button}' on ${p.route}`, async function () {
+					const route = await getTreeItem(driver, deploymentsSection, p.route);
+					expect(route).to.not.be.undefined;
+
+					const btn = await route?.getActionButton(rm.button);
+					await btn?.click();
+
+					await waitUntilTerminalHasText(driver, [`${rm.state} ${p.route}`], 1_000, 10_000);
+					await waitUntilRouteHasState(rm.state);
+
+					const buttons = (await route?.getActionButtons()) as ViewItemAction[];
+					const buttonsLabels = await Promise.all(buttons.map((btn) => btn.getLabel()));
+					expect(buttonsLabels).to.has.members(rm.allowedButtons);
+				});
+			});
+		});
+
+		async function waitUntilRouteHasState(state: string, interval = 500, timeout = 10_000): Promise<void> {
+			await driver.wait(
+				async function () {
+					try {
+						const route = await getTreeItem(driver, deploymentsSection, p.route);
+						const description = await route?.getDescription();
+						return description?.startsWith(state);
+					} catch (err) {
+						return false;
+					}
+				},
+				timeout,
+				`Timeout: route is not in an expected state - "${state}"`,
+				interval,
+			);
+		}
+	});
+});

--- a/package.json
+++ b/package.json
@@ -201,6 +201,30 @@
         "title": "Follow Logs",
         "category": "Kaoto",
         "icon": "$(terminal)"
+      },
+      {
+        "command": "kaoto.deployments.route.start",
+        "title": "Start",
+        "category": "Kaoto",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "kaoto.deployments.route.resume",
+        "title": "Resume",
+        "category": "Kaoto",
+        "icon": "$(debug-continue)"
+      },
+      {
+        "command": "kaoto.deployments.route.suspend",
+        "title": "Suspend",
+        "category": "Kaoto",
+        "icon": "$(debug-pause)"
+      },
+      {
+        "command": "kaoto.deployments.route.stop",
+        "title": "Stop",
+        "category": "Kaoto",
+        "icon": "$(debug-stop)"
       }
     ],
     "keybindings": {
@@ -276,6 +300,22 @@
         {
           "command": "kaoto.deployments.logs",
           "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.route.start",
+          "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.route.resume",
+          "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.route.suspend",
+          "when": "false"
+        },
+        {
+          "command": "kaoto.deployments.route.stop",
+          "when": "false"
         }
       ],
       "editor/title": [
@@ -349,6 +389,26 @@
           "command": "kaoto.deployments.logs",
           "group": "inline@2",
           "when": "view == kaoto.deployments && viewItem == parent-localhost"
+        },
+        {
+          "command": "kaoto.deployments.route.start",
+          "group": "inline@1",
+          "when": "view == kaoto.deployments && viewItem =~ /^.*startEnabled.*$/"
+        },
+        {
+          "command": "kaoto.deployments.route.resume",
+          "group": "inline@2",
+          "when": "view == kaoto.deployments && viewItem =~ /^.*resumeEnabled.*$/"
+        },
+        {
+          "command": "kaoto.deployments.route.suspend",
+          "group": "inline@3",
+          "when": "view == kaoto.deployments && viewItem =~ /^.*suspendEnabled.*$/"
+        },
+        {
+          "command": "kaoto.deployments.route.stop",
+          "group": "inline@4",
+          "when": "view == kaoto.deployments && viewItem =~ /^.*stopEnabled.*$/"
         }
       ]
     },

--- a/src/helpers/CamelJBang.ts
+++ b/src/helpers/CamelJBang.ts
@@ -102,6 +102,10 @@ export class CamelJBang {
 		return new ShellExecution(this.jbang, [...this.defaultJbangArgs, 'stop', name]);
 	}
 
+	public route(operation: RouteOperation, integration: string, routeId: string): ShellExecution {
+		return new ShellExecution(this.jbang, [...this.defaultJbangArgs, 'cmd', `${operation}-route`, integration, `--id=${routeId}`]);
+	}
+
 	private getKubernetesRunArguments(): string[] {
 		const kubernetesRunArgs = workspace.getConfiguration().get('kaoto.camelJBang.KubernetesRunArguments') as string[];
 		if (kubernetesRunArgs) {

--- a/src/tasks/CamelRouteOperationJBangTask.ts
+++ b/src/tasks/CamelRouteOperationJBangTask.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TaskRevealKind, TaskScope } from 'vscode';
+import { CamelJBangTask } from './CamelJBangTask';
+import { CamelJBang, RouteOperation } from '../helpers/CamelJBang';
+
+export class CamelRouteOperationJBangTask extends CamelJBangTask {
+	constructor(operation: RouteOperation, integration: string, route: string) {
+		super(
+			TaskScope.Workspace,
+			`${operation} - ${integration}: ${route}`,
+			new CamelJBang().route(operation, integration, route),
+			true,
+			TaskRevealKind.Silent,
+		);
+	}
+}

--- a/src/views/deploymentTreeItems/ChildItem.ts
+++ b/src/views/deploymentTreeItems/ChildItem.ts
@@ -16,9 +16,16 @@
 import { TreeItem, TreeItemCollapsibleState } from 'vscode';
 import { Route } from './Route';
 import { join } from 'path';
+import { ParentItem } from './ParentItem';
 
 export class ChildItem extends TreeItem {
-	constructor(label: string, state: TreeItemCollapsibleState, baseContext: string, route?: Route) {
+	constructor(
+		public readonly parentIntegration: ParentItem,
+		label: string,
+		state: TreeItemCollapsibleState,
+		baseContext: string,
+		route?: Route,
+	) {
 		super(label, state);
 
 		if (route) {
@@ -42,21 +49,21 @@ export class ChildItem extends TreeItem {
 		const visuals: Record<string, { icon: string; context: string }> = {
 			Started: {
 				icon: join(base, 'route-started.png'),
-				context: 'resumeDisabled suspendEnabled stopEnabled',
+				context: 'startDisabled resumeDisabled suspendEnabled stopEnabled',
 			},
 			Suspended: {
 				icon: join(base, 'route-suspended.png'),
-				context: 'resumeEnabled suspendDisabled stopEnabled',
+				context: 'startDisabled resumeEnabled suspendDisabled stopEnabled',
 			},
 			Stopped: {
 				icon: join(base, 'route-stopped.png'),
-				context: 'resumeEnabled suspendDisabled stopDisabled',
+				context: 'startEnabled resumeDisabled suspendDisabled stopDisabled',
 			},
 		};
 
 		const visual = visuals[state] || {
 			icon: join(base, 'route-default.png'),
-			context: 'resumeDisabled suspendDisabled stopDisabled',
+			context: 'startDisabled resumeDisabled suspendDisabled stopDisabled',
 		};
 
 		const description = state === 'Started' ? `${state} (${route.uptime})` : state;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/edd4d10f-0646-4fcf-8713-f2dabbf58c8b)
![image](https://github.com/user-attachments/assets/7907dd84-9971-4bd0-b251-cecdbc9e7fc7)
