### PR TITLE
chore: bump Kaoto UI to 2.11.0-RC3 and Kaoto Catalog to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.4.5",
-    "@kaoto/kaoto": "2.11.0-RC2",
+    "@kaoto/camel-catalog": "^0.5.2",
+    "@kaoto/kaoto": "2.11.0-RC3",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",
     "@kie-tools-core/i18n": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,10 +891,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.4.5":
-  version: 0.4.5
-  resolution: "@kaoto/camel-catalog@npm:0.4.5"
-  checksum: 10/2d90f699babdabf9b40fd53ac940951767158d6a42428c94d074af2e70b1087a8552f35ec3f25638b5c2e53bb3c2189f3b2d678b55b6130028a27dc9cbe8317d
+"@kaoto/camel-catalog@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@kaoto/camel-catalog@npm:0.5.2"
+  checksum: 10/c2ffe0b9152403a39662be5dd6086b4d2058931509261af9e9907a41abd97d0c6278c0ab58fc9ac923e1905566b2d3a24eb6bb94468f49fcea0b884cb3cdef6d
   languageName: node
   linkType: hard
 
@@ -916,9 +916,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/kaoto@npm:2.11.0-RC2":
-  version: 2.11.0-RC2
-  resolution: "@kaoto/kaoto@npm:2.11.0-RC2"
+"@kaoto/kaoto@npm:2.11.0-RC3":
+  version: 2.11.0-RC3
+  resolution: "@kaoto/kaoto@npm:2.11.0-RC3"
   dependencies:
     "@carbon/icons-react": "npm:^11.67.0"
     "@carbon/react": "npm:^1.102.0"
@@ -951,7 +951,7 @@ __metadata:
     zundo: "npm:^2.3.0"
     zustand: "npm:^5.0.11"
   peerDependencies:
-    "@kaoto/camel-catalog": ^0.4.4
+    "@kaoto/camel-catalog": ^0.5.2
     "@patternfly/patternfly": ^6.4.0
     "@patternfly/react-code-editor": ^6.4.0
     "@patternfly/react-core": ^6.4.0
@@ -963,7 +963,7 @@ __metadata:
     react: ^19.2.4
     react-dom: ^19.2.4
     react-monaco-editor: ^0.56.0
-  checksum: 10/e39378e692a2f00e9434b1d0844a4ee13b98d27404ca48274a5dc55f94fa2f9cd41b039077ad632a985b96ed9677053bde2fb04f8468eef2ad3b61d8f0a64693
+  checksum: 10/dee17ee67ab52e19d89134229559e9553bf0a3bfa1a1007fa09c3bbb7fef3dec5f8a2cc41a584c0aa08f543e7b747e5f110399b8445f367c9e48a7fd8ba2c8c9
   languageName: node
   linkType: hard
 
@@ -13648,8 +13648,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vscode-kaoto@workspace:."
   dependencies:
-    "@kaoto/camel-catalog": "npm:^0.4.5"
-    "@kaoto/kaoto": "npm:2.11.0-RC2"
+    "@kaoto/camel-catalog": "npm:^0.5.2"
+    "@kaoto/kaoto": "npm:2.11.0-RC3"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"
     "@kie-tools-core/i18n": "npm:10.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to latest compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->