### PR TITLE
Use newer online Catalog repository example

### DIFF
--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -7,7 +7,7 @@ describe('User Settings', function () {
 	this.timeout(240_000);
 
 	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars');
-	const CATALOG_URL = 'https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json';
+	const CATALOG_URL = 'https://raw.githubusercontent.com/KaotoIO/camel-catalog/refs/heads/main/catalog/index.json';
 	const CATALOG_SETTINGS_ID = 'kaoto.catalog.url';
 
 	let driver: WebDriver;

--- a/package.json
+++ b/package.json
@@ -438,7 +438,7 @@
           "kaoto.catalog.url": {
             "type": "string",
             "default": null,
-            "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/catalogs/main/catalogs/index.json`. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/kaoto/tree/main/packages/catalog-generator). It requires to reopen the Kaoto editors to be effective.",
+            "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/camel-catalog/refs/heads/main/catalog/index.json `. Documentation to generate your own set of catalog is available [here](https://github.com/KaotoIO/kaoto/tree/main/packages/catalog-generator). It requires to reopen the Kaoto editors to be effective.",
             "scope": "window",
             "order": 0
           },


### PR DESCRIPTION
the previous one was deprecated.

Note that the previous one is not compatible with current main version of Kaoto, see https://github.com/KaotoIO/kaoto/issues/2383