### PR TITLE
fix: OpenAPI Section - Support for JSON and YML File Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 2.10.1
 
+- display `*openapi.yml` files in OpenAPI view by default
+- fix JSON OpenAPI files detection and file validation
+
 # 2.10.0
 
 - Upgrade default Camel JBang version from 4.16.0 to 4.18.0

--- a/package.json
+++ b/package.json
@@ -1005,6 +1005,7 @@
             "additionalProperties": false,
             "default": [
               "*openapi.yaml",
+              "*openapi.yml",
               "*openapi.json"
             ],
             "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > OpenAPI` view.",

--- a/src/commands/ImportOpenApiCommand.ts
+++ b/src/commands/ImportOpenApiCommand.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { commands, ProgressLocation, QuickPickItem, Uri, window, workspace } from 'vscode';
-import { KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID, KAOTO_REST_APICURIO_REGISTRY_URL_SETTING_ID } from '../helpers/helpers';
+import { DEFAULT_KAOTO_OPENAPI_FILES_REGEXP, KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID, KAOTO_REST_APICURIO_REGISTRY_URL_SETTING_ID } from '../helpers/helpers';
 import { ApicurioRegistryService, ApicurioRegistryUrlError, type ApicurioArtifact } from '../services/apicurio-registry.service';
 import { OpenApiImportService, OpenApiParseError, OpenApiValidationError, type ParsedOperation } from '../services/openapi-import.service';
 import { AbstractNewCamelRouteCommand } from './AbstractNewCamelRouteCommand';
@@ -116,7 +116,7 @@ export class ImportOpenApiCommand extends AbstractNewCamelRouteCommand {
 	}
 
 	private async fetchFromFile(): Promise<string | undefined> {
-		const filesRegexp: string[] = workspace.getConfiguration().get(KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID) ?? ['*openapi.yaml', '*openapi.json'];
+		const filesRegexp: string[] = workspace.getConfiguration().get(KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID) ?? DEFAULT_KAOTO_OPENAPI_FILES_REGEXP;
 		const globPattern = '{' + filesRegexp.map((r) => '**/' + r).join(',') + '}';
 
 		const matchingFiles = await workspace.findFiles(globPattern);

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -48,6 +48,8 @@ export const KAOTO_TESTS_FILES_REGEXP_SETTING_ID: string = 'kaoto.tests.files.re
 
 export const KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID: string = 'kaoto.openapi.files.regexp';
 
+export const DEFAULT_KAOTO_OPENAPI_FILES_REGEXP: string[] = ['*openapi.yaml', '*openapi.yml', '*openapi.json'];
+
 export const KAOTO_REST_APICURIO_REGISTRY_URL_SETTING_ID: string = 'kaoto.restConfiguration.apicurioRegistryUrl';
 
 export const KAOTO_REST_CUSTOM_MEDIA_TYPES_SETTING_ID: string = 'kaoto.restConfiguration.customMediaTypes';

--- a/src/services/openapi-import.service.ts
+++ b/src/services/openapi-import.service.ts
@@ -312,7 +312,7 @@ export class OpenApiImportService {
 	 * @throws {OpenApiParseError} If parsing fails
 	 * @throws {OpenApiValidationError} If validation fails
 	 */
-	private parseOpenApiSpec(openApiString: string): OpenApi {
+	parseOpenApiSpec(openApiString: string): OpenApi {
 		try {
 			const spec = parse(openApiString) as OpenApi;
 			this.validateOpenApiSpec(spec);

--- a/src/views/providers/OpenApiProvider.ts
+++ b/src/views/providers/OpenApiProvider.ts
@@ -15,12 +15,12 @@
  */
 import { promises as fsPromises } from 'fs';
 import { Disposable, TreeItem, TreeItemCollapsibleState, Uri, workspace } from 'vscode';
-import { basename, extname, normalize } from 'path';
-import YAML from 'yaml';
+import { basename, normalize } from 'path';
 import { OpenApiFile } from '../openApiTreeItems/OpenApiFile';
 import { OpenApiFolder } from '../openApiTreeItems/OpenApiFolder';
 import { AbstractFolderTreeProvider } from './AbstractFolderTreeProvider';
-import { KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID } from '../../helpers/helpers';
+import { DEFAULT_KAOTO_OPENAPI_FILES_REGEXP, KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID } from '../../helpers/helpers';
+import { OpenApiImportService } from '../../services/openapi-import.service';
 
 export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 	public readonly VIEW_ITEM_SHOW_SOURCE_COMMAND_ID: string = 'kaoto.openapi.showSource';
@@ -33,6 +33,7 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 	/** Parsed OpenAPI data cached during filtering to avoid re-reading in toTreeItemForFile */
 	private readonly openApiDataCache = new Map<string, { version: string }>();
 
+	private readonly openApiService = new OpenApiImportService();
 	private configChangeDisposable?: Disposable;
 
 	constructor() {
@@ -42,7 +43,7 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 	}
 
 	protected getFilePattern(): string {
-		const filesRegexp: string[] = workspace.getConfiguration().get(KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID) ?? ['*openapi.yaml', '*openapi.json'];
+		const filesRegexp: string[] = workspace.getConfiguration().get(KAOTO_OPENAPI_FILES_REGEXP_SETTING_ID) ?? DEFAULT_KAOTO_OPENAPI_FILES_REGEXP;
 		return '{' + filesRegexp.map((r) => '**/' + r).join(',') + '}';
 	}
 
@@ -124,7 +125,7 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 
 	/**
 	 * Filter files to only those containing a valid OpenAPI spec.
-	 * Caches parsed OpenAPI data for reuse in toTreeItemForFile.
+	 * Delegates parsing and validation to {@link OpenApiImportService.parseOpenApiSpec}.
 	 */
 	private async filterToOpenApiFiles(files: Uri[]): Promise<Uri[]> {
 		this.openApiDataCache.clear();
@@ -133,12 +134,9 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 				const filepath = normalize(file.fsPath);
 				try {
 					const content = await fsPromises.readFile(filepath, 'utf8');
-					const ext = extname(filepath);
-					const parsed = ext === '.yaml' || ext === '.yml' ? YAML.parse(content) : JSON.parse(content);
-					if (parsed?.openapi) {
-						this.openApiDataCache.set(filepath, { version: parsed.openapi });
-						return file;
-					}
+					const spec = this.openApiService.parseOpenApiSpec(content);
+					this.openApiDataCache.set(filepath, { version: spec.openapi });
+					return file;
 				} catch {
 					// Not a valid OpenAPI file or parse error - skip
 				}
@@ -151,12 +149,8 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 	private async parseOpenApiFile(filepath: string): Promise<OpenApiFile | undefined> {
 		try {
 			const content = await fsPromises.readFile(filepath, 'utf8');
-			const ext = extname(filepath);
-			const parsed = ext === '.yaml' || ext === '.yml' ? YAML.parse(content) : JSON.parse(content);
-			if (parsed?.openapi) {
-				const fileName = basename(filepath);
-				return new OpenApiFile(fileName, filepath, parsed.openapi);
-			}
+			const spec = this.openApiService.parseOpenApiSpec(content);
+			return new OpenApiFile(basename(filepath), filepath, spec.openapi);
 		} catch (error) {
 			console.error(`Error parsing file: ${filepath}`, error);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended OpenAPI file format support to include `.yml` files in addition to existing `.yaml` and `.json` formats. The OpenAPI view now automatically discovers these specification files using updated default patterns.

* **Bug Fixes**
  * Enhanced detection and validation of JSON-formatted OpenAPI specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->