### PR TITLE
feat: Tests view - test files regex can be configured through settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - list existing Citrus tests in a current workspace
   - create a new Citrus Test file button
   - run single test or all tests in a folder
+  - test files regex can be configured through settings
 
 # 2.9.0
 

--- a/package.json
+++ b/package.json
@@ -897,6 +897,21 @@
             "scope": "window",
             "order": 4
           },
+          "kaoto.tests.files.regexp": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "additionalProperties": false,
+            "default": [
+              "*.test.yaml",
+              "*.citrus.yaml",
+              "jbang.properties"
+            ],
+            "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > Tests` view.",
+            "scope": "window",
+            "order": 5
+          },
           "redhat.telemetry.enabled": {
             "type": "boolean",
             "default": null,
@@ -905,7 +920,7 @@
               "telemetry"
             ],
             "scope": "window",
-            "order": 5
+            "order": 6
           }
         }
       },

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -44,6 +44,8 @@ export const KAOTO_LOCAL_KAMELET_DIRECTORIES_SETTING_ID: string = 'kaoto.localKa
 
 export const KAOTO_INTEGRATIONS_FILES_REGEXP_SETTING_ID: string = 'kaoto.integrations.files.regexp';
 
+export const KAOTO_TESTS_FILES_REGEXP_SETTING_ID: string = 'kaoto.tests.files.regexp';
+
 export const CAMEL_TRUSTED_SOURCE_URL: string = 'https://github.com/apache/camel/';
 
 export const CITRUS_TRUSTED_SOURCE_URL: string = 'https://github.com/citrusframework/citrus/';

--- a/src/views/providers/AbstractFolderTreeProvider.ts
+++ b/src/views/providers/AbstractFolderTreeProvider.ts
@@ -40,6 +40,7 @@ export abstract class AbstractFolderTreeProvider<TFolder extends IFolderTreeItem
 	readonly onDidChangeTreeData: Event<TreeItemType> = this._onDidChangeTreeData.event;
 
 	protected fileWatcher!: FileSystemWatcher;
+	protected filePattern: string;
 
 	/** Debounce timer for refresh operations */
 	private refreshDebounceTimer?: NodeJS.Timeout;
