### PR TITLE
feat(deploy): enable deployment to local kubernetes clusters

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,118 @@
+# package.json
+
+diff --git a/package.json b/package.json
+index 972b6de..7a20baf 100644
+--- a/package.json
++++ b/package.json
+@@ -793,6 +793,15 @@
+             "tags": [
+               "preview"
+             ]
++          },
++          "kaoto.deployment.clusterType": {
++            "type": "string",
++            "markdownDescription": "Allow to select the cluster type for the deployment. If not set, Kaoto will ask via Quick Pick.",
++            "enum": [
++              "OpenShift",
++              "Kubernetes"
++            ],
++            "scope": "window"
+           }
+         }
+       },
+
+# src/extension/ExtensionContextHandler.ts
+
+	public registerKubernetesRunCommands() {
+		const INTEGRATIONS_KUBERNETES_RUN_COMMAND_ID: string = 'kaoto.integrations.kubernetes.run';
+
+		this.context.subscriptions.push(
+			vscode.commands.registerCommand(INTEGRATIONS_KUBERNETES_RUN_COMMAND_ID, async (integration: Integration) => {
+				if (!(await verifyCamelKubernetesPluginIsInstalled())) {
+					await new CamelAddPluginJBangTask('kubernetes').executeAndWait();
+					KaotoOutputChannel.logInfo('Apache Camel JBang Kubernetes plugin was installed.');
+				}
+
+				const clusterType = await this.getClusterType();
+				if (!clusterType) {
+					return;
+				}
+
+				await new CamelKubernetesRunJBangTask(integration.filepath.fsPath, clusterType).execute();
+				await this.sendCommandTrackingEvent(INTEGRATIONS_KUBERNETES_RUN_COMMAND_ID);
+			}),
+		);
+	}
+
+	private async getClusterType(): Promise<string | undefined> {
+		const clusterTypeSetting = 'kaoto.deployment.clusterType';
+		let clusterType = vscode.workspace.getConfiguration().get(clusterTypeSetting) as string;
+
+		if (!clusterType) {
+			const selected = await vscode.window.showQuickPick(['OpenShift', 'Kubernetes'], {
+				placeHolder: 'Select target cluster type',
+			});
+			if (selected) {
+				clusterType = selected;
+				await vscode.workspace.getConfiguration().update(clusterTypeSetting, selected, vscode.ConfigurationTarget.Global);
+			}
+		}
+
+		return clusterType;
+	}
+
+# src/helpers/CamelJBang.ts
+
+import {
+	arePathsEqual,
+	findFolderOfPomXml,
+	KAOTO_CAMEL_JBANG_KUBERNETES_CLUSTER_RUN_ARGUMENTS_SETTING_ID,
++	KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RED_HAT_MAVEN_REPOSITORY_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_CAMEL_JBANG_RUN_SOURCE_DIR_ARGUMENTS_SETTING_ID,
+	KAOTO_CAMEL_JBANG_VERSION_SETTING_ID,
+	KAOTO_LOCAL_KAMELET_DIRECTORIES_SETTING_ID,
+	resolvePaths,
+} from './helpers';
+
+
+	public kubernetesRun(filePattern: string, clusterType: string, cwd?: string): ShellExecution {
+		const shellExecOptions: ShellExecutionOptions = {
+			cwd: cwd,
+		};
+		const runArgs = clusterType === 'Kubernetes' ? this.getKubernetesClusterRunArguments() : this.getKubernetesRunArguments();
+
+		return new ShellExecution(
+			this.jbang,
+			[...this.defaultJbangArgs, 'kubernetes', 'run', filePattern, this.getCamelVersion(), ...runArgs].filter(function (arg) {
+				return arg !== undefined && arg !== null && arg !== ''; // remove ALL empty values ("", null, undefined and 0)
+			}), // remove ALL empty values ("", null, undefined and 0)
+			shellExecOptions,
+		);
+	}
+
+
+	private getKubernetesRunArguments(): string[] {
+		const kubernetesRunArgs = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID) as string[];
+		return kubernetesRunArgs && kubernetesRunArgs.length > 0 ? kubernetesRunArgs : [];
+	}
+
+
+	private getKubernetesClusterRunArguments(): string[] {
+		const kubernetesClusterRunArgs = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_KUBERNETES_CLUSTER_RUN_ARGUMENTS_SETTING_ID) as string[];
+		return kubernetesClusterRunArgs && kubernetesClusterRunArgs.length > 0 ? kubernetesClusterRunArgs : [];
+	}
+
+# src/helpers/helpers.ts
+
+export const KAOTO_CAMEL_JBANG_KUBERNETES_CLUSTER_RUN_ARGUMENTS_SETTING_ID: string = 'kaoto.camelJbang.kubernetesClusterRunArguments';
+
+# src/tasks/CamelKubernetesRunJBangTask.ts
+
+export class CamelKubernetesRunJBangTask extends CamelJBangTask {
+	constructor(filePath: string, clusterType: string) {
+		super(TaskScope.Workspace, `Deploying - ${basename(filePath)}`, new CamelJBang().kubernetesRun(filePath, clusterType, dirname(filePath)));
+	}
+}

