### PR TITLE
fix: support Citrus tests YAML schema defined filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Learn more about Kaoto and how to use it effectively:
 - **Camel Route files**: `*.camel.yaml`, `*.camel.xml`
 - **Kamelet files**: `*.kamelet.yaml`
 - **Pipe files**: `*.pipe.yaml`
-- **Citrus Test files**: `*.test.yaml`, `*.citrus.yaml`
+- **Citrus Test files**: `*.citrus.yaml`, `*.citrus.test.yaml`, `*.citrus.it.yaml`, `*.citrus-test.yaml`, `*.citrus-it.yaml`
 
 ## Feedback
 

--- a/it-tests/views/10_TestsView.test.ts
+++ b/it-tests/views/10_TestsView.test.ts
@@ -29,6 +29,10 @@ describe('Tests View', function () {
 
 	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars', 'kaoto-view', 'example-tests');
 
+	const CITRUS_TEST_FILE_SUFFIXES: string[] = ['.citrus.yaml', '.citrus.test.yaml', '.citrus.it.yaml', '.citrus-test.yaml', '.citrus-it.yaml'];
+
+	const CITRUS_TEST_FILE_LABELS: string[] = CITRUS_TEST_FILE_SUFFIXES.map((suffix) => `myTest${suffix}`);
+
 	let kaotoViewContainer: ViewControl | undefined;
 	let testsSection: ViewSection | undefined;
 	let items: TreeItem[] | undefined;
@@ -72,20 +76,7 @@ describe('Tests View', function () {
 
 	it('items are displayed', async function () {
 		expect(labels).to.not.be.empty;
-	});
-
-	it('camel tests (*.test.yaml) loaded', async function () {
-		const tests = labels.filter((label) => label.includes('.test.yaml'));
-
-		expect(tests).to.not.be.empty;
-		expect(tests).to.include.members(['myTest.test.yaml']);
-	});
-
-	it('citrus tests (*.citrus.yaml) loaded', async function () {
-		const tests = labels.filter((label) => label.includes('.citrus.yaml'));
-
-		expect(tests).to.not.be.empty;
-		expect(tests).to.include.members(['myCitrusTest.citrus.yaml']);
+		expect(labels).to.include.members(CITRUS_TEST_FILE_LABELS);
 	});
 
 	it('jbang.properties loaded', async function () {

--- a/it-tests/views/11_TestsViewNewFile.test.ts
+++ b/it-tests/views/11_TestsViewNewFile.test.ts
@@ -62,7 +62,7 @@ describe('Tests View', function () {
 	});
 
 	describe(`Click 'New Citrus Test...' button`, function () {
-		const CITRUS_TEST_FILE: string = 'newTest.test.yaml';
+		const CITRUS_TEST_FILE: string = 'newTest.citrus.yaml';
 
 		let input: InputBox;
 

--- a/it-tests/views/12_TestsViewRun.test.ts
+++ b/it-tests/views/12_TestsViewRun.test.ts
@@ -62,13 +62,13 @@ describe('Tests View', function () {
 			await new EditorView().closeAllEditors();
 		});
 
-		it(`check 'myTest.test.yaml' is running`, async function () {
-			const item = await getTreeItem(driver, testsSection, 'myTest.test.yaml');
+		it(`check 'myTest.citrus.yaml' is running`, async function () {
+			const item = await getTreeItem(driver, testsSection, 'myTest.citrus.yaml');
 			expect(item).to.not.be.undefined;
 			const button = await getTreeItemActionButton(kaotoViewContainer, item as TreeItem, 'Run');
 			await button?.click();
 
-			await waitUntilTerminalHasText(driver, ['myTest.test-flow.json', 'Tests finished'], 4_000, 180_000);
+			await waitUntilTerminalHasText(driver, ['myTest.citrus-flow.json', 'Tests finished'], 4_000, 180_000);
 		});
 	});
 
@@ -86,7 +86,7 @@ describe('Tests View', function () {
 			const button = await getTreeItemActionButton(kaotoViewContainer, item as TreeItem, 'Run: Folder');
 			await button?.click();
 
-			await waitUntilTerminalHasText(driver, ['myFolderCitrusTest.citrus-flow.json', 'myFolderTest.test-flow.json', 'Tests finished'], 4_000, 180_000);
+			await waitUntilTerminalHasText(driver, ['myFolderTest.citrus-flow.json', 'myFolderTest.citrus.test-flow.json', 'Tests finished'], 4_000, 180_000);
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -904,8 +904,11 @@
             },
             "additionalProperties": false,
             "default": [
-              "*.test.yaml",
               "*.citrus.yaml",
+              "*.citrus.test.yaml",
+              "*.citrus.it.yaml",
+              "*.citrus-test.yaml",
+              "*.citrus-it.yaml",
               "jbang.properties"
             ],
             "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > Tests` view.",

--- a/src/commands/NewCamelTestCommand.ts
+++ b/src/commands/NewCamelTestCommand.ts
@@ -99,7 +99,7 @@ export class NewCamelTestCommand extends AbstractNewCamelRouteCommand {
 	protected getDSL(): CamelRouteDSL {
 		return {
 			language: 'YAML',
-			extension: 'test.yaml',
+			extension: 'citrus.yaml',
 			placeHolder: 'sample-test',
 		};
 	}

--- a/src/views/providers/TestsProvider.ts
+++ b/src/views/providers/TestsProvider.ts
@@ -26,7 +26,7 @@ export class TestsProvider extends AbstractFolderTreeProvider<TestFolder> {
 	public readonly VIEW_ITEM_SHOW_SOURCE_COMMAND_ID: string = 'kaoto.tests.showSource';
 	public readonly VIEW_ITEM_DELETE_COMMAND_ID: string = 'kaoto.tests.delete';
 
-	private static readonly TEST_FILE_PATTERN = '{**/*.test.yaml,**/*.citrus.yaml,**/*.it.yaml}';
+	private static readonly TEST_FILE_PATTERN = '{**/*.citrus.yaml,**/*.citrus.test.yaml,**/*.citrus.it.yaml,**/*.citrus-test.yaml,**/*.citrus-it.yaml}';
 	private static readonly SCHEDULE_REFRESH_MS = 100;
 
 	/** Cache of file paths to Test items for efficient lookup and single-item refresh */
@@ -233,7 +233,7 @@ export class TestsProvider extends AbstractFolderTreeProvider<TestFolder> {
 	async readTestResult(testFilePath: string): Promise<TestResult> {
 		try {
 			const testDir = dirname(testFilePath);
-			const fileName = basename(testFilePath, '.yaml'); // e.g., "name.test.yaml" -> "name.test" or "name.citrus.yaml" -> "name.citrus"
+			const fileName = basename(testFilePath, '.yaml');
 
 			const resultFilePath = join(testDir, '.citrus-jbang', 'citrus-reports', `${fileName}-flow.json`);
 

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/myFolderTest.citrus.test.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/myFolderTest.citrus.test.yaml
@@ -1,0 +1,10 @@
+name: myFolderTest.citrus.test
+author: Citrus
+status: FINAL
+description: Sample test in YAML
+variables:
+  - name: message
+    value: Citrus rocks!
+actions:
+  - echo:
+      message: "${message}"

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/myFolderTest.citrus.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/myFolderTest.citrus.yaml
@@ -1,4 +1,4 @@
-name: myFolderTest.test
+name: myFolderTest.citrus
 author: Citrus
 status: FINAL
 description: Sample test in YAML

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus-it.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus-it.yaml
@@ -1,4 +1,4 @@
-name: myTest.test
+name: myTest.citrus-it
 author: Citrus
 status: FINAL
 description: Sample test in YAML

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus-test.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus-test.yaml
@@ -1,0 +1,10 @@
+name: myTest.citrus-test
+author: Citrus
+status: FINAL
+description: Sample test in YAML
+variables:
+  - name: message
+    value: Citrus rocks!
+actions:
+  - echo:
+      message: "${message}"

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.it.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.it.yaml
@@ -1,0 +1,10 @@
+name: myTest.citrus.it
+author: Citrus
+status: FINAL
+description: Sample test in YAML
+variables:
+  - name: message
+    value: Citrus rocks!
+actions:
+  - echo:
+      message: "${message}"

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.test.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.test.yaml
@@ -1,4 +1,4 @@
-name: myCitrusTest.citrus
+name: myTest.citrus.test
 author: Citrus
 status: FINAL
 description: Sample test in YAML

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.yaml
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/myTest.citrus.yaml
@@ -1,4 +1,4 @@
-name: myFolderCitrusTest.citrus
+name: myTest.citrus
 author: Citrus
 status: FINAL
 description: Sample test in YAML


### PR DESCRIPTION
depends on #1280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded support for Citrus test file naming conventions. The application now recognizes additional file naming patterns: citrus.test.yaml, citrus.it.yaml, citrus-test.yaml, and citrus-it.yaml variants.

* **Documentation**
  * Updated documentation to include the expanded list of supported Citrus test file naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->