### PR TITLE
feat: Create Maven project with OpenShift deployment configuration

### DIFF
--- a/it-tests/Z_IntegrationsViewNewProject.test.ts
+++ b/it-tests/Z_IntegrationsViewNewProject.test.ts
@@ -133,7 +133,9 @@ describe('Integrations View', function () {
 						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'pom.xml')) &&
 						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'resources', 'camel', 'root-route.camel.yaml')) &&
 						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'resources', 'application.properties')) &&
-						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'resources', 'kamelets', 'rootKam-sink.kamelet.yaml'))
+						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'resources', 'kamelets', 'rootKam-sink.kamelet.yaml')) &&
+						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'docker', 'Dockerfile')) &&
+						fs.existsSync(join(PROJECT_OUTPUT_DIR, 'src', 'main', 'jkube', 'deployment.yml'))
 					);
 				},
 				240_000,

--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -411,7 +411,8 @@ export class ExtensionContextHandler {
 
 		this.context.subscriptions.push(
 			vscode.commands.registerCommand(INTEGRATIONS_KUBERNETES_RUN_COMMAND_ID, async (integration: Integration) => {
-				await new CamelKubernetesRunJBangTask(integration.filepath.fsPath).execute();
+				const deployTask = await CamelKubernetesRunJBangTask.create(integration.filepath.fsPath);
+				await deployTask.execute();
 				await this.sendCommandTrackingEvent(INTEGRATIONS_KUBERNETES_RUN_COMMAND_ID);
 			}),
 		);

--- a/src/helpers/CamelKubernetesJBang.ts
+++ b/src/helpers/CamelKubernetesJBang.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ShellExecution, ShellExecutionOptions, Uri, workspace } from 'vscode';
+import { CamelJBang } from './CamelJBang';
+import { KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID } from './helpers';
+
+/**
+ * Camel JBang class which allows shell execution of different JBang CLI commands
+ */
+export class CamelKubernetesJBang extends CamelJBang {
+	public async export(uri: Uri, gav: string, runtime: string, outputPath: string, cwd: string): Promise<ShellExecution> {
+		// export the project with the kubernetes plugin
+		return await super.export(uri, gav, runtime, outputPath, cwd, true);
+	}
+
+	public async run(filePattern: string, cwd?: string): Promise<ShellExecution> {
+		const shellExecOptions: ShellExecutionOptions = {
+			cwd: cwd,
+		};
+		return new ShellExecution(
+			this.jbang,
+			[...this.defaultJbangArgs, 'kubernetes', 'run', filePattern, this.getCamelVersion(), ...this.getKubernetesRunArguments()].filter(function (arg) {
+				return arg !== undefined && arg !== null && arg !== ''; // remove ALL empty values ("", null, undefined and 0)
+			}), // remove ALL empty values ("", null, undefined and 0)
+			shellExecOptions,
+		);
+	}
+
+	protected getKubernetesRunArguments(): string[] {
+		const kubernetesRunArgs = workspace.getConfiguration().get(KAOTO_CAMEL_JBANG_KUBERNETES_RUN_ARGUMENTS_SETTING_ID) as string[];
+		if (kubernetesRunArgs.length > 0) {
+			return kubernetesRunArgs;
+		} else {
+			return [];
+		}
+	}
+}

--- a/src/tasks/CamelExportJBangTask.ts
+++ b/src/tasks/CamelExportJBangTask.ts
@@ -15,7 +15,7 @@
  */
 import { ShellExecution, TaskRevealKind, TaskScope, Uri, WorkspaceFolder } from 'vscode';
 import { CamelJBangTask } from './CamelJBangTask';
-import { CamelJBang } from '../helpers/CamelJBang';
+import { CamelKubernetesJBang } from '../helpers/CamelKubernetesJBang';
 
 export class CamelExportJBangTask extends CamelJBangTask {
 	constructor(scope: WorkspaceFolder | TaskScope.Workspace, shellExecution: ShellExecution) {
@@ -30,7 +30,7 @@ export class CamelExportJBangTask extends CamelJBangTask {
 		outputPath: string,
 		cwd: string,
 	): Promise<CamelExportJBangTask> {
-		const shellExecution = await new CamelJBang().export(uri, gav, runtime, outputPath, cwd);
+		const shellExecution = await new CamelKubernetesJBang().export(uri, gav, runtime, outputPath, cwd);
 		return new CamelExportJBangTask(scope, shellExecution);
 	}
 }

--- a/src/tasks/CamelKubernetesRunJBangTask.ts
+++ b/src/tasks/CamelKubernetesRunJBangTask.ts
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TaskScope } from 'vscode';
+import { ShellExecution, TaskScope } from 'vscode';
 import { CamelJBangTask } from './CamelJBangTask';
-import { CamelJBang } from '../helpers/CamelJBang';
 import { basename, dirname } from 'path';
+import { CamelKubernetesJBang } from '../helpers/CamelKubernetesJBang';
 
 export class CamelKubernetesRunJBangTask extends CamelJBangTask {
-	constructor(filePath: string) {
-		super(TaskScope.Workspace, `Deploying - ${basename(filePath)}`, new CamelJBang().kubernetesRun(filePath, dirname(filePath)));
+	private constructor(shellExecution: ShellExecution, filePath: string) {
+		super(TaskScope.Workspace, `Deploying - ${basename(filePath)}`, shellExecution);
+	}
+
+	static async create(filePath: string): Promise<CamelKubernetesRunJBangTask> {
+		const shellExecution = await new CamelKubernetesJBang().run(filePath, dirname(filePath));
+		return new CamelKubernetesRunJBangTask(shellExecution, filePath);
 	}
 }


### PR DESCRIPTION
use `camel kubernetes export` instead of `camel export` to provide maven project with deployment configurations