### PR TITLE
fix: OpenAPI Import - URI Validation Too Restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - display `*openapi.yml` files in OpenAPI view by default
 - fix JSON OpenAPI files detection and file validation
+- removed file extension restrictions from API URL imports, enabling greater flexibility with various URL formats.
 
 # 2.10.0
 

--- a/src/commands/ImportOpenApiCommand.ts
+++ b/src/commands/ImportOpenApiCommand.ts
@@ -149,8 +149,8 @@ export class ImportOpenApiCommand extends AbstractNewCamelRouteCommand {
 
 	private async fetchFromUri(): Promise<string | undefined> {
 		const uri = await window.showInputBox({
-			prompt: 'Enter the URL to the OpenAPI specification (YAML or JSON)',
-			placeHolder: 'https://example.com/openapi.yaml',
+			prompt: 'Enter the URL to the OpenAPI specification',
+			placeHolder: 'https://example.com/api-docs',
 			title: 'Import OpenAPI - Enter URL',
 			validateInput: (value) => {
 				if (!value) {
@@ -164,10 +164,6 @@ export class ImportOpenApiCommand extends AbstractNewCamelRouteCommand {
 				}
 				if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 					return 'Only HTTP and HTTPS URLs are supported';
-				}
-				const path = url.pathname.toLowerCase();
-				if (!path.endsWith('.yaml') && !path.endsWith('.yml') && !path.endsWith('.json')) {
-					return 'URL must point to a .yaml, .yml, or .json file';
 				}
 				return undefined;
 			},
@@ -268,16 +264,39 @@ export class ImportOpenApiCommand extends AbstractNewCamelRouteCommand {
 				try {
 					const response = await fetch(url);
 					if (!response.ok) {
-						window.showErrorMessage(`Failed to fetch: ${response.status} ${response.statusText}`);
+						const sanitizedUrl = this.sanitizeUrl(url);
+						window.showErrorMessage(`Failed to fetch: ${response.status} ${response.statusText} (${sanitizedUrl})`);
 						return undefined;
 					}
 					return await response.text();
 				} catch (error) {
-					window.showErrorMessage(`Failed to fetch from URL: ${error instanceof Error ? error.message : String(error)}`);
+					const sanitizedUrl = this.sanitizeUrl(url);
+					window.showErrorMessage(`Failed to fetch from URL: ${error instanceof Error ? error.message : String(error)} (${sanitizedUrl})`);
 					return undefined;
 				}
 			},
 		);
+	}
+
+	/**
+	 * Sanitizes a URL by removing sensitive information (credentials, query parameters, and fragments).
+	 *
+	 * @param url - The URL to sanitize
+	 * @returns Sanitized URL string safe for display in error messages
+	 */
+	private sanitizeUrl(url: string): string {
+		try {
+			const parsedUrl = new URL(url);
+			// Clear sensitive information
+			parsedUrl.username = '';
+			parsedUrl.password = '';
+			parsedUrl.search = '';
+			parsedUrl.hash = '';
+			return parsedUrl.toString();
+		} catch {
+			// If URL parsing fails, return a generic message
+			return 'invalid URL';
+		}
 	}
 
 	// --- Step 2: Select operations ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed file-extension restrictions for API URL imports, allowing a wider range of URL formats to be accepted.
  * Improved error messages to include the requested URL (sanitized) for clearer troubleshooting when imports fail.

* **Style**
  * Clarified the API import input prompt and updated the example placeholder URL for better user guidance.

* **Documentation**
  * Added changelog entry noting the removal of URL extension restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->