@@ -56,7 +57,8 @@ export abstract class AbstractFolderTreeProvider<TFolder extends IFolderTreeItem
 	 * Initialize the file watcher. Must be called by subclasses after their constructor initialization.
 	 */
 	protected initFileWatcher(): void {
-		this.fileWatcher = workspace.createFileSystemWatcher(this.getFilePattern());
+		this.filePattern = this.getFilePattern();
+		this.fileWatcher = workspace.createFileSystemWatcher(this.filePattern);
 		const invalidateAndRefresh = () => {
 			this.invalidateCache();
 			this.refresh();
@@ -83,6 +85,11 @@ export abstract class AbstractFolderTreeProvider<TFolder extends IFolderTreeItem
 	 * Get the exclude pattern for file search
 	 */
 	protected abstract getExcludePattern(): string;
+
+	/**
+	 * Handle configuration file pattern changes
+	 */
+	protected abstract onConfigurationChange(): void;
 
 	/**
 	 * Create a folder tree item

--- a/src/views/providers/IntegrationsProvider.ts
+++ b/src/views/providers/IntegrationsProvider.ts
@@ -31,7 +31,7 @@ export class IntegrationsProvider implements TreeDataProvider<TreeItem> {
 	private readonly _onDidChangeTreeData: EventEmitter<TreeItemType> = new EventEmitter<TreeItemType>();
 	readonly onDidChangeTreeData: Event<TreeItemType> = this._onDidChangeTreeData.event;
 
-	public static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/target/**,**/.mvn/**}';
+	public static readonly EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.camel-jbang*/**,**/.citrus-jbang*/**,**/target/**,**/.mvn/**}';
 
 	private fileWatcher: FileSystemWatcher;
 	private filePattern: string;

--- a/src/views/providers/TestsProvider.ts
+++ b/src/views/providers/TestsProvider.ts
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { commands, RelativePattern, TreeItem, TreeItemCollapsibleState, Uri, workspace } from 'vscode';
 import { AbstractFolderTreeProvider } from './AbstractFolderTreeProvider';
+import { commands, Disposable, RelativePattern, TreeItem, TreeItemCollapsibleState, Uri, workspace } from 'vscode';
 import { Test } from '../testTreeItems/Test';
 import { TestResult } from '../../types/testTreeItemType';
 import { TestFolder } from '../testTreeItems/TestFolder';
 import { basename, dirname, join } from 'path';
 import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';
+import { KAOTO_TESTS_FILES_REGEXP_SETTING_ID } from '../../helpers/helpers';
 
 export class TestsProvider extends AbstractFolderTreeProvider<TestFolder> {
 	public readonly VIEW_ITEM_SHOW_SOURCE_COMMAND_ID: string = 'kaoto.tests.showSource';
 	public readonly VIEW_ITEM_DELETE_COMMAND_ID: string = 'kaoto.tests.delete';
 
-	private static readonly FILE_PATTERN = '{**/*.test.yaml,**/*.citrus.yaml,**/jbang.properties}';
-	private static readonly TEST_FILE_PATTERN = '{**/*.test.yaml,**/*.citrus.yaml}';
+	private static readonly TEST_FILE_PATTERN = '{**/*.test.yaml,**/*.citrus.yaml,**/*.it.yaml}';
+	private static readonly SCHEDULE_REFRESH_MS = 100;
 
 	/** Cache of file paths to Test items for efficient lookup and single-item refresh */
 	private readonly testItemCache: Map<string, Test> = new Map();
@@ -37,19 +38,31 @@ export class TestsProvider extends AbstractFolderTreeProvider<TestFolder> {
 	/** Paths awaiting a batched full refresh (items not yet in cache) */
 	private readonly pendingRefreshPaths = new Set<string>();
 	private pendingRefreshTimer?: NodeJS.Timeout;
-	private static readonly SCHEDULE_REFRESH_MS = 100;
+	private configChangeDisposable?: Disposable;
 
 	constructor() {
 		super();
 		this.initFileWatcher();
+		this.onConfigurationChange();
 	}
 
 	protected getFilePattern(): string {
-		return TestsProvider.FILE_PATTERN;
+		const filesRegexp: string[] = workspace.getConfiguration().get(KAOTO_TESTS_FILES_REGEXP_SETTING_ID) as string[];
+		return '{' + filesRegexp.map((r) => '**/' + r).join(',') + '}';
 	}
 
 	protected getExcludePattern(): string {
 		return TestsProvider.EXCLUDE_PATTERN;
+	}
+
+	protected onConfigurationChange(): void {
+		this.configChangeDisposable = workspace.onDidChangeConfiguration((event) => {
+			if (event.affectsConfiguration(KAOTO_TESTS_FILES_REGEXP_SETTING_ID)) {
+				this.fileWatcher?.dispose();
+				this.initFileWatcher();
+				this.refresh();
+			}
+		});
 	}
 
 	protected createFolderItem(name: string, folderUri: Uri, isUnderMavenRoot: boolean, isMavenRoot: boolean, isWorkspaceRoot: boolean = false): TestFolder {
@@ -102,6 +115,19 @@ export class TestsProvider extends AbstractFolderTreeProvider<TestFolder> {
 		this.testItemCache.clear();
 		this.invalidateCache();
 		super.refresh();
+	}
+
+	/**
+	 * Dispose of the provider and all associated resources
+	 */
+	override dispose(): void {
+		if (this.pendingRefreshTimer) {
+			clearTimeout(this.pendingRefreshTimer);
+			this.pendingRefreshTimer = undefined;
+			this.pendingRefreshPaths.clear();
+		}
+		this.configChangeDisposable?.dispose();
+		super.dispose();
 	}
 
 	/**


### PR DESCRIPTION
depends on #1278 

<img width="513" height="200" alt="Screenshot 2026-02-27 at 16 10 46" src="https://github.com/user-attachments/assets/03df64d6-fe15-4a0c-ac0a-8bcc4c6436aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test file filtering patterns are now configurable via settings.
  * Adds support for additional test filename convention (.it.yaml).
  * Test results are persisted so results survive restarts.

* **Refactor**
  * Configuration changes now trigger automatic re-initialization and refresh of test listings.
  * File-watching and refreshes are debounced and batched for more responsive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->