### PR TITLE
feat(UI): Support VS Code ColorTheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Add `Deployments` view into Kaoto view container which displays all local running integrations
 - Add `Stop` and `Follow Logs` action buttons into Deployments view
 - Add `Start/Stop/Suspend/Resume` action button on `route` level within Deployments view
+- Support for Dark theme
+  - The Kaoto editor must closed/reopened to have theme applied
+  - The High Contrast Dark Theme is not supported
 
 # 2.4.0
 

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -1,5 +1,5 @@
 import { KaotoEditorChannelApi } from '@kaoto/kaoto';
-import { ISettingsModel, NodeLabelType, NodeToolbarTrigger, SettingsModel } from '@kaoto/kaoto/models';
+import { ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger, SettingsModel } from '@kaoto/kaoto/models';
 import { BackendProxy } from '@kie-tools-core/backend/dist/api';
 import { I18n } from '@kie-tools-core/i18n/dist/core';
 import { NotificationsChannelApi } from '@kie-tools-core/notifications/dist/api';
@@ -39,6 +39,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 		const catalogUrl = await vscode.workspace.getConfiguration('kaoto').get<Promise<string | null>>('catalog.url');
 		const nodeLabel = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeLabelType | null>>('nodeLabel');
 		const nodeToolbarTrigger = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeToolbarTrigger | null>>('nodeToolbarTrigger');
+		const colorScheme = this.getColorSchemeFromVSCode(vscode.window.activeColorTheme);
 		const enableDragAndDrop = await vscode.workspace
 			.getConfiguration('kaoto')
 			.get<Promise<ISettingsModel['experimentalFeatures']['enableDragAndDrop'] | null>>('enableDragAndDrop');
@@ -47,6 +48,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 			catalogUrl: catalogUrl ?? '',
 			nodeLabel: nodeLabel ?? NodeLabelType.Description,
 			nodeToolbarTrigger: nodeToolbarTrigger ?? NodeToolbarTrigger.onHover,
+			colorScheme,
 			experimentalFeatures: {
 				enableDragAndDrop: enableDragAndDrop ?? false,
 			},
@@ -203,6 +205,19 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 		} else {
 			const parentFolder = path.basename(path.dirname(this.currentEditedDocument.uri.fsPath));
 			return vscode.Uri.file(path.join(parentFolder, '.kaoto'));
+		}
+	}
+
+	private getColorSchemeFromVSCode(activeColorTheme: vscode.ColorTheme): ColorScheme {
+		switch (activeColorTheme.kind) {
+			case vscode.ColorThemeKind.Dark:
+			case vscode.ColorThemeKind.HighContrast:
+				return ColorScheme.Dark;
+			case vscode.ColorThemeKind.Light:
+			case vscode.ColorThemeKind.HighContrastLight:
+				return ColorScheme.Light;
+			default:
+				return ColorScheme.Light;
 		}
 	}
 }


### PR DESCRIPTION
### Context
In order to support setting the VS Code ColorTheme in Kaoto, we need to initialize the SettingsAdapter with the appropriate ColorSchema interpolation.

fix: https://github.com/KaotoIO/kaoto/issues/1543
requires: https://github.com/KaotoIO/kaoto/pull/2118