### PR TITLE
fix(sonar): use correct versions for GH actions steps - qemu, minikube

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,10 @@ jobs:
           distribution: "temurin"
           java-version: "21"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.6.0
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
       - name: Start Minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@v0.0.20
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         with:
           driver: docker

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -34,9 +34,9 @@ jobs:
           distribution: "temurin"
           java-version: "21"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.6.0
       - name: Start Minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@v0.0.20
         with:
           driver: docker
           addons: registry,registry-aliases


### PR DESCRIPTION
reported by sonar cloud code analysis