### PR TITLE
fix: show pop-up information for running multiple workspaces only for Run: All Workspaces button

### DIFF
--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -358,7 +358,7 @@ export class ExtensionContextHandler {
 			const storageKey = 'kaoto.showRunAllFoldersMessage';
 			let showInfoMessage = this.context.globalState.get<boolean>(storageKey, true);
 
-			if (showInfoMessage) {
+			if (showInfoMessage && commandId === INTEGRATIONS_RUN_ALL_WORKSPACES_COMMAND_ID) {
 				const doNotShowAgain = "Don't show again";
 				const ok = 'OK';
 				const result = await vscode.window.showInformationMessage(


### PR DESCRIPTION
### Context
Currently, when working in a multi-folder workspace, running a single folder makes Kaoto show a warning about running across multiple folders.
<img width="455" height="116" alt="image" src="https://github.com/user-attachments/assets/1ef9701f-9397-438c-ad03-48e717ba3082" />

### Changes
This PR adds a check to only show this warning when running all folders at the same time. (Using the `Run workspace` button at the top of the integration panel)
<img width="301" height="95" alt="image" src="https://github.com/user-attachments/assets/cbb6210d-bc54-400c-8875-167e61596eef" />
