### PR TITLE
Update contributing guide after structure change of Kaoto project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,6 @@ If you'd like to test latest Kaoto and not rely on a released version, follow th
 
 - In `kaoto` local clone folder:
   - `yarn`
-  - `yarn workspace @kaoto/camel-catalog run build`
   - `yarn workspace @kaoto/kaoto run build:lib`
 - Open VS Code on `vscode-kaoto` local clone folder
 - `yarn`


### PR DESCRIPTION
There is no more need to build the Catalog as it is an external dependency to Kaoto and no more a specific subworkspace.