### PR TITLE
feat(Rest): OpenAPI Import service

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
+    "@kaoto/camel-catalog": "^0.4.0",
     "@kaoto/kaoto": "2.10.0-RC2",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",
@@ -1125,6 +1126,7 @@
     "@types/chai": "^4.3.20",
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.10",
+    "@types/openapi-v3": "^3.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/vscode": "^1.100.0",

--- a/src/services/openapi-import.service.ts
+++ b/src/services/openapi-import.service.ts
@@ -1,0 +1,729 @@
+import type {
+	FromDefinition,
+	Param1,
+	ProcessorDefinition,
+	ResponseHeader,
+	ResponseMessage1,
+	Rest,
+	RestSecurity,
+	RouteDefinition,
+	Type5,
+} from '@kaoto/camel-catalog/types';
+import type {
+	OpenApi,
+	OpenApiHeader,
+	OpenApiMap,
+	OpenApiMediaType,
+	OpenApiParameter,
+	OpenApiReference,
+	OpenApiRequestBody,
+	OpenApiResponse,
+	OpenApiResponses,
+	OpenApiSchema,
+	OpenApiSecurityRequirement,
+} from 'openapi-v3';
+import { parse } from 'yaml';
+
+/**
+ * Utility type to flatten array types.
+ */
+export type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
+
+/**
+ * REST HTTP methods supported by Camel REST DSL.
+ */
+export type RestMethods = 'get' | 'head' | 'post' | 'put' | 'patch' | 'delete';
+
+/**
+ * Union type of all REST method definition types.
+ */
+export type RestMethodDefinitions =
+	| Flatten<Rest['get']>
+	| Flatten<Rest['head']>
+	| Flatten<Rest['post']>
+	| Flatten<Rest['put']>
+	| Flatten<Rest['patch']>
+	| Flatten<Rest['delete']>;
+
+/**
+ * Array of supported REST DSL verbs.
+ */
+export const REST_DSL_VERBS: RestMethods[] = ['get', 'post', 'put', 'delete', 'patch', 'head'];
+
+/**
+ * Configuration options for OpenAPI import process.
+ */
+export interface OpenApiImportOptions {
+	/**
+	 * Whether to generate a REST definition from the OpenAPI spec.
+	 * Default: false
+	 */
+	shouldGenerateRest?: boolean;
+
+	/**
+	 * Whether to generate RouteDefinition entities for each operation.
+	 * Default: true
+	 */
+	shouldGenerateRoutes?: boolean;
+
+	/**
+	 * Optional source identifier (file path or URI) to reference in the REST definition.
+	 * This will be set in the REST definition's openApi.specification field.
+	 */
+	sourceIdentifier?: string;
+}
+
+/**
+ * Internal representation of a parsed OpenAPI operation with all necessary data
+ * for generating Camel REST and Route definitions.
+ */
+interface ParsedOperation {
+	operationId: string;
+	method: RestMethods;
+	path: string;
+	description?: string;
+	deprecated?: boolean;
+	consumes?: string;
+	produces?: string;
+	parameters: Param1[];
+	security: RestSecurity[];
+	responseMessages: ResponseMessage1[];
+}
+
+/**
+ * Error thrown when OpenAPI specification parsing fails.
+ */
+export class OpenApiParseError extends Error {
+	constructor(
+		message: string,
+		public readonly cause?: Error,
+	) {
+		super(message);
+		this.name = 'OpenApiParseError';
+	}
+}
+
+/**
+ * Error thrown when OpenAPI specification validation fails.
+ */
+export class OpenApiValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'OpenApiValidationError';
+	}
+}
+
+/**
+ * Service for importing OpenAPI v3 specifications and converting them to Apache Camel entities.
+ *
+ * This service parses OpenAPI specifications and generates:
+ * - REST definitions (Camel REST DSL)
+ * - RouteDefinition entities with default implementations
+ *
+ * @example
+ * ```typescript
+ * const service = new OpenApiImportService();
+ * const openApiYaml = `
+ *   openapi: 3.0.0
+ *   info:
+ *     title: My API
+ *   paths:
+ *     /users:
+ *       get:
+ *         operationId: getUsers
+ * `;
+ *
+ * const entities = await service.parseOpenApi(openApiYaml, {
+ *   shouldGenerateRest: true,
+ *   shouldGenerateRoutes: true,
+ *   sourceIdentifier: 'file:///path/to/api.yaml'
+ * });
+ * ```
+ */
+export class OpenApiImportService {
+	/**
+	 * Cache for resolved references to prevent infinite loops in circular references.
+	 * Maps $ref paths to their resolved values.
+	 */
+	private readonly referenceCache: Map<string, unknown> = new Map();
+
+	/**
+	 * The current OpenAPI specification being processed.
+	 * Used for resolving internal references.
+	 */
+	private currentSpec?: OpenApi;
+
+	private readonly BRACES_REGEXP = /[{}/]/g;
+	private readonly MULTIPLE_DASH_REGEXP = /-+/g;
+
+	/**
+	 * Parses an OpenAPI v3 specification and generates Camel entities.
+	 *
+	 * @param openApiString - The OpenAPI specification as a YAML or JSON string
+	 * @param options - Configuration options for the import process
+	 * @returns A promise that resolves to an array containing REST and/or RouteDefinition entities
+	 * @throws {OpenApiValidationError} If the input is invalid or options are misconfigured
+	 * @throws {OpenApiParseError} If parsing fails
+	 */
+	async parseOpenApi(openApiString: string, options: OpenApiImportOptions = {}): Promise<Array<RouteDefinition | Rest>> {
+		const { shouldGenerateRest = false, shouldGenerateRoutes = true, sourceIdentifier } = options;
+
+		// Validate input
+		if (!openApiString?.trim()) {
+			throw new OpenApiValidationError('OpenAPI specification string cannot be empty');
+		}
+
+		if (!shouldGenerateRest && !shouldGenerateRoutes) {
+			throw new OpenApiValidationError('At least one of shouldGenerateRest or shouldGenerateRoutes must be true');
+		}
+
+		try {
+			// Parse and validate OpenAPI spec
+			const openApi = this.parseOpenApiSpec(openApiString);
+
+			// Initialize spec reference and clear cache for this parsing session
+			this.currentSpec = openApi;
+			this.referenceCache.clear();
+
+			// Extract operations
+			const operations = this.extractOperations(openApi);
+
+			if (operations.length === 0) {
+				throw new OpenApiValidationError('No operations found in OpenAPI specification');
+			}
+
+			// Build result array
+			const result: Array<RouteDefinition | Rest> = [];
+
+			// Generate REST definition if requested
+			if (shouldGenerateRest) {
+				const restId = `rest-${Date.now()}`;
+				const rest = this.buildRestDefinition(operations, restId, sourceIdentifier);
+				result.push(rest);
+			}
+
+			// Generate route definitions if requested
+			if (shouldGenerateRoutes) {
+				const routes = this.buildRouteDefinitions(operations);
+				result.push(...routes);
+			}
+
+			return result;
+		} catch (error) {
+			if (error instanceof OpenApiParseError || error instanceof OpenApiValidationError) {
+				throw error;
+			}
+			throw new OpenApiParseError('Failed to process OpenAPI specification', error instanceof Error ? error : undefined);
+		}
+	}
+
+	/**
+	 * Parses and validates an OpenAPI specification string.
+	 *
+	 * @param openApiString - The OpenAPI specification as a YAML or JSON string
+	 * @returns The parsed OpenAPI specification object
+	 * @throws {OpenApiParseError} If parsing fails
+	 * @throws {OpenApiValidationError} If validation fails
+	 */
+	private parseOpenApiSpec(openApiString: string): OpenApi {
+		try {
+			const spec = parse(openApiString) as OpenApi;
+			this.validateOpenApiSpec(spec);
+			return spec;
+		} catch (error) {
+			if (error instanceof OpenApiValidationError) {
+				throw error;
+			}
+			throw new OpenApiParseError(`Failed to parse OpenAPI specification: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	/**
+	 * Validates an OpenAPI specification object.
+	 *
+	 * @param spec - The OpenAPI specification to validate
+	 * @throws {OpenApiValidationError} If validation fails
+	 */
+	private validateOpenApiSpec(spec: OpenApi): void {
+		if (!spec || typeof spec !== 'object') {
+			throw new OpenApiValidationError('Invalid OpenAPI specification: not an object');
+		}
+
+		if (!spec.openapi?.startsWith('3.')) {
+			throw new OpenApiValidationError('Invalid OpenAPI specification: only OpenAPI 3.x is supported');
+		}
+
+		if (!spec.paths || typeof spec.paths !== 'object') {
+			throw new OpenApiValidationError('Invalid OpenAPI specification: missing or invalid paths');
+		}
+
+		if (Object.keys(spec.paths).length === 0) {
+			throw new OpenApiValidationError('Invalid OpenAPI specification: no paths defined');
+		}
+	}
+
+	/**
+	 * Extracts operations from an OpenAPI specification.
+	 *
+	 * @param spec - The OpenAPI specification
+	 * @returns Array of parsed operations
+	 */
+	private extractOperations(spec: OpenApi): ParsedOperation[] {
+		const operations: ParsedOperation[] = [];
+		const paths = spec.paths;
+
+		for (const [pathKey, pathItem] of Object.entries(paths)) {
+			if (!pathItem || typeof pathItem !== 'object') {
+				continue;
+			}
+
+			// Get path-level parameters
+			const pathParameters = this.resolveParameters(pathItem.parameters);
+
+			for (const method of REST_DSL_VERBS) {
+				const operation = pathItem[method];
+				if (!operation) {
+					continue;
+				}
+
+				const operationId = operation.operationId ?? this.generateOperationId(method, pathKey);
+				const description = operation.description ?? operation.summary;
+
+				// Merge path-level and operation-level parameters
+				const operationParameters = this.resolveParameters(operation.parameters);
+				const allParameters = this.mergeParameters(pathParameters, operationParameters);
+				const mappedParameters = allParameters.map((param) => this.mapParameter(param));
+
+				// Extract media types from request body
+				const requestBody = this.resolveReference<OpenApiRequestBody>(operation.requestBody);
+				const consumes = requestBody?.content ? this.getMediaTypes(requestBody.content) : undefined;
+
+				// Extract media types from responses
+				const responses = this.resolveReference<OpenApiResponses>(operation.responses);
+				const produces = this.extractProducesFromResponses(responses);
+
+				// Map security requirements
+				const security = this.mapSecurityRequirements(operation.security);
+
+				// Map response messages
+				const responseMessages = this.mapResponseMessages(responses);
+
+				operations.push({
+					operationId,
+					method,
+					path: pathKey,
+					description,
+					deprecated: operation.deprecated,
+					consumes,
+					produces,
+					parameters: mappedParameters,
+					security,
+					responseMessages,
+				});
+			}
+		}
+
+		return operations;
+	}
+
+	/**
+	 * Generates a unique operation ID from method and path.
+	 *
+	 * @param method - HTTP method
+	 * @param path - API path
+	 * @returns Generated operation ID
+	 */
+	private generateOperationId(method: string, path: string): string {
+		return `${method}-${path}`.replaceAll(this.BRACES_REGEXP, '-').replaceAll(this.MULTIPLE_DASH_REGEXP, '-');
+	}
+
+	/**
+	 * Maps an OpenAPI parameter to Camel REST DSL parameter format.
+	 *
+	 * @param parameter - OpenAPI parameter
+	 * @returns Camel parameter object
+	 */
+	private mapParameter(parameter: OpenApiParameter): Param1 {
+		/* OpenApi parameter in: 'path' | 'query' | 'header' | 'cookie'; */
+		/* Camel rest parameter: 'body' | 'formData' | 'header' | 'path' | 'query'; */
+		const paramType: Type5 = parameter.in === 'cookie' ? 'header' : parameter.in;
+
+		const mapped: Param1 = {
+			name: parameter.name,
+			type: paramType,
+		};
+
+		if (parameter.required !== undefined) {
+			mapped.required = parameter.required;
+		}
+
+		if (parameter.description) {
+			mapped.description = parameter.description;
+		}
+
+		// Extract data type from schema
+		const schema = this.resolveReference<OpenApiSchema>(parameter.schema);
+		if (schema?.type) {
+			mapped.dataType = schema.type;
+		}
+
+		// Extract default value
+		if (schema && 'default' in schema) {
+			mapped.defaultValue = String(schema.default);
+		}
+
+		// Extract enum values as allowable values
+		if (schema?.enum && Array.isArray(schema.enum)) {
+			mapped.allowableValues = schema.enum.map((value) => ({ value: String(value) }));
+		}
+
+		return mapped;
+	}
+
+	/**
+	 * Merges path-level and operation-level parameters, with operation-level taking precedence.
+	 *
+	 * @param pathParams - Path-level parameters
+	 * @param operationParams - Operation-level parameters
+	 * @returns Merged parameters array
+	 */
+	private mergeParameters(pathParams: OpenApiParameter[], operationParams: OpenApiParameter[]): OpenApiParameter[] {
+		const merged = new Map<string, OpenApiParameter>();
+
+		// Add path-level parameters
+		for (const param of pathParams) {
+			const key = `${param.in}:${param.name}`;
+			merged.set(key, param);
+		}
+
+		// Override with operation-level parameters
+		for (const param of operationParams) {
+			const key = `${param.in}:${param.name}`;
+			merged.set(key, param);
+		}
+
+		return Array.from(merged.values());
+	}
+
+	/**
+	 * Maps OpenAPI security requirements to Camel REST DSL format.
+	 *
+	 * @param security - OpenAPI security requirements
+	 * @returns Array of Camel security objects
+	 */
+	private mapSecurityRequirements(security?: OpenApiSecurityRequirement[]): RestSecurity[] {
+		if (!security || !Array.isArray(security)) {
+			return [];
+		}
+
+		const mapped: RestSecurity[] = [];
+
+		for (const requirement of security) {
+			for (const [key, scopes] of Object.entries(requirement)) {
+				const securityItem: RestSecurity = { key };
+
+				if (scopes && scopes.length > 0) {
+					securityItem.scopes = scopes.join(',');
+				}
+
+				mapped.push(securityItem);
+			}
+		}
+
+		return mapped;
+	}
+
+	/**
+	 * Maps OpenAPI responses to Camel REST DSL response messages.
+	 *
+	 * @param responses - OpenAPI responses object
+	 * @returns Array of Camel response message objects
+	 */
+	private mapResponseMessages(responses: OpenApiResponses | undefined): ResponseMessage1[] {
+		if (!responses || typeof responses !== 'object') {
+			return [];
+		}
+
+		const mapped: ResponseMessage1[] = [];
+
+		for (const [statusCode, response] of Object.entries(responses)) {
+			if (statusCode === 'default') {
+				continue;
+			}
+
+			const resolvedResponse = this.resolveReference<OpenApiResponse>(response);
+			if (!resolvedResponse) {
+				continue;
+			}
+
+			const message: ResponseMessage1 = {
+				code: statusCode,
+				message: resolvedResponse.description || `Response ${statusCode}`,
+			};
+
+			// Extract content type
+			if (resolvedResponse.content) {
+				const contentTypes = Object.keys(resolvedResponse.content);
+				if (contentTypes.length > 0) {
+					message.contentType = contentTypes.join(',');
+				}
+			}
+
+			// Map headers
+			if (resolvedResponse.headers) {
+				message.header = this.mapResponseHeaders(resolvedResponse.headers);
+			}
+
+			mapped.push(message);
+		}
+
+		return mapped;
+	}
+
+	/**
+	 * Maps OpenAPI response headers to Camel REST DSL format.
+	 *
+	 * @param headers - OpenAPI response headers
+	 * @returns Array of Camel response header objects
+	 */
+	private mapResponseHeaders(headers: OpenApiMap<OpenApiHeader | OpenApiReference>): ResponseHeader[] {
+		const mapped: ResponseHeader[] = [];
+
+		for (const [name, header] of Object.entries(headers)) {
+			const resolvedHeader = this.resolveReference<OpenApiHeader>(header);
+			if (!resolvedHeader) {
+				continue;
+			}
+
+			const mappedHeader: ResponseHeader = { name };
+
+			if (resolvedHeader.description) {
+				mappedHeader.description = resolvedHeader.description;
+			}
+
+			const schema = this.resolveReference<OpenApiSchema>(resolvedHeader.schema);
+			if (schema?.type) {
+				mappedHeader.dataType = schema.type;
+			}
+
+			if (schema?.enum && Array.isArray(schema.enum)) {
+				mappedHeader.allowableValues = schema.enum.map((value) => ({ value: String(value) }));
+			}
+
+			mapped.push(mappedHeader);
+		}
+
+		return mapped;
+	}
+
+	/**
+	 * Builds a Camel REST definition from parsed operations.
+	 *
+	 * @param operations - Array of parsed operations
+	 * @param restId - Unique identifier for the REST definition
+	 * @param sourceIdentifier - Optional source identifier for the OpenAPI spec
+	 * @returns Camel REST definition
+	 */
+	private buildRestDefinition(operations: ParsedOperation[], restId: string, sourceIdentifier?: string): Rest {
+		const rest: Rest = { id: restId };
+
+		// Add OpenAPI specification reference if provided
+		if (sourceIdentifier?.trim()) {
+			rest.openApi = { specification: sourceIdentifier.trim() };
+		}
+
+		// Group operations by HTTP method
+		for (const operation of operations) {
+			const methodKey = operation.method;
+			const methodArray = (rest[methodKey] as RestMethodDefinitions[]) ?? [];
+
+			const operationDef: Partial<RestMethodDefinitions> = {
+				id: operation.operationId,
+				path: operation.path,
+				routeId: `route-${operation.operationId}`,
+				to: `direct:${operation.operationId}`,
+			};
+
+			if (operation.description?.trim()) {
+				operationDef.description = operation.description;
+			}
+
+			if (operation.consumes?.trim()) {
+				operationDef.consumes = operation.consumes;
+			}
+
+			if (operation.produces?.trim()) {
+				operationDef.produces = operation.produces;
+			}
+
+			if (operation.parameters.length > 0) {
+				operationDef.param = operation.parameters;
+			}
+
+			if (operation.responseMessages.length > 0) {
+				operationDef.responseMessage = operation.responseMessages;
+			}
+
+			if (operation.security.length > 0) {
+				operationDef.security = operation.security;
+			}
+
+			if (operation.deprecated !== undefined) {
+				operationDef.deprecated = operation.deprecated;
+			}
+
+			methodArray.push(operationDef as RestMethodDefinitions);
+			(rest as any)[methodKey] = methodArray;
+		}
+
+		return rest;
+	}
+
+	/**
+	 * Builds Camel RouteDefinition entities from parsed operations.
+	 *
+	 * @param operations - Array of parsed operations
+	 * @returns Array of Camel RouteDefinition entities
+	 */
+	private buildRouteDefinitions(operations: ParsedOperation[]): RouteDefinition[] {
+		return operations.map((operation) => {
+			const from: FromDefinition = {
+				uri: `direct:${operation.operationId}`,
+				id: `direct-from-${operation.operationId}`,
+				steps: [
+					{
+						setBody: {
+							constant: `Operation ${operation.operationId} not yet implemented`,
+						},
+					} as ProcessorDefinition,
+				],
+			};
+
+			const route: RouteDefinition = {
+				id: `route-${operation.operationId}`,
+				from,
+			};
+
+			return route;
+		});
+	}
+
+	/**
+	 * Resolves an OpenAPI reference or returns the item as-is.
+	 * Supports internal references only (e.g., #/components/schemas/Pet).
+	 *
+	 * @param item - Item that may be a reference
+	 * @returns Resolved item or undefined
+	 */
+	private resolveReference<T>(item: T | OpenApiReference | undefined): T | undefined {
+		if (!item) {
+			return undefined;
+		}
+
+		// Check if it's a reference object
+		if (typeof item === 'object' && '$ref' in item) {
+			const ref = item.$ref;
+
+			// Only support internal references
+			if (!ref?.startsWith('#/')) {
+				console.warn('External references are not supported:', ref);
+				return undefined;
+			}
+
+			// Check cache first to prevent infinite loops
+			if (this.referenceCache.has(ref)) {
+				return this.referenceCache.get(ref) as T;
+			}
+
+			// Parse the reference path
+			const resolved = this.resolveInternalReference<T>(ref);
+
+			// Cache the result (even if undefined to prevent repeated lookups)
+			this.referenceCache.set(ref, resolved);
+
+			return resolved;
+		}
+
+		return item as T;
+	}
+
+	/**
+	 * Resolves an internal OpenAPI reference by navigating the spec object.
+	 *
+	 * @param ref - Reference path (e.g., "#/components/schemas/Pet")
+	 * @returns Resolved value or undefined if not found
+	 */
+	private resolveInternalReference<T>(ref: string): T | undefined {
+		if (!this.currentSpec) {
+			console.warn('Cannot resolve reference: no spec loaded');
+			return undefined;
+		}
+
+		// Remove leading '#/' and split path
+		const path = ref.replace(/^#\//, '').split('/');
+
+		// Navigate the spec object
+		let current: any = this.currentSpec;
+		for (const segment of path) {
+			if (current === null || current === undefined || typeof current !== 'object') {
+				console.warn(`Reference resolution failed at segment "${segment}" in path: ${ref}`);
+				return undefined;
+			}
+
+			// Decode URI-encoded segments (e.g., "~1" -> "/", "~0" -> "~")
+			const decodedSegment = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+			current = current[decodedSegment];
+		}
+
+		return current as T;
+	}
+
+	/**
+	 * Resolves an array of parameters that may contain references.
+	 *
+	 * @param parameters - Array of parameters or references
+	 * @returns Array of resolved parameters
+	 */
+	private resolveParameters(parameters?: (OpenApiParameter | OpenApiReference)[]): OpenApiParameter[] {
+		if (!parameters || !Array.isArray(parameters)) {
+			return [];
+		}
+
+		return parameters.map((param) => this.resolveReference<OpenApiParameter>(param)).filter((param): param is OpenApiParameter => param !== undefined);
+	}
+
+	/**
+	 * Extracts media types from OpenAPI content object.
+	 *
+	 * @param content - OpenAPI content object
+	 * @returns Comma-separated media types
+	 */
+	private getMediaTypes(content: OpenApiMap<OpenApiMediaType>): string {
+		return Object.keys(content).join(',');
+	}
+
+	/**
+	 * Extracts produces media types from OpenAPI responses.
+	 *
+	 * @param responses - OpenAPI responses object
+	 * @returns Comma-separated media types or undefined
+	 */
+	private extractProducesFromResponses(responses: OpenApiResponses | undefined): string | undefined {
+		if (!responses) {
+			return undefined;
+		}
+
+		const mediaTypes = new Set<string>();
+
+		for (const response of Object.values(responses)) {
+			const resolvedResponse = this.resolveReference<OpenApiResponse>(response);
+			if (resolvedResponse?.content) {
+				for (const mediaType of Object.keys(resolvedResponse.content)) {
+					mediaTypes.add(mediaType);
+				}
+			}
+		}
+
+		return mediaTypes.size > 0 ? Array.from(mediaTypes).join(',') : undefined;
+	}
+}

--- a/src/test/openapi-import.service.test.ts
+++ b/src/test/openapi-import.service.test.ts
@@ -1,0 +1,1044 @@
+import type { Get, Rest, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { expect } from 'chai';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { OpenApiImportService, OpenApiParseError, OpenApiValidationError } from '../services/openapi-import.service';
+
+suite('OpenApiImportService', function () {
+	let service: OpenApiImportService;
+
+	setup(function () {
+		service = new OpenApiImportService();
+	});
+
+	suite('parseOpenApi - validation', function () {
+		test('should throw error for empty string', async function () {
+			try {
+				await service.parseOpenApi('');
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+				expect((error as Error).message).to.include('OpenAPI specification string cannot be empty');
+			}
+		});
+
+		test('should throw error for whitespace-only string', async function () {
+			try {
+				await service.parseOpenApi('   ');
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+			}
+		});
+
+		test('should throw error for invalid YAML', async function () {
+			const invalidYaml = 'invalid: yaml: content: [unclosed';
+			try {
+				await service.parseOpenApi(invalidYaml);
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiParseError);
+			}
+		});
+
+		test('should throw error for non-OpenAPI 3.x spec', async function () {
+			const swagger2Spec = `
+swagger: "2.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      summary: Test
+`;
+			try {
+				await service.parseOpenApi(swagger2Spec);
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+				expect((error as Error).message).to.include('only OpenAPI 3.x is supported');
+			}
+		});
+
+		test('should throw error when paths are missing', async function () {
+			const specWithoutPaths = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+`;
+			try {
+				await service.parseOpenApi(specWithoutPaths);
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+				expect((error as Error).message).to.include('missing or invalid paths');
+			}
+		});
+
+		test('should throw error when paths are empty', async function () {
+			const specWithEmptyPaths = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+`;
+			try {
+				await service.parseOpenApi(specWithEmptyPaths);
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+				expect((error as Error).message).to.include('no paths defined');
+			}
+		});
+
+		test('should throw error when both generation options are false', async function () {
+			const validSpec = createMinimalValidSpec();
+			try {
+				await service.parseOpenApi(validSpec, {
+					shouldGenerateRest: false,
+					shouldGenerateRoutes: false,
+				});
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error).to.be.instanceOf(OpenApiValidationError);
+				expect((error as Error).message).to.include('At least one of shouldGenerateRest or shouldGenerateRoutes must be true');
+			}
+		});
+	});
+
+	suite('parseOpenApi - REST generation', function () {
+		test('should generate REST definition when shouldGenerateRest is true', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			expect(result).to.have.length(1);
+			const restDef = result[0] as Rest;
+			expect(restDef.id).to.not.be.undefined;
+			expect(restDef.get).to.not.be.undefined;
+			expect(restDef.get).to.have.length(1);
+		});
+
+		test('should include sourceIdentifier in REST definition', async function () {
+			const spec = createMinimalValidSpec();
+			const sourceId = 'file:///path/to/openapi.yaml';
+			const result = await service.parseOpenApi(spec, {
+				shouldGenerateRest: true,
+				shouldGenerateRoutes: false,
+				sourceIdentifier: sourceId,
+			});
+
+			const restDef = result[0] as Rest;
+			expect(restDef.openApi?.specification).to.equal(sourceId);
+		});
+
+		test('should not include empty sourceIdentifier', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, {
+				shouldGenerateRest: true,
+				shouldGenerateRoutes: false,
+				sourceIdentifier: '   ',
+			});
+
+			const restDef = result[0] as Rest;
+			expect(restDef.openApi).to.be.undefined;
+		});
+
+		test('should generate REST operations for all HTTP methods', async function () {
+			const spec = createSpecWithAllMethods();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			expect(restDef.get).to.not.be.undefined;
+			expect(restDef.post).to.not.be.undefined;
+			expect(restDef.put).to.not.be.undefined;
+			expect(restDef.delete).to.not.be.undefined;
+			expect(restDef.patch).to.not.be.undefined;
+			expect(restDef.head).to.not.be.undefined;
+		});
+
+		test('should include operation details in REST definition', async function () {
+			const spec = createSpecWithOperationDetails();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.id).to.equal('getUsers');
+			expect(getOp?.path).to.equal('/users');
+			expect(getOp?.description).to.equal('Get all users');
+			expect(getOp?.routeId).to.equal('route-getUsers');
+			expect(getOp?.to).to.equal('direct:getUsers');
+		});
+
+		test('should include parameters in REST operation', async function () {
+			const spec = createSpecWithParameters();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.param).to.not.be.undefined;
+			expect(getOp?.param?.length).to.be.greaterThan(0);
+			expect(getOp?.param?.[0].name).to.equal('limit');
+			expect(getOp?.param?.[0].type).to.equal('query');
+		});
+
+		test('should include security requirements in REST operation', async function () {
+			const spec = createSpecWithSecurity();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.security).to.not.be.undefined;
+			expect(getOp?.security?.length).to.be.greaterThan(0);
+		});
+
+		test('should include response messages in REST operation', async function () {
+			const spec = createSpecWithResponses();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.responseMessage).to.not.be.undefined;
+			expect(getOp?.responseMessage?.length).to.be.greaterThan(0);
+		});
+
+		test('should mark deprecated operations', async function () {
+			const spec = createSpecWithDeprecatedOperation();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.deprecated).to.equal(true);
+		});
+	});
+
+	suite('parseOpenApi - Route generation', function () {
+		test('should generate route definitions when shouldGenerateRoutes is true', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			expect(result.length).to.be.greaterThan(0);
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.id).to.not.be.undefined;
+			expect(routeDef.from).to.not.be.undefined;
+		});
+
+		test('should generate route with correct ID pattern', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.id).to.match(/^route-/);
+		});
+
+		test('should generate route with direct endpoint', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.from.uri).to.match(/^direct:/);
+		});
+
+		test('should generate route with default implementation', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.from.steps).to.not.be.undefined;
+			expect(routeDef.from.steps.length).to.be.greaterThan(0);
+			const setBodyStep = routeDef.from.steps[0] as any;
+			expect(setBodyStep.setBody).to.not.be.undefined;
+			expect(setBodyStep.setBody.constant).to.include('not yet implemented');
+		});
+
+		test('should generate one route per operation', async function () {
+			const spec = createSpecWithMultipleOperations();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			expect(result.length).to.equal(3); // 3 operations
+			result.forEach((item) => {
+				const routeDef = item as RouteDefinition;
+				expect(routeDef.from).to.not.be.undefined;
+			});
+		});
+	});
+
+	suite('parseOpenApi - Combined generation', function () {
+		test('should generate both REST and routes when both options are true', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, {
+				shouldGenerateRest: true,
+				shouldGenerateRoutes: true,
+			});
+
+			expect(result.length).to.be.greaterThan(1);
+			const restDef = result.find((item) => 'get' in item || 'post' in item);
+			const routeDef = result.find((item) => 'from' in item);
+
+			expect(restDef).to.not.be.undefined;
+			expect(routeDef).to.not.be.undefined;
+		});
+
+		test('should generate REST first, then routes', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, {
+				shouldGenerateRest: true,
+				shouldGenerateRoutes: true,
+			});
+
+			// First item should be REST definition
+			expect('get' in result[0] || 'post' in result[0]).to.equal(true);
+			// Remaining items should be routes
+			for (let i = 1; i < result.length; i++) {
+				expect('from' in result[i]).to.equal(true);
+			}
+		});
+	});
+
+	suite('parseOpenApi - Operation ID generation', function () {
+		test('should use operationId from spec when available', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.id).to.equal('route-getUsers');
+		});
+
+		test('should generate operationId when not provided', async function () {
+			const spec = createSpecWithoutOperationId();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.id).to.match(/^route-get-users$/);
+		});
+
+		test('should sanitize path in generated operationId', async function () {
+			const spec = createSpecWithComplexPath();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRoutes: true });
+
+			const routeDef = result[0] as RouteDefinition;
+			expect(routeDef.id).to.match(/^route-get-users-id-posts$/);
+		});
+	});
+
+	suite('parseOpenApi - Media types', function () {
+		test('should extract consumes from request body', async function () {
+			const spec = createSpecWithRequestBody();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const postOp = restDef.post?.[0];
+			expect(postOp?.consumes).to.not.be.undefined;
+			expect(postOp?.consumes).to.include('application/json');
+		});
+
+		test('should extract produces from responses', async function () {
+			const spec = createSpecWithResponses();
+			const result = await service.parseOpenApi(spec, { shouldGenerateRest: true, shouldGenerateRoutes: false });
+
+			const restDef = result[0] as Rest;
+			const getOp = restDef.get?.[0];
+			expect(getOp?.produces).to.not.be.undefined;
+			expect(getOp?.produces).to.include('application/json');
+		});
+	});
+
+	suite('parseOpenApi - Default options', function () {
+		test('should use default options when not provided', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec);
+
+			// Default: shouldGenerateRoutes = true, shouldGenerateRest = false
+			expect(result.length).to.be.greaterThan(0);
+			expect('from' in result[0]).to.equal(true);
+		});
+
+		test('should not generate REST by default', async function () {
+			const spec = createMinimalValidSpec();
+			const result = await service.parseOpenApi(spec);
+
+			const hasRest = result.some((item) => 'get' in item || 'post' in item);
+			expect(hasRest).to.equal(false);
+		});
+	});
+});
+
+suite('OpenAPI $ref Resolution', function () {
+	let service: OpenApiImportService;
+
+	setup(function () {
+		service = new OpenApiImportService();
+	});
+
+	test('should resolve schema references in parameters', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{userId}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/UserId'
+      responses:
+        '200':
+          description: Success
+components:
+  schemas:
+    UserId:
+      type: string
+      pattern: '^[0-9]+$'
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].param).to.not.be.undefined;
+		expect(rest.get![0].param![0].dataType).to.equal('string');
+	});
+
+	test('should resolve schema references in request bodies', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    post:
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.post).to.not.be.undefined;
+		expect(rest.post![0].consumes).to.equal('application/json');
+	});
+
+	test('should resolve response references', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          $ref: '#/components/responses/UserListResponse'
+components:
+  responses:
+    UserListResponse:
+      description: List of users
+      content:
+        application/json:
+          schema:
+            type: array
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].responseMessage).to.not.be.undefined;
+		expect(rest.get![0].responseMessage![0].message).to.equal('List of users');
+	});
+
+	test('should resolve parameter references', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: Success
+components:
+  parameters:
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        default: 10
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].param).to.not.be.undefined;
+		expect(rest.get![0].param![0].name).to.equal('limit');
+		expect(rest.get![0].param![0].dataType).to.equal('integer');
+		expect(rest.get![0].param![0].defaultValue).to.equal('10');
+	});
+
+	test('should resolve nested schema references', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    post:
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequest'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    UserRequest:
+      type: object
+      properties:
+        profile:
+          $ref: '#/components/schemas/Profile'
+    Profile:
+      type: object
+      properties:
+        name:
+          type: string
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.post).to.not.be.undefined;
+		expect(rest.post![0].consumes).to.equal('application/json');
+	});
+
+	test('should handle circular references without infinite loops', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /nodes:
+    get:
+      operationId: getNodes
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+components:
+  schemas:
+    Node:
+      type: object
+      properties:
+        id:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].produces).to.equal('application/json');
+	});
+
+	test('should handle missing references gracefully', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - $ref: '#/components/parameters/NonExistent'
+      responses:
+        '200':
+          description: Success
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		// Missing reference should be filtered out
+		expect(rest.get![0].param).to.be.undefined;
+	});
+
+	test('should not support external references', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - $ref: './external.yaml#/components/parameters/UserId'
+      responses:
+        '200':
+          description: Success
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		// External reference should be filtered out
+		expect(rest.get![0].param).to.be.undefined;
+	});
+
+	test('should resolve header references in responses', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+          headers:
+            X-Rate-Limit:
+              $ref: '#/components/headers/RateLimit'
+components:
+  headers:
+    RateLimit:
+      description: Rate limit remaining
+      schema:
+        type: integer
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].responseMessage).to.not.be.undefined;
+		expect(rest.get![0].responseMessage![0].header).to.not.be.undefined;
+		expect(rest.get![0].responseMessage![0].header![0].name).to.equal('X-Rate-Limit');
+		expect(rest.get![0].responseMessage![0].header![0].dataType).to.equal('integer');
+	});
+
+	test('should handle URI-encoded reference paths', async function () {
+		const spec = `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - $ref: '#/components/parameters/user~1id'
+      responses:
+        '200':
+          description: Success
+components:
+  parameters:
+    user/id:
+      name: userId
+      in: query
+      schema:
+        type: string
+`;
+
+		const result = await service.parseOpenApi(spec, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: false,
+		});
+
+		expect(result).to.have.length(1);
+		const rest = result[0] as Rest;
+		expect(rest.get).to.not.be.undefined;
+		expect(rest.get![0].param).to.not.be.undefined;
+		expect(rest.get![0].param![0].name).to.equal('userId');
+	});
+});
+
+suite('Pet Store OpenAPI Integration', function () {
+	let service: OpenApiImportService;
+
+	setup(function () {
+		service = new OpenApiImportService();
+	});
+
+	test('should parse pet-store.openapi.json and generate REST DSL + Routes', async function () {
+		const petStoreJson = await fs.readFile(path.join(__dirname, '../../../src/test/stubs', 'pet-store.openapi.json'), 'utf-8');
+
+		const result = await service.parseOpenApi(petStoreJson, {
+			shouldGenerateRest: true,
+			shouldGenerateRoutes: true,
+		});
+
+		const restDef = result.find((item) => 'get' in item || 'post' in item) as Rest;
+		const routes = result.filter((item) => 'from' in item);
+
+		expect(restDef).to.not.be.undefined;
+		expect(routes).to.have.length.greaterThan(0);
+
+		expect(restDef.get).to.not.be.undefined;
+		expect(restDef.post).to.not.be.undefined;
+		expect(restDef.put).to.not.be.undefined;
+		expect(restDef.delete).to.not.be.undefined;
+
+		const totalOperations =
+			(restDef.get?.length || 0) +
+			(restDef.post?.length || 0) +
+			(restDef.put?.length || 0) +
+			(restDef.delete?.length || 0) +
+			(restDef.patch?.length || 0) +
+			(restDef.head?.length || 0);
+
+		expect(totalOperations).to.equal(routes.length);
+
+		// 8. Validate specific endpoints
+		const getPetById = restDef.get?.find((op: Get) => op.path === '/pet/{petId}');
+		expect(getPetById).to.not.be.undefined;
+		expect(getPetById?.id).to.equal('getPetById');
+		expect(getPetById?.param).to.have.length(1);
+		expect(getPetById?.param?.[0].name).to.equal('petId');
+	});
+});
+
+// Helper functions to create test fixtures
+
+function createMinimalValidSpec(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      summary: Get all users
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithAllMethods(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+    post:
+      operationId: createUser
+      responses:
+        '201':
+          description: Created
+    put:
+      operationId: updateUser
+      responses:
+        '200':
+          description: Success
+    delete:
+      operationId: deleteUser
+      responses:
+        '204':
+          description: No Content
+    patch:
+      operationId: patchUser
+      responses:
+        '200':
+          description: Success
+    head:
+      operationId: headUsers
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithOperationDetails(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      summary: Get all users
+      description: Get all users
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithParameters(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of results
+          required: false
+          schema:
+            type: integer
+            default: 10
+        - name: offset
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithSecurity(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+`;
+}
+
+function createSpecWithResponses(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+        '404':
+          description: Not Found
+`;
+}
+
+function createSpecWithDeprecatedOperation(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      deprecated: true
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithoutOperationId(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: Get all users
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithComplexPath(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{id}/posts:
+    get:
+      summary: Get user posts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+`;
+}
+
+function createSpecWithRequestBody(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    post:
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '201':
+          description: Created
+`;
+}
+
+function createSpecWithMultipleOperations(): string {
+	return `
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+    post:
+      operationId: createUser
+      responses:
+        '201':
+          description: Created
+  /posts:
+    get:
+      operationId: getPosts
+      responses:
+        '200':
+          description: Success
+`;
+}

--- a/src/test/stubs/pet-store.openapi.json
+++ b/src/test/stubs/pet-store.openapi.json
@@ -1,0 +1,542 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [https://swagger.io](https://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "https://swagger.io/terms/",
+    "contact": { "email": "apiteam@swagger.io" },
+    "license": { "name": "Apache 2.0", "url": "https://www.apache.org/licenses/LICENSE-2.0.html" },
+    "version": "1.0.27"
+  },
+  "externalDocs": { "description": "Find out more about Swagger", "url": "https://swagger.io" },
+  "servers": [{ "url": "/api/v3" }],
+  "tags": [
+    { "name": "pet", "description": "Everything about your Pets", "externalDocs": { "description": "Find out more", "url": "https://swagger.io" } },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": { "description": "Find out more about our store", "url": "https://swagger.io" }
+    },
+    { "name": "user", "description": "Operations about user" }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet.",
+        "description": "Update an existing pet by Id.",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+            "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } },
+            "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/Pet" } }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" },
+          "422": { "description": "Validation exception" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store.",
+        "description": "Add a new pet to the store.",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+            "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } },
+            "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/Pet" } }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          },
+          "400": { "description": "Invalid input" },
+          "422": { "description": "Validation exception" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status.",
+        "description": "Multiple status values can be provided with comma separated strings.",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": { "type": "string", "default": "available", "enum": ["available", "pending", "sold"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } },
+              "application/xml": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } }
+            }
+          },
+          "400": { "description": "Invalid status value" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags.",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "explode": true,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } },
+              "application/xml": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } }
+            }
+          },
+          "400": { "description": "Invalid tag value" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID.",
+        "description": "Returns a single pet.",
+        "operationId": "getPetById",
+        "parameters": [
+          { "name": "petId", "in": "path", "description": "ID of pet to return", "required": true, "schema": { "type": "integer", "format": "int64" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "api_key": [] }, { "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data.",
+        "description": "Updates a pet resource based on the form data.",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          { "name": "name", "in": "query", "description": "Name of pet that needs to be updated", "schema": { "type": "string" } },
+          { "name": "status", "in": "query", "description": "Status of pet that needs to be updated", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          },
+          "400": { "description": "Invalid input" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet.",
+        "description": "Delete a pet.",
+        "operationId": "deletePet",
+        "parameters": [
+          { "name": "api_key", "in": "header", "description": "", "required": false, "schema": { "type": "string" } },
+          { "name": "petId", "in": "path", "description": "Pet id to delete", "required": true, "schema": { "type": "integer", "format": "int64" } }
+        ],
+        "responses": {
+          "200": { "description": "Pet deleted" },
+          "400": { "description": "Invalid pet value" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "Uploads an image.",
+        "description": "Upload image of the pet.",
+        "operationId": "uploadFile",
+        "parameters": [
+          { "name": "petId", "in": "path", "description": "ID of pet to update", "required": true, "schema": { "type": "integer", "format": "int64" } },
+          { "name": "additionalMetadata", "in": "query", "description": "Additional Metadata", "required": false, "schema": { "type": "string" } }
+        ],
+        "requestBody": { "content": { "application/octet-stream": { "schema": { "type": "string", "format": "binary" } } } },
+        "responses": {
+          "200": { "description": "successful operation", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ApiResponse" } } } },
+          "400": { "description": "No file uploaded" },
+          "404": { "description": "Pet not found" },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status.",
+        "description": "Returns a map of status codes to quantities.",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": { "application/json": { "schema": { "type": "object", "additionalProperties": { "type": "integer", "format": "int32" } } } }
+          },
+          "default": { "description": "Unexpected error" }
+        },
+        "security": [{ "api_key": [] }]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet.",
+        "description": "Place a new order in the store.",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Order" } },
+            "application/xml": { "schema": { "$ref": "#/components/schemas/Order" } },
+            "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/Order" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "successful operation", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Order" } } } },
+          "400": { "description": "Invalid input" },
+          "422": { "description": "Validation exception" },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID.",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Order" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Order" } }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Order not found" },
+          "default": { "description": "Unexpected error" }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by identifier.",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or non-integers will generate API errors.",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "order deleted" },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Order not found" },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user.",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/User" } },
+            "application/xml": { "schema": { "$ref": "#/components/schemas/User" } },
+            "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/User" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/User" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/User" } }
+            }
+          },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array.",
+        "description": "Creates list of users with given input array.",
+        "operationId": "createUsersWithListInput",
+        "requestBody": { "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/User" } } } } },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/User" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/User" } }
+            }
+          },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system.",
+        "description": "Log into the system.",
+        "operationId": "loginUser",
+        "parameters": [
+          { "name": "username", "in": "query", "description": "The user name for login", "required": false, "schema": { "type": "string" } },
+          { "name": "password", "in": "query", "description": "The password for login in clear text", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": { "description": "calls per hour allowed by the user", "schema": { "type": "integer", "format": "int32" } },
+              "X-Expires-After": { "description": "date in UTC when token expires", "schema": { "type": "string", "format": "date-time" } }
+            },
+            "content": { "application/xml": { "schema": { "type": "string" } }, "application/json": { "schema": { "type": "string" } } }
+          },
+          "400": { "description": "Invalid username/password supplied" },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session.",
+        "description": "Log user out of the system.",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": { "200": { "description": "successful operation" }, "default": { "description": "Unexpected error" } }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name.",
+        "description": "Get user detail based on username.",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/User" } },
+              "application/xml": { "schema": { "$ref": "#/components/schemas/User" } }
+            }
+          },
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" },
+          "default": { "description": "Unexpected error" }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Update user resource.",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [{ "name": "username", "in": "path", "description": "name that need to be deleted", "required": true, "schema": { "type": "string" } }],
+        "requestBody": {
+          "description": "Update an existent user in the store",
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/User" } },
+            "application/xml": { "schema": { "$ref": "#/components/schemas/User" } },
+            "application/x-www-form-urlencoded": { "schema": { "$ref": "#/components/schemas/User" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "successful operation" },
+          "400": { "description": "bad request" },
+          "404": { "description": "user not found" },
+          "default": { "description": "Unexpected error" }
+        }
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user resource.",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          { "name": "username", "in": "path", "description": "The name that needs to be deleted", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "User deleted" },
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" },
+          "default": { "description": "Unexpected error" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "petId": { "type": "integer", "format": "int64", "example": 198772 },
+          "quantity": { "type": "integer", "format": "int32", "example": 7 },
+          "shipDate": { "type": "string", "format": "date-time" },
+          "status": { "type": "string", "description": "Order Status", "example": "approved", "enum": ["placed", "approved", "delivered"] },
+          "complete": { "type": "boolean" }
+        },
+        "xml": { "name": "order" }
+      },
+      "Category": {
+        "type": "object",
+        "properties": { "id": { "type": "integer", "format": "int64", "example": 1 }, "name": { "type": "string", "example": "Dogs" } },
+        "xml": { "name": "category" }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "username": { "type": "string", "example": "theUser" },
+          "firstName": { "type": "string", "example": "John" },
+          "lastName": { "type": "string", "example": "James" },
+          "email": { "type": "string", "example": "john@email.com" },
+          "password": { "type": "string", "example": "12345" },
+          "phone": { "type": "string", "example": "12345" },
+          "userStatus": { "type": "integer", "description": "User Status", "format": "int32", "example": 1 }
+        },
+        "xml": { "name": "user" }
+      },
+      "Tag": { "type": "object", "properties": { "id": { "type": "integer", "format": "int64" }, "name": { "type": "string" } }, "xml": { "name": "tag" } },
+      "Pet": {
+        "required": ["name", "photoUrls"],
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "name": { "type": "string", "example": "doggie" },
+          "category": { "$ref": "#/components/schemas/Category" },
+          "photoUrls": { "type": "array", "xml": { "wrapped": true }, "items": { "type": "string", "xml": { "name": "photoUrl" } } },
+          "tags": { "type": "array", "xml": { "wrapped": true }, "items": { "$ref": "#/components/schemas/Tag" } },
+          "status": { "type": "string", "description": "pet status in the store", "enum": ["available", "pending", "sold"] }
+        },
+        "xml": { "name": "pet" }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": { "code": { "type": "integer", "format": "int32" }, "type": { "type": "string" }, "message": { "type": "string" } },
+        "xml": { "name": "##default" }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } },
+          "application/xml": { "schema": { "$ref": "#/components/schemas/Pet" } }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/User" } } } }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": { "write:pets": "modify pets in your account", "read:pets": "read your pets" }
+          }
+        }
+      },
+      "api_key": { "type": "apiKey", "name": "api_key", "in": "header" }
+    }
+  }
+}

--- a/tsconfig.unit-tests.json
+++ b/tsconfig.unit-tests.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "module": "CommonJS",
     "moduleResolution": "Node",
+    "paths": {
+      "@kaoto/camel-catalog/types": ["./node_modules/@kaoto/camel-catalog/dist/types/index.ts"]
+    },
     "strict": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,7 @@ const commonConfig = (env) => {
 			new CopyPlugin({
 				patterns: [
 					{
-						from: 'node_modules/@kaoto/kaoto/lib/camel-catalog',
+						from: 'node_modules/@kaoto/camel-catalog/dist/camel-catalog',
 						to: 'webview/editors/kaoto/camel-catalog',
 					},
 				],

--- a/yarn.lock
+++ b/yarn.lock
@@ -556,6 +556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kaoto/camel-catalog@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@kaoto/camel-catalog@npm:0.4.0"
+  checksum: 10/ded19bf56618c8ff3edc16f4193d72ff2dcd17db73c5dd020eee1e252f28b73bd09631bd68a918a73668874a1bbb36747a42bff6517bb60f7816b1af031ab330
+  languageName: node
+  linkType: hard
+
 "@kaoto/forms@npm:^1.6.0":
   version: 1.6.0
   resolution: "@kaoto/forms@npm:1.6.0"
@@ -2162,6 +2169,13 @@ __metadata:
   version: 2.4.4
   resolution: "@types/normalize-package-data@npm:2.4.4"
   checksum: 10/65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
+  languageName: node
+  linkType: hard
+
+"@types/openapi-v3@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/openapi-v3@npm:3.0.0"
+  checksum: 10/a793fb3edfa511bfd3f370ebcc813277cd5e7b886c60a45bbd9777c78620bd47cc651f38e22f952a97d91a8920af46917755a131a3907091c8df7e2e89b1617a
   languageName: node
   linkType: hard
 
@@ -13038,6 +13052,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vscode-kaoto@workspace:."
   dependencies:
+    "@kaoto/camel-catalog": "npm:^0.4.0"
     "@kaoto/kaoto": "npm:2.10.0-RC2"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"
@@ -13055,6 +13070,7 @@ __metadata:
     "@types/chai": "npm:^4.3.20"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/mocha": "npm:^10.0.10"
+    "@types/openapi-v3": "npm:^3.0.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/vscode": "npm:^1.100.0"


### PR DESCRIPTION
### Context
This service is meant to translate a `OpenAPI` schema into a `Rest DSL` definition and `Camel Routes`.

There's an existing import logic in `@kaoto/kaoto` to import such schemas, but the issue is that is tied to `react` and it doesn't consider `$ref` definitions. This service will first be used in VS Code Kaoto and then migrated to @kaoto/kaoto to replace the existing service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for importing OpenAPI v3 specifications (YAML/JSON format) and automatically converting them to Apache Camel REST definitions and routes.

* **Tests**
  * Introduced comprehensive test coverage for OpenAPI import functionality, including validation, REST generation, route generation, and reference resolution scenarios.

* **Chores**
  * Updated build configuration and added required dependencies to support OpenAPI v3 parsing and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->