### PR TITLE
fix: ensure globalStorage used by extension is not in a corrupted state

### DIFF
--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -80,6 +80,38 @@ export class ExtensionContextHandler {
 	}
 
 	/**
+	 * Safely reads a value from globalState with error handling.
+	 * Returns the default value if the read fails.
+	 *
+	 * @param key - The storage key to read
+	 * @param defaultValue - The default value to return on failure
+	 * @returns The stored value or the default value
+	 */
+	private safeGlobalStateGet<T>(key: string, defaultValue: T): T {
+		try {
+			return this.context.globalState.get<T>(key, defaultValue);
+		} catch (err) {
+			KaotoOutputChannel.logWarning(`Unable to read global state for key '${key}': ${String(err)}`);
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Safely updates a value in globalState with error handling.
+	 * Logs a warning if the update fails but continues execution.
+	 *
+	 * @param key - The storage key to update
+	 * @param value - The value to store
+	 */
+	private async safeGlobalStateUpdate(key: string, value: any): Promise<void> {
+		try {
+			await this.context.globalState.update(key, value);
+		} catch (err) {
+			KaotoOutputChannel.logWarning(`Unable to update global state for key '${key}': ${String(err)}`);
+		}
+	}
+
+	/**
 	 * a workaround which is temporarily disabling shortcuts for undo/redo in Kaoto Editor
 	 * Related issues:
 	 * - https://github.com/KaotoIO/kaoto/issues/2521
@@ -190,13 +222,14 @@ export class ExtensionContextHandler {
 				return;
 			}
 			const storageKey = 'kaoto.lastWhatsNewShownVersion';
-			const lastShown = this.context.globalState.get<string>(storageKey);
+			const lastShown = this.safeGlobalStateGet<string | undefined>(storageKey, undefined);
+
 			// Only show What's New if lastShown is undefined (first install) or lastShown < currentVersion (upgrade)
 			if (lastShown && satisfies(lastShown, `>=${currentVersion}`)) {
 				return;
 			}
 			await WhatsNewPanel.show(this.context, currentVersion);
-			await this.context.globalState.update(storageKey, currentVersion);
+			await this.safeGlobalStateUpdate(storageKey, currentVersion);
 		} catch (err) {
 			KaotoOutputChannel.logWarning(`Unable to show What's New: ${String(err)}`);
 		}
@@ -736,7 +769,7 @@ export class ExtensionContextHandler {
 	 */
 	private async showMultiWorkspaceInfoMessage(): Promise<void> {
 		const storageKey = 'kaoto.showRunAllFoldersMessage';
-		const showInfoMessage = this.context.globalState.get<boolean>(storageKey, true);
+		const showInfoMessage = this.safeGlobalStateGet<boolean>(storageKey, true);
 
 		if (showInfoMessage) {
 			const doNotShowAgain = "Don't show again";
@@ -747,7 +780,7 @@ export class ExtensionContextHandler {
 				doNotShowAgain,
 			);
 			if (result === doNotShowAgain) {
-				await this.context.globalState.update(storageKey, false);
+				await this.safeGlobalStateUpdate(storageKey, false);
 			}
 		}
 	}

--- a/src/extension/WhatsNewPanel.ts
+++ b/src/extension/WhatsNewPanel.ts
@@ -28,7 +28,7 @@ export class WhatsNewPanel {
 			const bytes = await vscode.workspace.fs.readFile(indexMdUri);
 			const markdown = new TextDecoder('utf-8').decode(bytes);
 
-			const htmlContent: string = (await vscode.commands.executeCommand('markdown.api.render', markdown)) as string;
+			const htmlContent: string = await vscode.commands.executeCommand('markdown.api.render', markdown);
 
 			const panel = vscode.window.createWebviewPanel(
 				'kaoto.whatsNew',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when reading or saving extension preferences so settings operations fail gracefully instead of causing interruptions.
  * Made "What's New" display and persistence more reliable — the last-shown version is now recorded more robustly to prevent repeated prompts.
  * Made "Don't show again" dismissal more reliable so informational messages respect and persist the user's choice consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/vscode-kaoto/pull/1384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->