--- a/it-tests/vscode-settings-minikube.json
+++ b/it-tests/vscode-settings-minikube.json
@@ -11,5 +11,6 @@
     "container.image-push=true",
     "--trait",
     "container.image-pull-policy=IfNotPresent"
-  ]
+  ],
+  "kaoto.deploy.clusterType": "Minikube"
 }

--- a/it-tests/vscode-settings.json
+++ b/it-tests/vscode-settings.json
@@ -3,5 +3,6 @@
   "redhat.telemetry.enabled": false,
   "workbench.secondarySideBar.defaultVisibility": "hidden",
   "window.zoomLevel": -1.5,
-  "window.openFoldersInNewWindow": "off"
+  "window.openFoldersInNewWindow": "off",
+  "kaoto.deploy.clusterType": "Kubernetes"
 }

--- a/package.json
+++ b/package.json
@@ -884,6 +884,15 @@
             "tags": [
               "preview"
             ]
+          },
+          "kaoto.deployment.clusterType": {
+            "type": "string",
+            "markdownDescription": "Allow to select the cluster type for the deployment. If not set, Kaoto will ask via Quick Pick.",
+            "enum": [
+              "OpenShift",
+              "Kubernetes"
+            ],
+            "scope": "window"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -812,6 +812,21 @@
             "scope": "window",
             "order": 3
           },
+          "kaoto.deploy.clusterType": {
+            "type": "string",
+            "enum": [
+              "Ask",
+              "Kubernetes",
+              "OpenShift",
+              "Knative",
+              "Minikube",
+              "Kind"
+            ],
+            "default": "Ask",
+            "markdownDescription": "Specifies the cluster type for deployment. If set to 'Ask', you will be prompted to select a cluster type for each deployment.",
+            "scope": "window",
+            "order": 4
+          },
           "kaoto.integrations.files.regexp": {
             "type": "array",
             "items": {
@@ -884,15 +899,6 @@
             "tags": [
               "preview"
             ]
-          },
-          "kaoto.deployment.clusterType": {
-            "type": "string",
-            "markdownDescription": "Allow to select the cluster type for the deployment. If not set, Kaoto will ask via Quick Pick.",
-            "enum": [
-              "OpenShift",
-              "Kubernetes"
-            ],
-            "scope": "window"
           }
         }
       },

--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -490,6 +490,23 @@ export class ExtensionContextHandler {
 		);
 	}
 
+	private async getClusterType(): Promise<string | undefined> {
+		const clusterTypeSetting = 'kaoto.deployment.clusterType';
+		let clusterType = vscode.workspace.getConfiguration().get(clusterTypeSetting) as string;
+
+		if (!clusterType) {
+			const selected = await vscode.window.showQuickPick(['OpenShift', 'Kubernetes'], {
+				placeHolder: 'Select target cluster type',
+			});
+			if (selected) {
+				clusterType = selected;
+				await vscode.workspace.getConfiguration().update(clusterTypeSetting, selected, vscode.ConfigurationTarget.Global);
+			}
+		}
+
+		return clusterType;
+	}
+
 	public registerDeploymentsIntegrationCommands() {
 		const DEPLOYMENTS_INTEGRATION_STOP_COMMAND_ID: string = 'kaoto.deployments.stop';
 		const DEPLOYMENTS_INTEGRATION_LOGS_COMMAND_ID: string = 'kaoto.deployments.logs';

--- a/src/helpers/CamelKubernetesJBang.ts
+++ b/src/helpers/CamelKubernetesJBang.ts
@@ -26,13 +26,17 @@ export class CamelKubernetesJBang extends CamelJBang {
 		return await super.export(uri, gav, runtime, outputPath, cwd, true);
 	}
 
-	public async run(filePattern: string, cwd?: string): Promise<ShellExecution> {
+	public async run(filePattern: string, cwd?: string, port?: number, clusterType?: string): Promise<ShellExecution> {
 		const shellExecOptions: ShellExecutionOptions = {
 			cwd: cwd,
 		};
+		const args = [...this.defaultJbangArgs, 'kubernetes', 'run', filePattern, this.getCamelVersion(), ...this.getKubernetesRunArguments()];
+		if (clusterType && clusterType !== 'Ask') {
+			args.push(`--cluster-type=${clusterType.toLowerCase()}`);
+		}
 		return new ShellExecution(
 			this.jbang,
-			[...this.defaultJbangArgs, 'kubernetes', 'run', filePattern, this.getCamelVersion(), ...this.getKubernetesRunArguments()].filter(function (arg) {
+			args.filter(function (arg) {
 				return arg !== undefined && arg !== null && arg !== ''; // remove ALL empty values ("", null, undefined and 0)
 			}), // remove ALL empty values ("", null, undefined and 0)
 			shellExecOptions,


### PR DESCRIPTION
This PR adds support for deploying Camel integrations to a local Kubernetes cluster, in addition to the existing OpenShift deployment.

A new option is now available when triggering the "Deploy" command, allowing users to select the desired target platform:

- OpenShift (default behavior)
- Kubernetes (new)

If Kubernetes deployment is selected (either through a prompt or via VS Code Settings), the extension now generates a ShellExecution to run:

kamel run <filePattern>

This enables Kubernetes users  (especially those working with Minikube, Kind, K3d, or other local clusters) to deploy and test integrations directly from the Kaoto VS Code extension.