### PR TITLE
chore: in a dev mode disable other extensions for an Extension Host vscode instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "args": ["${env:VSCODE_DISABLE_EXT}", "--extensionDevelopmentPath=${workspaceRoot}"],
       "outFiles": ["${workspaceRoot}/dist/**/*.js"],
       "preLaunchTask": "npm: watch",
       "env": {
@@ -18,7 +18,7 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionDevelopmentKind=web"],
+      "args": ["${env:VSCODE_DISABLE_EXT}", "--extensionDevelopmentPath=${workspaceRoot}", "--extensionDevelopmentKind=web"],
       "outFiles": ["${workspaceRoot}/dist/**/*.js"],
       "preLaunchTask": "npm: watch",
       "env": {


### PR DESCRIPTION
for those interested just add into your .bashrc/.zshrc line

`export VSCODE_DISABLE_EXT="--disable-extensions"`