### PR TITLE
Fix JBang installation link in checkJbangOnPath

### DIFF
--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -106,7 +106,7 @@ export class ExtensionContextHandler {
 		const jbangExec = await verifyJBangExists();
 		await vscode.commands.executeCommand('setContext', 'kaoto.jbangAvailable', jbangExec); // store availability in VS Code context
 		if (!jbangExec) {
-			const jbangInstallationLink: string = 'https://www.jbang.dev/documentation/guide/latest/installation.html';
+			const jbangInstallationLink: string = 'https://www.jbang.dev/documentation/jbang/latest/installation.html';
 			const msg: string = `JBang is missing on a system PATH. Please follow instructions below and install JBang. [JBang Installation Guide](${jbangInstallationLink}).`;
 			KaotoOutputChannel.logWarning(msg);
 			const selection = await vscode.window.showWarningMessage(msg, 'Install');


### PR DESCRIPTION
Updated the JBang installation link to the latest documentation at https://www.jbang.dev/documentation/jbang/latest/installation.html