### PR TITLE
Allow to update dependencies on not fully configured route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.8.0
 
+- Allow to update Maven dependencies on not fully configured route
 - Use Node 22 instead of Node 20
 - show `What's New` release page after each extension upgrade (only for first startup)
 

--- a/src/helpers/CamelJBang.ts
+++ b/src/helpers/CamelJBang.ts
@@ -96,7 +96,16 @@ export class CamelJBang {
 	 */
 	public async dependencyUpdate(pomPath: string, routePath: string, cwd?: string): Promise<number> {
 		return await new Promise<number>((resolve) => {
-			const args: string[] = [`-Dcamel.jbang.version=${this.camelJBangVersion}`, 'camel@apache/camel', 'dependency', 'update', pomPath, routePath];
+			const args: string[] = [
+				`-Dcamel.jbang.version=${this.camelJBangVersion}`,
+				'camel@apache/camel',
+				'dependency',
+				'update',
+				pomPath,
+				routePath,
+				'--lazy-bean',
+				'--ignore-loading-error',
+			];
 			KaotoOutputChannel.logInfo(`Camel Dependency Update: jbang ${args.join(' ')}`);
 			execFile(this.jbang, args, { cwd, maxBuffer: 50 * 1024 * 1024 }, (error, stdout, stderr) => {
 				if (stdout) {


### PR DESCRIPTION
which is often the case just after we added a step and that save is hit.

fixes #1093
fixes #1094