### PR TITLE
Fix deploy on OpenShift by default on restricted environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `Breaking:` Remove legacy support for Kaoto v1 file patterns (`*.kaoto.yaml`, `*.kaoto.yml`)
 - `Breaking:` Bump minimal VS Code version from 1.74.0 to 1.95.0
+- Potential breakage: when using a Camel Jbang version strictly prior to 4.11, the parameter `--disable-auto` must be removed from the setting `Kubernetes Run Parameters`
 - Upgrade to Kaoto 2.5.0-M4
 - Add Kaoto view container with initial Help & Feedback view
 - Improve toggle source code (open/close camel file in a side textual editor) using one button

--- a/package.json
+++ b/package.json
@@ -559,9 +559,10 @@
               "type": "string"
             },
             "additionalProperties": false,
-            "markdownDescription": "User defined arguments to be applied at every deploy (See [Camel JBang Kubernetes](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes.\n\n**Note**: Excluding `--camel-version` which is already being set in `#kaoto.camelVersion#`.",
+            "markdownDescription": "User defined arguments to be applied at every deploy (See [Camel JBang Kubernetes](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes.\n\n**Note**: Excluding `--camel-version` which is already being set in `#kaoto.camelVersion#`.\n\nBeware that `--disable-auto`, which is provided by default, requires Camel 4.11+.",
             "default": [
               "--cluster-type=openshift",
+              "--disable-auto",
               "--dev"
             ],
             "order": 3


### PR DESCRIPTION
Camel 4.11 has introduced `--disable-auto` parameter without checking if the cluster-type has been already set or not.
The automatic detection does not work if connected user cannot list resource "clusterversions" in API group "config.openshift.io" at the cluster scope.

Other better ways that could be done later on:
* remove automatically the --disable-auto when detecting that the version is prior to 4.11
* forget about 4.11 and improve handling these parameters in Camel JBang