### PR TITLE
feat: add Canvas Layout Direction user setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1055,6 +1055,16 @@
               "light",
               "dark"
             ]
+          },
+          "kaoto.canvasLayoutDirection": {
+            "type": "string",
+            "markdownDescription": "Choose the layout direction for the canvas. `SelectInCanvas` will allow to select nodes in the canvas, `Horizontal` and `Vertical` will set the layout direction. It requires to reopen the Kaoto editors to be effective.",
+            "default": "SelectInCanvas",
+            "enum": [
+              "SelectInCanvas",
+              "Horizontal",
+              "Vertical"
+            ]
           }
         }
       },

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -1,5 +1,5 @@
 import { CatalogKind, KaotoEditorChannelApi, RuntimeMavenInformation, StepUpdateAction, Suggestion, SuggestionRequestContext } from '@kaoto/kaoto';
-import { ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger, SettingsModel } from '@kaoto/kaoto/models';
+import { CanvasLayoutDirection, ColorScheme, ISettingsModel, NodeLabelType, NodeToolbarTrigger, SettingsModel } from '@kaoto/kaoto/models';
 import { BackendProxy } from '@kie-tools-core/backend/dist/api';
 import { I18n } from '@kie-tools-core/i18n/dist/core';
 import { DefaultVsCodeKieEditorChannelApiImpl } from '@kie-tools-core/vscode-extension/dist/DefaultVsCodeKieEditorChannelApiImpl';
@@ -50,6 +50,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 		const nodeLabel = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeLabelType | null>>('nodeLabel');
 		const nodeToolbarTrigger = await vscode.workspace.getConfiguration('kaoto').get<Promise<NodeToolbarTrigger | null>>('nodeToolbarTrigger');
 		const colorThemeSetting = await vscode.workspace.getConfiguration('kaoto').get<Promise<ColorScheme | null>>('colorTheme');
+		const canvasLayoutDirection = await vscode.workspace.getConfiguration('kaoto').get<Promise<CanvasLayoutDirection | null>>('canvasLayoutDirection');
 		const colorTheme = this.getColorSchemeFromVSCode(colorThemeSetting, vscode.window.activeColorTheme);
 
 		const settingsModel: Partial<ISettingsModel> = {
@@ -57,6 +58,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 			nodeLabel: nodeLabel ?? NodeLabelType.Description,
 			nodeToolbarTrigger: nodeToolbarTrigger ?? NodeToolbarTrigger.onHover,
 			colorScheme: colorTheme,
+			canvasLayoutDirection: canvasLayoutDirection ?? CanvasLayoutDirection.SelectInCanvas,
 		};
 
 		return new SettingsModel(settingsModel);


### PR DESCRIPTION
<img width="896" height="202" alt="Screenshot 2026-03-11 at 12 31 54" src="https://github.com/user-attachments/assets/5d843147-1a56-45c0-a2b6-a50eb5d793ae" />

closing #1303 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canvas layout direction setting with three modes: SelectInCanvas (default), Horizontal, and Vertical.
  * The selection controls whether nodes are selectable in-canvas or laid out horizontally/vertically; changes take effect after reopening Kaoto editors and are configurable via the application settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->