### PR TITLE
Enable drag-and-drop by default in Kaoto VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -511,18 +511,13 @@
               "light",
               "dark"
             ]
-          }
-        }
-      },
-      {
-        "title": "Experimental",
-        "properties": {
+          },
           "kaoto.enableDragAndDrop": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "markdownDescription": "Control whether to enable drag and drop feature. It requires to reopen the Kaoto editors to be effective.",
             "tags": [
-              "experimental"
+              "preview"
             ]
           }
         }


### PR DESCRIPTION
Enable drag-and-drop by default in Kaoto VSCode.