### PR TITLE
fix: user configurations are not divided into categories in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -627,6 +627,7 @@
     ],
     "configuration": [
       {
+        "id": "kaoto",
         "title": "Kaoto",
         "properties": {
           "kaoto.catalog.url": {
@@ -695,6 +696,7 @@
         }
       },
       {
+        "id": "canvas",
         "title": "Canvas",
         "properties": {
           "kaoto.nodeLabel": {
@@ -737,6 +739,7 @@
         }
       },
       {
+        "id": "jbang",
         "title": "JBang",
         "properties": {
           "kaoto.camelJbang.version": {
@@ -791,6 +794,7 @@
         }
       },
       {
+        "id": "maven",
         "title": "Maven Projects",
         "properties": {
           "kaoto.maven.dependenciesUpdate.onSave": {


### PR DESCRIPTION
From VS Code 1.106 the user configurations stopped to be divided into categories in UI

**BEFORE the fix:**
<img width="263" height="105" alt="Screenshot 2025-11-27 at 0 42 57" src="https://github.com/user-attachments/assets/b4eab050-7e48-4772-a142-0c172d49702b" />


**AFTER the fix:**
<img width="290" height="146" alt="Screenshot 2025-11-27 at 0 41 26" src="https://github.com/user-attachments/assets/5a5b33ff-e4cb-4cd9-a60d-690554d0a193" />