### PR TITLE
chore(ci): optimize workflows to reduce disk usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,7 @@ name: Build with released version of Kaoto
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
@@ -30,95 +26,200 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "21"
+      - name: yarn install
+        run: yarn --network-timeout 1000000
+      - name: yarn build:prod
+        run: yarn build:prod
+      - name: Install JBang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Allow unprivileged user namespace
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      - name: Run Unit tests
+        run: xvfb-run -a yarn test:unit
+      - name: vsix package
+        run: yarn vsce package --no-dependencies --yarn
+      - name: Generate SBOM
+        run: |
+          npm install -g @cyclonedx/cdxgen
+          cdxgen -o manifest.json
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+          path: "*.vsix"
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: sbom
+          path: manifest.json
+      - name: Store Unit Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ubuntu-unit-test-logs
+          path: .vscode-test/user-data/logs/*
+
+  test-integration-ubuntu:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.21
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         with:
           driver: docker
           addons: registry,registry-aliases
           container-runtime: docker
           insecure-registry: "10.0.0.0/24"
       - name: Set Minikube ENV
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           eval $(minikube -p minikube docker-env)
           echo "INSTALL_REGISTRY=$(kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}')" >> $GITHUB_ENV
           echo $INSTALL_REGISTRY
-      - name: Install JBang (ubuntu, macOS)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-latest'
+      - name: Install JBang
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
-      - name: Install JBang (windows)
-        if: matrix.os == 'windows-latest'
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Allow unprivileged user namespace
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      - name: Run Integration Tests
+        run: |
+          eval $(minikube -p minikube docker-env)
+          xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
+      - name: Store Integration Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: vscode-logs-ubuntu
+          path: test-resources/settings/logs
+      - name: Store Integration Tests VS Code screenshots
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ui-test-screenshots-ubuntu
+          path: test-resources/screenshots
+
+  test-integration-macos:
+    needs: build
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Install JBang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Run Integration Tests
+        run: yarn run test:it:with-prebuilt-vsix
+      - name: Store Integration Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: vscode-logs-macos
+          path: test-resources/settings/logs
+      - name: Store Integration Tests VS Code screenshots
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ui-test-screenshots-macos
+          path: test-resources/screenshots
+
+  test-integration-windows:
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Install JBang
         run: choco install jbang
       - name: Add Camel Trusted Source to JBang
         run: jbang trust add https://github.com/apache/camel/
       - name: Add Kubernetes plugin to Camel JBang
         run: jbang camel@apache/camel plugin add kubernetes
-      - name: yarn
-        run: yarn --network-timeout 1000000
-      - name: yarn build:prod
-        run: yarn build:prod
-      - name: vsix package
-        run: yarn vsce package --no-dependencies --yarn
-      - name: Archive vsix
-        uses: actions/upload-artifact@v6
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
         with:
-          name: "vscode-kaoto-vsix"
-          path: "*.vsix"
-      - name: Allow unprivileged user namespace (ubuntu)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      - name: Run Unit tests on Linux
-        run: xvfb-run -a yarn test:unit
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-      - name: Run Unit tests on Other OSes than Linux
-        run: yarn test:unit
-        if: ${{ matrix.os != 'ubuntu-latest' }}
-      - name: Run UI Tests on Linux
-        run: |
-          eval $(minikube -p minikube docker-env)
-          xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-      - name: Run UI Tests on macOS
-        run: yarn run test:it:with-prebuilt-vsix
-        if: matrix.os == 'macos-latest'
-      - name: Run UI Tests on windows
-        if: matrix.os == 'windows-latest'
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Run Integration Tests
         run: |
           Set-DisplayResolution -Width 1920 -Height 1080 -Force
           yarn run test:it:with-prebuilt-vsix
-      - name: Generate SBOM
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          npm install -g @cyclonedx/cdxgen
-          cdxgen -o manifest.json
-      - name: Store SBOM
-        uses: actions/upload-artifact@v6
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          name: sbom
-          path: manifest.json
-      - name: Store UI Tests VS Code Logs
+      - name: Store Integration Tests VS Code Logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: vscode-logs-${{ matrix.os }}
+          name: vscode-logs-windows
           path: test-resources/settings/logs
-      - name: Store Unit Tests VS Code Logs
+      - name: Store Integration Tests VS Code screenshots
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ${{ matrix.os }}-test-logs
-          path: .vscode-test/user-data/logs/*
-      - name: Store UI Tests VS Code screenshots
-        uses: actions/upload-artifact@v6
-        if: failure()
-        with:
-          name: ui-test-screenshots-${{ matrix.os }}
+          name: ui-test-screenshots-windows
           path: test-resources/screenshots

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -33,6 +33,64 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "21"
+      - name: Kaoto build
+        working-directory: kaoto
+        run: |
+          yarn
+          yarn workspace @kaoto/kaoto run build:lib
+      - name: yarn link kaoto
+        working-directory: vscode-kaoto
+        run: yarn link ../kaoto/packages/ui
+      - name: yarn build:prod
+        working-directory: vscode-kaoto
+        run: yarn build:prod
+      - name: Install JBang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Allow unprivileged user namespace
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+      - name: Run Unit tests
+        working-directory: vscode-kaoto
+        run: xvfb-run -a yarn test:unit
+      - name: vsix package
+        working-directory: vscode-kaoto
+        run: yarn vsce package --no-dependencies --yarn
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: vsix-from-main-branch-of-kaoto
+          path: "vscode-kaoto/*.vsix"
+      - name: Store Unit Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ubuntu-unit-test-logs
+          path: vscode-kaoto/.vscode-test/user-data/logs/*
+
+  test-integration-ubuntu:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - name: Checkout vscode-kaoto
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
       - name: Start Minikube
@@ -55,44 +113,27 @@ jobs:
         run: jbang trust add https://github.com/apache/camel/
       - name: Add Kubernetes plugin to Camel JBang
         run: jbang camel@apache/camel plugin add kubernetes
-      - name: Kaoto build
-        working-directory: kaoto
-        run: |
-          yarn
-          yarn workspace @kaoto/kaoto run build:lib
-      - name: yarn link kaoto
-        working-directory: vscode-kaoto
-        run: yarn link ../kaoto/packages/ui
-      - name: yarn build:prod
-        working-directory: vscode-kaoto
-        run: yarn build:prod
-      - name: vsix package
-        working-directory: vscode-kaoto
-        run: yarn vsce package --no-dependencies --yarn
-      - name: Archive vsix
-        uses: actions/upload-artifact@v6
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
         with:
           name: vsix-from-main-branch-of-kaoto
-          path: "vscode-kaoto/*.vsix"
-      - name: Allow unprivileged user namespace (ubuntu)
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Allow unprivileged user namespace
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      - name: Run Unit tests
-        working-directory: vscode-kaoto
-        run: xvfb-run -a yarn test:unit
-      - name: Run UI Tests
-        working-directory: vscode-kaoto
+      - name: Run Integration Tests
         run: |
           eval $(minikube -p minikube docker-env)
           xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
-      - name: Store UI Tests VS Code Logs
+      - name: Store Integration Tests VS Code Logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: vscode-logs
-          path: vscode-kaoto/test-resources/settings/logs
-      - name: Store UI Tests VS Code screenshots
+          name: vscode-logs-ubuntu
+          path: test-resources/settings/logs
+      - name: Store Integration Tests VS Code screenshots
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ui-test-screenshots
-          path: vscode-kaoto/test-resources/screenshots
+          name: ui-test-screenshots-ubuntu
+          path: test-resources/screenshots

--- a/.github/workflows/test-snapshot.yaml
+++ b/.github/workflows/test-snapshot.yaml
@@ -6,11 +6,7 @@ name: Test with snapshot version of Camel JBang
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
@@ -30,94 +26,182 @@ jobs:
           fi
           echo "Latest Camel JBang snapshot version: $VERSION"
           echo "CAMEL_JBANG_SNAPSHOT_VERSION=$VERSION" >> $GITHUB_ENV
-
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: "yarn"
-
       - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
+      - name: yarn install
+        run: yarn --network-timeout 1000000
+      - name: yarn build:prod
+        run: yarn build:prod
+      - name: vsix package
+        run: yarn vsce package --no-dependencies --yarn
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+          path: "*.vsix"
 
+  test-integration-ubuntu:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.7.0
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.21
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         with:
           driver: docker
           addons: registry,registry-aliases
           container-runtime: docker
           insecure-registry: "10.0.0.0/24"
-
       - name: Set Minikube ENV
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           eval $(minikube -p minikube docker-env)
           echo "INSTALL_REGISTRY=$(kubectl -n kube-system get service registry -o jsonpath='{.spec.clusterIP}')" >> $GITHUB_ENV
           echo $INSTALL_REGISTRY
-
-      - name: Install JBang (ubuntu, macOS)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }} || matrix.os == 'macos-latest'
+      - name: Install JBang
         run: |
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           echo "$HOME/.jbang/bin" >> $GITHUB_PATH
-
-      - name: Install JBang (windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install jbang
-
       - name: Add Camel Trusted Source to JBang
         run: jbang trust add https://github.com/apache/camel/
-
       - name: Add Kubernetes plugin to Camel JBang
         run: jbang camel@apache/camel plugin add kubernetes
-
-      - name: yarn
-        run: yarn --network-timeout 1000000
-
-      - name: yarn build:prod
-        run: yarn build:prod
-
-      - name: vsix package
-        run: yarn vsce package --no-dependencies --yarn
-
-      - name: Allow unprivileged user namespace (ubuntu)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Allow unprivileged user namespace
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-      - name: Run UI Tests on Linux
+      - name: Run Integration Tests
         run: |
           eval $(minikube -p minikube docker-env)
           xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Store Integration Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: vscode-logs-ubuntu
+          path: test-resources/settings/logs
+      - name: Store Integration Tests VS Code screenshots
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ui-test-screenshots-ubuntu
+          path: test-resources/screenshots
 
-      - name: Run UI Tests on macOS
+  test-integration-macos:
+    needs: build
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Install JBang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Run Integration Tests
         run: yarn run test:it:with-prebuilt-vsix
-        if: matrix.os == 'macos-latest'
+      - name: Store Integration Tests VS Code Logs
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: vscode-logs-macos
+          path: test-resources/settings/logs
+      - name: Store Integration Tests VS Code screenshots
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ui-test-screenshots-macos
+          path: test-resources/screenshots
 
-      - name: Run UI Tests on windows
-        if: matrix.os == 'windows-latest'
+  test-integration-windows:
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    env:
+      CODE_VERSION: max
+      TEST_RESOURCES: test-resources
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+      - name: Install JBang
+        run: choco install jbang
+      - name: Add Camel Trusted Source to JBang
+        run: jbang trust add https://github.com/apache/camel/
+      - name: Add Kubernetes plugin to Camel JBang
+        run: jbang camel@apache/camel plugin add kubernetes
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: vscode-kaoto-vsix
+      - name: Install test dependencies
+        run: yarn install --mode=skip-build
+      - name: Run Integration Tests
         run: |
           Set-DisplayResolution -Width 1920 -Height 1080 -Force
           yarn run test:it:with-prebuilt-vsix
-
-      - name: Store UI Tests VS Code Logs
+      - name: Store Integration Tests VS Code Logs
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: vscode-logs-${{ matrix.os }}
+          name: vscode-logs-windows
           path: test-resources/settings/logs
-
-      - name: Store UI Tests VS Code screenshots
+      - name: Store Integration Tests VS Code screenshots
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ui-test-screenshots-${{ matrix.os }}
+          name: ui-test-screenshots-windows
           path: test-resources/screenshots


### PR DESCRIPTION
Refactor GitHub Actions workflows to eliminate "no space left on device" errors by implementing a build-once, test-everywhere pattern.

Changes:
- Separate build job (Ubuntu) that creates VSIX artifact once
- Test jobs download pre-built VSIX instead of rebuilding
- Reduced redundant yarn installs across multiple OS runners
- Test jobs use 'yarn install --mode=skip-build' for minimal dependencies