### PR TITLE
Stabilize MavenDependencyUpdateTest

### DIFF
--- a/it-tests/MavenDependencyUpdate.test.ts
+++ b/it-tests/MavenDependencyUpdate.test.ts
@@ -64,7 +64,7 @@ describe('Maven dependency update pom.xml on save test', function () {
 			false,
 			'Updating Camel dependencies in pom.xml',
 			'Timeout waiting for the notification of the Maven dependency update',
-			25_000,
+			40_000,
 			1_000,
 		);
 	});


### PR DESCRIPTION
based on https://github.com/KaotoIO/vscode-kaoto/pull/1089 (to be merged first)

the error was:
```
   1) Maven dependency update pom.xml on save test
       should invoke the update of the Maven dependencies when a step is
added:
     StaleElementReferenceError: stale element reference: stale element
not found in the current frame
  (Session info: chrome=134.0.6998.205)
      at Object.throwDecodedError
(node_modules/selenium-webdriver/lib/error.js:523:15)
      at parseHttpResponse
(node_modules/selenium-webdriver/lib/http.js:524:13)
      at Executor.execute
(node_modules/selenium-webdriver/lib/http.js:456:28)
      at process.processTicksAndRejections
(node:internal/process/task_queues:105:5)
      at async Driver.execute
(node_modules/selenium-webdriver/lib/webdriver.js:745:17)
      at async CenterNotification.getMessage
(node_modules/@redhat-developer/page-objects/out/components/workbench/Notification.js:43:23)
      at async /Users/runner/work/vscode-kaoto/vscode-kaoto/out/MavenDependencyUpdate.test.js:80:90
      at async Promise.all (index 0)
      at async /Users/runner/work/vscode-kaoto/vscode-kaoto/out/MavenDependencyUpdate.test.js:80:30
```