### PR TITLE
feat: Citrus tests auto-open using Kaoto editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1201,7 +1201,7 @@
             "filenamePattern": "*.camel.xml"
           },
           {
-            "filenamePattern": "*.citrus{.yaml,.test.yaml,.it.yaml,.test.yaml,.it.yaml}"
+            "filenamePattern": "*{.citrus,.citrus.test,.citrus.it,.citrus-test,.citrus-it}.yaml"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
     "workspaceContains:**/*-pipe.yaml",
     "workspaceContains:**/*-pipe.yml",
     "workspaceContains:**/*.camel.xml",
+    "workspaceContains:**/*.citrus.yaml",
+    "workspaceContains:**/*.citrus.test.yaml",
+    "workspaceContains:**/*.citrus.it.yaml",
+    "workspaceContains:**/*.citrus-test.yaml",
+    "workspaceContains:**/*.citrus-it.yaml",
     "onStartupFinished"
   ],
   "capabilities": {
@@ -1194,6 +1199,9 @@
           },
           {
             "filenamePattern": "*.camel.xml"
+          },
+          {
+            "filenamePattern": "*.citrus{.yaml,.test.yaml,.it.yaml,.test.yaml,.it.yaml}"
           }
         ]
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The VS Code extension now recognizes additional Citrus test file naming conventions (e.g., *.citrus.yaml, *.citrus.test.yaml, *.citrus.it.yaml, *.citrus-test.yaml, *.citrus-it.yaml). These files will trigger the extension and be opened with the extension’s custom editor, improving discovery and editing of Citrus YAML tests within workspaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->