### PR TITLE
chore: revert minimal VS Code requirement back to v1.100.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.8.0
 
-- Use Node 22 instead of Node 20, minimal version of VS Code is now 1.101
+- Use Node 22 instead of Node 20
 
 # 2.7.0
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto"><img src="https://img.shields.io/visual-studio-marketplace/v/redhat.vscode-kaoto?style=for-the-badge&color=yellow" alt="Marketplace Version"/></a>
   <a href="https://github.com/KaotoIO/kaoto/releases"><img alt="Kaoto UI version" src="https://img.shields.io/badge/Kaoto_UI-2.7.1-yellow?style=for-the-badge&logo=npm"></a>
-  <img src="https://img.shields.io/badge/VS%20Code-1.101+-yellow?style=for-the-badge" alt="Visual Studio Code Support"/>
+  <img src="https://img.shields.io/badge/VS%20Code-1.100+-yellow?style=for-the-badge" alt="Visual Studio Code Support"/>
   <br/>
   <a href="https://github.com/KaotoIO/vscode-kaoto/blob/main/LICENSE"><img src="https://img.shields.io/github/license/KaotoIO/vscode-kaoto?color=yellow&style=for-the-badge&logo=apache" alt="License"/></a>
   <a href="https://camel.zulipchat.com/#narrow/stream/258729-camel-tooling"><img src="https://img.shields.io/badge/zulip-join_chat-brightgreen?color=yellow&style=for-the-badge&logo=zulip&logoColor=white" alt="Zulip"/></a></br>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "main": "./dist/extension/extension.js",
   "browser": "./dist/extension/extensionWeb.js",
   "engines": {
-    "vscode": "^1.101.0"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Other"
@@ -681,7 +681,7 @@
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.10",
     "@types/react": "18.3.1",
-    "@types/vscode": "^1.101.0",
+    "@types/vscode": "^1.100.0",
     "@types/wait-on": "^5.3.4",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,7 +2224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:^1.101.0":
+"@types/vscode@npm:^1.100.0":
   version: 1.104.0
   resolution: "@types/vscode@npm:1.104.0"
   checksum: 10/d421aec4246bc24a40e8b6f111badae458369e2cd409bc6e1a1c7e4014029432751b84d59624f0622fd26a42f097c4b53cf51923e476e1f23fdea7e00c7191ef
@@ -12835,7 +12835,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     "@types/mocha": "npm:^10.0.10"
     "@types/react": "npm:18.3.1"
-    "@types/vscode": "npm:^1.101.0"
+    "@types/vscode": "npm:^1.100.0"
     "@types/wait-on": "npm:^5.3.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.44.0"
     "@typescript-eslint/parser": "npm:^8.44.0"


### PR DESCRIPTION
Red Hat Developer SandBox is running with VS Code 1.100.3 so we cannot bump minimal version to support also that environment