### PR TITLE
feat(KIE): Override KIE KogitoEditorEnvelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -681,6 +681,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.10",
     "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.1",
     "@types/vscode": "^1.100.0",
     "@types/wait-on": "^5.3.4",
     "@typescript-eslint/eslint-plugin": "^8.44.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@kie-tools-core/vscode-extension": "10.0.0",
     "@patternfly/patternfly": "6.3.1",
     "@patternfly/react-code-editor": "6.3.1",
-    "@patternfly/react-core": "6.3.1",
+    "@patternfly/react-core": "6.3.1-prerelease.13",
     "@patternfly/react-icons": "6.3.1",
     "@patternfly/react-table": "6.3.1",
     "@patternfly/react-topology": "6.3.0",

--- a/src/webview/KaotoEditorEnvelopeApp.ts
+++ b/src/webview/KaotoEditorEnvelopeApp.ts
@@ -1,12 +1,31 @@
-import { NoOpKeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope';
-import * as EditorEnvelope from '@kie-tools-core/editor/dist/envelope';
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { KaotoEditorFactory } from '@kaoto/kaoto';
+import { KogitoEditorEnvelopeApiImpl } from '@kie-tools-core/editor/dist/envelope';
+import { NoOpKeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope';
+import { initCustom } from './envelope-overrides/envelope-init';
 
 declare const acquireVsCodeApi: any;
 
-EditorEnvelope.init({
+void initCustom({
 	container: document.getElementById('envelope-app')!,
 	bus: acquireVsCodeApi(),
-	editorFactory: new KaotoEditorFactory(),
+	apiImplFactory: {
+		create: (createArgs) => new KogitoEditorEnvelopeApiImpl(createArgs, new KaotoEditorFactory()),
+	},
 	keyboardShortcutsService: new NoOpKeyboardShortcutsService(),
 });

--- a/src/webview/envelope-overrides/KogitoEditorEnvelope.tsx
+++ b/src/webview/envelope-overrides/KogitoEditorEnvelope.tsx
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This class is a copy of https://github.com/apache/incubator-kie-tools/blob/main/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
+ * meant to override how React apps are bootstrapped.
+ */
+import { Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
+import { EditorEnvelopeViewApi } from '@kie-tools-core/editor/dist/envelope';
+import { Envelope, EnvelopeApiFactory } from '@kie-tools-core/envelope';
+import { ApiDefinition } from '@kie-tools-core/envelope-bus/dist/api';
+import { I18nService } from '@kie-tools-core/i18n/dist/envelope';
+import { KeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService';
+import { getOperatingSystem } from '@kie-tools-core/operating-system';
+import { RefObject } from 'react';
+import { createRoot } from 'react-dom/client';
+import { KogitoEditorEnvelopeApp } from './KogitoEditorEnvelopeApp';
+
+export class KogitoEditorEnvelope<
+	E extends Editor,
+	EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
+	ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
+> {
+	constructor(
+		private readonly kogitoEditorEnvelopeApiFactory: EnvelopeApiFactory<
+			EnvelopeApi,
+			ChannelApi,
+			EditorEnvelopeViewApi<E>,
+			KogitoEditorEnvelopeContextType<ChannelApi>
+		>,
+		private readonly keyboardShortcutsService: KeyboardShortcutsService,
+		private readonly i18nService: I18nService,
+		private readonly envelope: Envelope<EnvelopeApi, ChannelApi, EditorEnvelopeViewApi<E>, KogitoEditorEnvelopeContextType<ChannelApi>>,
+		private readonly context: KogitoEditorEnvelopeContextType<ChannelApi> = {
+			channelApi: envelope.channelApi,
+			operatingSystem: getOperatingSystem(),
+			services: {
+				keyboardShortcuts: keyboardShortcutsService,
+				i18n: i18nService,
+			},
+			supportedThemes: [],
+		},
+	) {}
+
+	public start(container: HTMLElement) {
+		return this.envelope.start(() => this.renderView(container), this.context, this.kogitoEditorEnvelopeApiFactory);
+	}
+
+	private renderView(container: HTMLElement): Promise<() => EditorEnvelopeViewApi<E>> {
+		return new Promise<() => EditorEnvelopeViewApi<E>>((resolve) => {
+			const callback = (ref: RefObject<EditorEnvelopeViewApi<E>>) => {
+				resolve(() => ref.current!);
+			};
+
+			setTimeout(() => {
+				const root = createRoot(container);
+				root.render(
+					<KogitoEditorEnvelopeApp callback={callback} context={this.context} showKeyBindingsOverlay={this.keyboardShortcutsService.isEnabled()} />,
+				);
+			}, 0);
+		});
+	}
+}

--- a/src/webview/envelope-overrides/KogitoEditorEnvelopeApp.tsx
+++ b/src/webview/envelope-overrides/KogitoEditorEnvelopeApp.tsx
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This class is a copy of https://github.com/apache/incubator-kie-tools/blob/main/packages/editor/src/envelope/KogitoEditorEnvelope.tsx
+ * meant to override how React apps are bootstrapped.
+ */
+import { Editor, KogitoEditorEnvelopeContext, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
+import { EditorEnvelopeView, EditorEnvelopeViewApi } from '@kie-tools-core/editor/dist/envelope/EditorEnvelopeView';
+import { EditorEnvelopeI18nContext, editorEnvelopeI18nDefaults, editorEnvelopeI18nDictionaries } from '@kie-tools-core/editor/dist/envelope/i18n';
+import { I18nDictionariesProvider } from '@kie-tools-core/i18n/dist/react-components';
+import { createRef, FunctionComponent, RefObject, useCallback } from 'react';
+
+interface KogitoEditorEnvelopeAppProps {
+	callback: (ref: RefObject<EditorEnvelopeViewApi<Editor>>) => void;
+	context: KogitoEditorEnvelopeContextType<any>;
+	showKeyBindingsOverlay: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const KogitoEditorEnvelopeApp: FunctionComponent<KogitoEditorEnvelopeAppProps> = ({
+	callback,
+	context,
+	showKeyBindingsOverlay,
+}: KogitoEditorEnvelopeAppProps) => {
+	const editorEnvelopeViewRef = createRef<EditorEnvelopeViewApi<Editor>>();
+
+	const onMountFn = useCallback(() => {
+		callback(editorEnvelopeViewRef);
+	}, []);
+
+	return (
+		<div ref={onMountFn}>
+			<KogitoEditorEnvelopeContext.Provider value={context}>
+				<I18nDictionariesProvider
+					defaults={editorEnvelopeI18nDefaults}
+					dictionaries={editorEnvelopeI18nDictionaries}
+					ctx={EditorEnvelopeI18nContext}
+					initialLocale={navigator.language}
+				>
+					<EditorEnvelopeI18nContext.Consumer>
+						{({ setLocale }) => (
+							<EditorEnvelopeView ref={editorEnvelopeViewRef} setLocale={setLocale} showKeyBindingsOverlay={showKeyBindingsOverlay} />
+						)}
+					</EditorEnvelopeI18nContext.Consumer>
+				</I18nDictionariesProvider>
+			</KogitoEditorEnvelopeContext.Provider>
+		</div>
+	);
+};

--- a/src/webview/envelope-overrides/envelope-init.ts
+++ b/src/webview/envelope-overrides/envelope-init.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Editor, KogitoEditorChannelApi, KogitoEditorEnvelopeApi, KogitoEditorEnvelopeContextType } from '@kie-tools-core/editor/dist/api';
+import { EditorEnvelopeViewApi } from '@kie-tools-core/editor/dist/envelope';
+import { Envelope, EnvelopeApiFactory } from '@kie-tools-core/envelope';
+import { ApiDefinition, EnvelopeBus } from '@kie-tools-core/envelope-bus/dist/api';
+import { I18nService } from '@kie-tools-core/i18n/dist/envelope';
+import { DefaultKeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope';
+import { KeyboardShortcutsService } from '@kie-tools-core/keyboard-shortcuts/dist/envelope/KeyboardShortcutsService';
+import { getOperatingSystem } from '@kie-tools-core/operating-system';
+import { KogitoEditorEnvelope } from './KogitoEditorEnvelope';
+
+export function initCustom<
+	E extends Editor,
+	EnvelopeApi extends KogitoEditorEnvelopeApi & ApiDefinition<EnvelopeApi>,
+	ChannelApi extends KogitoEditorChannelApi & ApiDefinition<ChannelApi>,
+>(args: {
+	container: HTMLElement;
+	bus: EnvelopeBus;
+	apiImplFactory: EnvelopeApiFactory<EnvelopeApi, ChannelApi, EditorEnvelopeViewApi<E>, KogitoEditorEnvelopeContextType<ChannelApi>>;
+	keyboardShortcutsService?: KeyboardShortcutsService;
+}) {
+	const keyboardShortcutsService = args.keyboardShortcutsService ?? new DefaultKeyboardShortcutsService({ os: getOperatingSystem() });
+	const i18nService = new I18nService();
+	const envelope = new Envelope<EnvelopeApi, ChannelApi, EditorEnvelopeViewApi<E>, KogitoEditorEnvelopeContextType<ChannelApi>>(args.bus);
+
+	return new KogitoEditorEnvelope(args.apiImplFactory, keyboardShortcutsService, i18nService, envelope).start(args.container);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,6 +2183,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:18.3.1":
+  version: 18.3.1
+  resolution: "@types/react-dom@npm:18.3.1"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10/33f9ba79b26641ddf00a8699c30066b7e3573ab254e97475bf08f82fab83a6d3ce8d4ebad86afeb49bb8df3374390a9ba93125cece33badc4b3e8f7eac3c84d8
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:*":
   version: 18.3.3
   resolution: "@types/react@npm:18.3.3"
@@ -12845,6 +12854,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     "@types/mocha": "npm:^10.0.10"
     "@types/react": "npm:18.3.1"
+    "@types/react-dom": "npm:18.3.1"
     "@types/vscode": "npm:^1.100.0"
     "@types/wait-on": "npm:^5.3.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.44.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,20 +1043,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:6.3.1, @patternfly/react-core@npm:^6.3.1":
-  version: 6.3.1
-  resolution: "@patternfly/react-core@npm:6.3.1"
+"@patternfly/react-core@npm:6.3.1-prerelease.13":
+  version: 6.3.1-prerelease.13
+  resolution: "@patternfly/react-core@npm:6.3.1-prerelease.13"
   dependencies:
-    "@patternfly/react-icons": "npm:^6.3.1"
-    "@patternfly/react-styles": "npm:^6.3.1"
-    "@patternfly/react-tokens": "npm:^6.3.1"
+    "@patternfly/react-icons": "npm:^6.3.1-prerelease.0"
+    "@patternfly/react-styles": "npm:^6.3.1-prerelease.0"
+    "@patternfly/react-tokens": "npm:^6.3.1-prerelease.0"
     focus-trap: "npm:7.6.4"
     react-dropzone: "npm:^14.3.5"
     tslib: "npm:^2.8.1"
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10/a1198b5863a6a2bf28b9e8b70f6c484a983b2ea5af066bba2581b6f4787e68b92d998078dbdbd3110b9c3ecee3370f41447e368324cf1cee930b3bb8214cb17e
+  checksum: 10/916dd7695c1fce5a5664b4cab2c66dfa51ef9ce59f7d38c9aaf7ac98c1fa60b86a82aaa53453f6687124dc2a4bfcc816d86622a6c6882d9ca322dcd4aaad9c93
   languageName: node
   linkType: hard
 
@@ -1095,7 +1095,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:6.3.1, @patternfly/react-icons@npm:^6.3.1":
+"@patternfly/react-core@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@patternfly/react-core@npm:6.3.1"
+  dependencies:
+    "@patternfly/react-icons": "npm:^6.3.1"
+    "@patternfly/react-styles": "npm:^6.3.1"
+    "@patternfly/react-tokens": "npm:^6.3.1"
+    focus-trap: "npm:7.6.4"
+    react-dropzone: "npm:^14.3.5"
+    tslib: "npm:^2.8.1"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/a1198b5863a6a2bf28b9e8b70f6c484a983b2ea5af066bba2581b6f4787e68b92d998078dbdbd3110b9c3ecee3370f41447e368324cf1cee930b3bb8214cb17e
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-icons@npm:6.3.1, @patternfly/react-icons@npm:^6.3.1, @patternfly/react-icons@npm:^6.3.1-prerelease.0":
   version: 6.3.1
   resolution: "@patternfly/react-icons@npm:6.3.1"
   peerDependencies:
@@ -1139,7 +1156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^6.3.1":
+"@patternfly/react-styles@npm:^6.3.1, @patternfly/react-styles@npm:^6.3.1-prerelease.0":
   version: 6.3.1
   resolution: "@patternfly/react-styles@npm:6.3.1"
   checksum: 10/a7669833906a8fe373bf9b37853aeb5ba8479a161b7885a4520ffd054c5d0cb6d3058d96d6f38b41dcf48c1b142475ae38f6a9bc777afb0305947fd0bd690d78
@@ -1177,7 +1194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-tokens@npm:^6.3.1":
+"@patternfly/react-tokens@npm:^6.3.1, @patternfly/react-tokens@npm:^6.3.1-prerelease.0":
   version: 6.3.1
   resolution: "@patternfly/react-tokens@npm:6.3.1"
   checksum: 10/5dfc1b6b172b23a86c4d1821c556daaeb26db44a0f3c6c175e263a7b22514d3402187f579de1e4cd5571eebd5d96cf0cf3d8c070e40fbdc93f1f0bb53b61939b
@@ -12817,7 +12834,7 @@ __metadata:
     "@kie-tools-core/vscode-extension": "npm:10.0.0"
     "@patternfly/patternfly": "npm:6.3.1"
     "@patternfly/react-code-editor": "npm:6.3.1"
-    "@patternfly/react-core": "npm:6.3.1"
+    "@patternfly/react-core": "npm:6.3.1-prerelease.13"
     "@patternfly/react-icons": "npm:6.3.1"
     "@patternfly/react-table": "npm:6.3.1"
     "@patternfly/react-topology": "npm:6.3.0"


### PR DESCRIPTION
### Context
Currently, the `kie-tools` repository uses `React 17` which has a particular way to be bootstrapped, referenced now as `Legacy Root API`.

Kaoto UI uses `React 18` which uses a different bootstrap API called `New Root API`, and while it's backward compatible, the runtime behavior is the one from `React 17`.

This causes many subtles differences between how Kaoto behaves as a web deployment vs how it behaves as a VS Code target.

Updating `React` in the [`kie-tools`](https://github.com/apache/incubator-kie-tools) it's not viable at the moment, see: https://github.com/apache/incubator-kie-issues/issues/118

### Changes
This commit copies the `KogitoEditorEnvelope.tsx` and the `index.ts` file into this repository so we can override how React is bootstrapped to use the `New Root API`.

### Notes
* https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis
* https://github.com/reactwg/react-18/discussions/5

cc @fantonangeli

fix: https://github.com/KaotoIO/vscode-kaoto/issues/1074