### PR TITLE
Enable drag-and-drop by default in Kaoto VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -519,7 +519,7 @@
         "properties": {
           "kaoto.enableDragAndDrop": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "Control whether to enable drag and drop feature. It requires to reopen the Kaoto editors to be effective.",
             "tags": [
               "experimental"


### PR DESCRIPTION
Enable drag-and-drop by default in Kaoto VSCode