### PR TITLE
feat: show what's new page on a first start up after new extension version installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.8.0
 
 - Use Node 22 instead of Node 20
+- show `What's New` release page after each extension upgrade (only for first startup)
 
 # 2.7.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,6 @@ It is launching UI tests. Beware that it can take several minutes to start. Stay
 
 - To have everything working properly, we need to double check that versions of package list below is up to date with [kaoto dependencies](https://github.com/KaotoIO/kaoto/blob/main/packages/ui/package.json#L44) versions of same packages
 - Inside `package.json`
-
   - Check to have the version of the VS Code extension similar to the version of Kaoto
   - :exclamation: update `dependencies` section, update`"@kaoto/kaoto": "<version>"` to next version of publish Kaoto UI package
   - :warning: update `resolutions` and `dependencies` section
@@ -174,6 +173,7 @@ It is launching UI tests. Beware that it can take several minutes to start. Stay
     - Push changes in a Pull Request
     - Wait for Pull Request to be merged
 - Check that the version of VS Code extension aligns as much as possible with version of embedded Kaoto
+- Check `What's New` release page is up to date (`/resources/whats-new/<release-version>`)
 - Check build is working fine on [GitHub Actions](https://github.com/KaotoIO/vscode-kaoto/actions) and [Jenkins CI](https://jenkins-csb-fusetools-qe-master.dno.corp.redhat.com/view/VS%20Code%20-%20release/job/vscode/job/eng/job/vscode-kaoto-release/)
 - Check that someone listed as _submitter_ in Jenkinsfile is available
 - Create a tag
@@ -188,5 +188,7 @@ It is launching UI tests. Beware that it can take several minutes to start. Stay
 - Keep build forever on Jenkins CI for later reference and edit build information to indicate the version
 - Prepare next iteration:
   - Update version in `package.json`
+  - Add new version section into `CHANGELOG.md`
+  - Add new What's new page in `resources/whats-new/<next-iteration-version>`
   - Push changes in a Pull Request
   - Follow Pull Request until it is approved/merged

--- a/resources/whats-new/2.8/index.md
+++ b/resources/whats-new/2.8/index.md
@@ -1,0 +1,7 @@
+# Kaoto 2.8 released
+
+We are happy to announce that new version of extension was released!
+
+## Key highlights of this release
+
+- ...

--- a/src/extension/WhatsNewPanel.ts
+++ b/src/extension/WhatsNewPanel.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as vscode from 'vscode';
+import { KaotoOutputChannel } from './KaotoOutputChannel';
+
+export class WhatsNewPanel {
+	private static currentPanel: vscode.WebviewPanel | undefined;
+
+	public static async show(context: vscode.ExtensionContext, version: string): Promise<void> {
+		const folderVersion = this.extractMajorMinor(version);
+		const whatsNewFolder = vscode.Uri.joinPath(context.extensionUri, 'resources', 'whats-new', folderVersion);
+		const indexMdUri = vscode.Uri.joinPath(whatsNewFolder, 'index.md');
+
+		try {
+			const bytes = await vscode.workspace.fs.readFile(indexMdUri);
+			const markdown = new TextDecoder('utf-8').decode(bytes);
+
+			const htmlContent: string = (await vscode.commands.executeCommand('markdown.api.render', markdown)) as string;
+
+			const panel = vscode.window.createWebviewPanel('kaoto.whatsNew', `What's New in Kaoto ${folderVersion}`, {
+				viewColumn: vscode.ViewColumn.Active,
+				preserveFocus: false,
+			});
+
+			panel.webview.html = this.getHtmlForWebview(htmlContent, folderVersion);
+
+			panel.onDidDispose(() => {
+				if (WhatsNewPanel.currentPanel === panel) {
+					WhatsNewPanel.currentPanel = undefined;
+				}
+			});
+
+			WhatsNewPanel.currentPanel = panel;
+		} catch (err) {
+			KaotoOutputChannel.logWarning(`What's New content is not available for this version. ${String(err)}`);
+		}
+	}
+
+	private static extractMajorMinor(version: string): string {
+		const regExp = new RegExp(/(\d+)\.(\d+)/);
+		const match = regExp.exec(version);
+		if (match) {
+			return `${match[1]}.${match[2]}`;
+		}
+		return version;
+	}
+
+	private static getHtmlForWebview(htmlBody: string, folderVersion: string): string {
+		const blogUrl = `https://kaoto.io/blog/kaoto-${folderVersion}-release/`;
+
+		return [
+			'<!DOCTYPE html>',
+			'<html lang="en">',
+			'<head>',
+			'<meta charset="UTF-8">',
+			`<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
+			'<style>', // Minimal readable styling
+			'body { font-family: var(--vscode-font-family); padding: 0 1.2rem 2rem; color: var(--vscode-foreground); }',
+			'h1, h2, h3 { color: var(--vscode-foreground); }',
+			'.logo { max-width: 50%; height: auto; margin-top: 1rem; margin-bottom: 1rem; }', // Kaoto logo
+			'a { color: var(--vscode-textLink-foreground); }',
+			'ul { padding-left: 1.2rem; }',
+			'.blog-note { margin: 1rem 0 1.2rem; padding: 0.8rem 1rem; border-left: 3px solid var(--vscode-textLink-foreground); }',
+			'</style>',
+			'</head>',
+			'<body>',
+			`<img class="logo" src="https://raw.githubusercontent.com/KaotoIO/vscode-kaoto/57103641d7c3f2d7ac6be9433d1d360d9732a926/images/logo-kaoto.png" alt="Kaoto">`,
+			htmlBody,
+			`<div class="blog-note">Read the full blog post on our official site - <a href="${blogUrl}" target="_blank" rel="noreferrer noopener">${blogUrl}</a></div>`,
+			'</body>',
+			'</html>',
+		].join('\n');
+	}
+}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -120,6 +120,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	 */
 	await contextHandler.showRecommendedExtensions();
 
+	/*
+	 * Show What's New on first start for this version
+	 */
+	await contextHandler.showWhatsNewIfNeeded();
+
 	KaotoOutputChannel.logInfo('Kaoto extension is successfully setup.');
 }
 

--- a/src/extension/extensionWeb.ts
+++ b/src/extension/extensionWeb.ts
@@ -73,6 +73,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	 */
 	contextHandler.registerHelpAndFeedbackView();
 
+	/*
+	 * Show What's New on first start for this version
+	 */
+	await contextHandler.showWhatsNewIfNeeded();
+
 	KaotoOutputChannel.logInfo('Kaoto extension is successfully setup.');
 }
 


### PR DESCRIPTION
- make news more visible and highlight changes in Kaoto UI and Kaoto extension to users more easily

<img width="1433" height="1688" alt="Screenshot 2025-09-08 at 16 12 46" src="https://github.com/user-attachments/assets/16afcb6c-a4aa-4ed6-a7ab-801981a32df4" />
