### PR TITLE
chore: bump default Camel JBang version to 4.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.11.0
 
-- Upgrade default Camel JBang version from 4.18.0 to 4.19.0
+- Upgrade default Camel JBang version from 4.18.0 to 4.20.0
 
 # 2.10.2
 

--- a/package.json
+++ b/package.json
@@ -1081,7 +1081,7 @@
           "kaoto.camelJbang.version": {
             "type": "string",
             "markdownDescription": "Apache [Camel JBang](https://camel.apache.org/manual/camel-jbang.html) version used for an internal Camel JBang CLI calls. Requirements can differ between versions.\n\nIt is recommended to use `default` version to ensure all extension features works properly.",
-            "default": "4.19.0",
+            "default": "4.20.0",
             "order": 0
           },
           "kaoto.camelJbang.runArguments": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Camel JBang version to 4.20.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/vscode-kaoto/pull/1367)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->