### PR TITLE
chore: Upgrade default Camel JBang version from 4.18.0 to 4.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.11.0
 
+- Upgrade default Camel JBang version from 4.18.0 to 4.19.0
+
 # 2.10.2
 
 - fix: allow user to overwrite default run arguments

--- a/package.json
+++ b/package.json
@@ -1081,7 +1081,7 @@
           "kaoto.camelJbang.version": {
             "type": "string",
             "markdownDescription": "Apache [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) version used for an internal Camel JBang CLI calls. Requirements can differ between versions.\n\nIt is recommended to use `default` version to ensure all extension features works properly.",
-            "default": "4.18.0",
+            "default": "4.19.0",
             "order": 0
           },
           "kaoto.camelJbang.runArguments": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default Apache Camel JBang version from 4.18.0 to 4.19.0.
  * Impact: Built-in tools and features that rely on the default Camel JBang will now use 4.19.0 unless overridden, potentially causing minor CLI or runtime behavior differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->