### PR TITLE
fix(types): Fix createRef typings

### DIFF
--- a/src/webview/envelope-overrides/KogitoEditorEnvelopeApp.tsx
+++ b/src/webview/envelope-overrides/KogitoEditorEnvelopeApp.tsx
@@ -28,7 +28,7 @@ import { I18nDictionariesProvider } from '@kie-tools-core/i18n/dist/react-compon
 import { createRef, FunctionComponent, RefObject, useCallback } from 'react';
 
 interface KogitoEditorEnvelopeAppProps {
-	callback: (ref: RefObject<EditorEnvelopeViewApi<Editor>>) => void;
+	callback: (ref: RefObject<EditorEnvelopeViewApi<Editor> | null>) => void;
 	context: KogitoEditorEnvelopeContextType<any>;
 	showKeyBindingsOverlay: boolean;
 }


### PR DESCRIPTION
### Context
As a prerequisite for upgrading React to v19, we need to explicitly include the `| null` type part in the `useRef` or `createRef` utils.