### PR TITLE
chore: Upgrade default Camel JBang version from 4.17.0 to 4.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.10.0
 
-- Upgrade default Camel JBang version from 4.16.0 to 4.17.0
+- Upgrade default Camel JBang version from 4.16.0 to 4.18.0
 - export Maven projects with OpenShift deployment configurations using Camel Kubernetes plugin
 - export Maven projects with predefined VS Code launch configurations for easy deployment to OpenShift
 - Add `Tests` section into Kaoto view

--- a/package.json
+++ b/package.json
@@ -894,7 +894,7 @@
           "kaoto.camelJbang.version": {
             "type": "string",
             "markdownDescription": "Apache [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) version used for an internal Camel JBang CLI calls. Requirements can differ between versions.\n\nIt is recommended to use `default` version to ensure all extension features works properly.",
-            "default": "4.17.0",
+            "default": "4.18.0",
             "order": 0
           },
           "kaoto.camelJbang.runArguments": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Camel JBang default version to 4.18.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->