### PR TITLE
fix: Camel JBang settings title in new vscode version is displayed wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Upgrade default Camel JBang version from 4.11.0 to 4.14.0
   - Note that due to regression [CAMEL-22131](https://issues.apache.org/jira/browse/CAMEL-22131) in Camel JBang 4.12, the project creation on Windows doesn't include the Maven wrapper with 4.12.x Camel Jbang version.
 - Drag-and-Drop functionality on Kaoto canvas now enabled by default
+- **BREAKING CHANGE**: Camel JBang user settings have now different IDs, so for those who are using local workspace VS Code settings they need to be updated to new values
 
 # 2.6.0
 

--- a/it-tests/vscode-settings-minikube.json
+++ b/it-tests/vscode-settings-minikube.json
@@ -1,5 +1,5 @@
 {
-  "kaoto.camelJBang.KubernetesRunArguments": [
+  "kaoto.camelJbang.kubernetesRunArguments": [
     "--cluster-type=minikube",
     "--dev",
     "--verbose",

--- a/package.json
+++ b/package.json
@@ -444,7 +444,7 @@
           },
           "kaoto.camelVersion": {
             "type": "string",
-            "markdownDescription": "Camel version used for internal Camel JBang CLI commands execution. As default Camel Version is used `#kaoto.camelJBang.Version#`.",
+            "markdownDescription": "Camel version used for internal Camel JBang CLI commands execution. As default Camel Version is used `#kaoto.camelJbang.version#`.",
             "order": 1
           },
           "kaoto.deployments.refresh.interval": {
@@ -525,13 +525,13 @@
       {
         "title": "JBang",
         "properties": {
-          "kaoto.camelJBang.Version": {
+          "kaoto.camelJbang.version": {
             "type": "string",
             "markdownDescription": "Apache [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) version used for an internal Camel JBang CLI calls. Requirements can differ between versions.\n\nIt is recommended to use `default` version to ensure all extension features works properly.",
             "default": "4.14.0",
             "order": 0
           },
-          "kaoto.camelJBang.RunArguments": {
+          "kaoto.camelJbang.runArguments": {
             "type": "array",
             "uniqueItems": true,
             "items": {
@@ -547,19 +547,19 @@
             ],
             "order": 1
           },
-          "kaoto.camelJBang.redHatMavenRepository": {
+          "kaoto.camelJbang.redHatMavenRepository": {
             "type": "string",
             "markdownDescription": "Define Red Hat Maven Repository, which is used automatically in case the `#kaoto.camelVersion#` uses Red Hat productized Camel version (e.g. `4.8.0.redhat-00017`).",
             "default": "https://maven.repository.redhat.com/ga/",
             "order": 2
           },
-          "kaoto.camelJBang.redHatMavenRepository.global": {
+          "kaoto.camelJbang.redHatMavenRepository.global": {
             "type": "boolean",
             "markdownDescription": "The `#repos` placeholder will be added by default to use also repositories defined in global Camel JBang configuration file.\n\n**Note**: The placeholder is available for versions `3.20.7/3.21` onwards.",
             "default": true,
             "order": 3
           },
-          "kaoto.camelJBang.KubernetesRunArguments": {
+          "kaoto.camelJbang.kubernetesRunArguments": {
             "type": "array",
             "uniqueItems": true,
             "items": {

--- a/src/helpers/CamelJBang.ts
+++ b/src/helpers/CamelJBang.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 import { RelativePattern, ShellExecution, ShellExecutionOptions, Uri, workspace, window } from 'vscode';
-import { arePathsEqual } from './helpers';
+import {
+	arePathsEqual,
+	KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_CAMEL_JBANG_VERSION_SETTING_ID,
+} from './helpers';
 import { dirname, join } from 'path';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
@@ -39,7 +46,7 @@ export class CamelJBang {
 	private readonly defaultJbangArgs: string[];
 
 	constructor(private readonly jbang: string = 'jbang') {
-		this.camelJBangVersion = workspace.getConfiguration().get('kaoto.camelJBang.Version') as string;
+		this.camelJBangVersion = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_VERSION_SETTING_ID) as string;
 		this.defaultJbangArgs = [`'-Dcamel.jbang.version=${this.camelJBangVersion}'`, 'camel@apache/camel'];
 	}
 
@@ -140,7 +147,7 @@ export class CamelJBang {
 				if (satisfies(this.camelJBangVersion, '>=4.13')) {
 					camelJbangVersionToUse = this.camelJBangVersion;
 				} else {
-					const defaultValue = workspace.getConfiguration().inspect('kaoto.camelJBang.Version')?.defaultValue as string;
+					const defaultValue = workspace.getConfiguration().inspect(KAOTO_CAMEL_JBANG_VERSION_SETTING_ID)?.defaultValue as string;
 					camelJbangVersionToUse = defaultValue ?? '4.13.0';
 				}
 				const response: string = execSync(
@@ -173,7 +180,7 @@ export class CamelJBang {
 	}
 
 	private getKubernetesRunArguments(): string[] {
-		const kubernetesRunArgs = workspace.getConfiguration().get('kaoto.camelJBang.KubernetesRunArguments') as string[];
+		const kubernetesRunArgs = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID) as string[];
 		if (kubernetesRunArgs) {
 			return kubernetesRunArgs;
 		} else {
@@ -182,7 +189,7 @@ export class CamelJBang {
 	}
 
 	private async getRunArguments(filePath: string): Promise<string[]> {
-		const runArgs = workspace.getConfiguration().get('kaoto.camelJBang.RunArguments') as string[];
+		const runArgs = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_RUN_ARGUMENTS_SETTING_ID) as string[];
 		if (runArgs) {
 			return await this.handleMissingXslFiles(filePath, runArgs);
 		} else {
@@ -201,7 +208,7 @@ export class CamelJBang {
 
 	private getRedHatMavenRepository(): string {
 		if (this.getCamelVersion().includes('redhat')) {
-			const url = workspace.getConfiguration().get('kaoto.camelJBang.redHatMavenRepository') as string;
+			const url = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_SETTING_ID) as string;
 			const reposPlaceholder = this.getCamelGlobalRepos();
 			return url ? `--repos=${reposPlaceholder}${url}` : '';
 		} else {
@@ -210,7 +217,7 @@ export class CamelJBang {
 	}
 
 	private getCamelGlobalRepos(): string {
-		const globalRepos = workspace.getConfiguration().get('kaoto.camelJBang.redHatMavenRepository.global') as boolean;
+		const globalRepos = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID) as boolean;
 		if (globalRepos) {
 			return '#repos,';
 		} else {

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -25,6 +25,16 @@ import { normalize } from 'path';
 
 export const KAOTO_FILE_PATH_GLOB: string = '**/*.{yml,yaml,xml}';
 
+export const KAOTO_CAMEL_JBANG_VERSION_SETTING_ID: string = 'kaoto.camelJbang.version';
+
+export const KAOTO_CAMEL_JBANG_RUN_ARGUMENTS_SETTING_ID: string = 'kaoto.camelJbang.runArguments';
+
+export const KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_SETTING_ID: string = 'kaoto.camelJbang.redHatMavenRepository';
+
+export const KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID: string = 'kaoto.camelJbang.redHatMavenRepository.global';
+
+export const KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID: string = 'kaoto.camelJbang.kubernetesRunArguments';
+
 export async function verifyJBangExists(): Promise<boolean> {
 	const execPromise = promisify(exec);
 	return await window.withProgress<boolean>(


### PR DESCRIPTION
BEFORE:
<img width="269" height="39" alt="Screenshot 2025-09-02 at 13 07 26" src="https://github.com/user-attachments/assets/9f9957a9-2514-46a5-af45-1d2a599590f9" />

AFTER:
<img width="226" height="29" alt="Screenshot 2025-09-02 at 13 07 30" src="https://github.com/user-attachments/assets/79c40f0f-0cc8-49a9-a5da-1ae93d7bfbc7" />

unfortunately there is no way to have it as before "JBang", after changes in latest vscode versions it displays this weird space 😞 
