### PR TITLE
feat: add executor architecture, catalog service, and supporting code

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-monaco-editor": "0.56.2",
+    "unzipper": "^0.12.3",
     "valid-filename": "4.0.0",
     "wait-on": "^9.0.10",
     "yaml": "^2.9.0"
@@ -922,7 +923,7 @@
           "kaoto.catalog.url": {
             "type": "string",
             "default": null,
-            "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/camel-catalog/refs/heads/main/catalog/index.json `. Documentation to generate your own set of catalog is available [here](https://kaoto.io/docs/manual/09_generatingcatalog/). It requires to reopen the Kaoto editors to be effective.",
+            "markdownDescription": "URL to a Kaoto catalog. For instance `https://raw.githubusercontent.com/KaotoIO/camel-catalog/refs/heads/main/catalog/index.json `. Documentation to generate your own set of catalog is available [here](https://kaoto.io/docs/manual/09_generatingcatalog/).\n\nIt requires to reopen the Kaoto editors to be effective.\n\n**Note**: Use the Kaoto editor status bar to select from a custom catalogs.",
             "scope": "window",
             "order": 0
           },
@@ -932,18 +933,74 @@
               "type": "string"
             },
             "additionalProperties": false,
-            "markdownDescription": "List of local directories to be used for Kamelet files. It is used for every run by adding `--local-kamelet-dir` argument into `#kaoto.camelJbang.runArguments#` or `#kaoto.camelJbang.runFolderOrWorkspaceArguments#` settings.\n\n**Note**: The setting can be overridden by the `--local-kamelet-dir` argument set in mentioned run arguments settings.\n\nSupports common variables - `${workspaceFolder}`, `${workspaceFolderBasename}`, `${cwd}`",
+            "markdownDescription": "List of local directories to be used for Kamelet files. It is used for every run by adding `--local-kamelet-dir` argument into `#kaoto.executor.runArguments#` or `#kaoto.executor.runFolderOrWorkspaceArguments#` settings.\n\n**Note**: The setting can be overridden by the `--local-kamelet-dir` argument set in mentioned run arguments settings.\n\nSupports common variables - `${workspaceFolder}`, `${workspaceFolderBasename}`, `${cwd}`",
             "default": [
               "."
             ],
             "scope": "window",
-            "order": 1
+            "order": 3
           },
-          "kaoto.camelVersion": {
+          "redhat.telemetry.enabled": {
+            "type": "boolean",
+            "default": null,
+            "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
+            "tags": [
+              "telemetry"
+            ],
+            "scope": "window",
+            "order": 4
+          }
+        }
+      },
+      {
+        "id": "canvas",
+        "title": "Canvas",
+        "properties": {
+          "kaoto.nodeLabel": {
             "type": "string",
-            "markdownDescription": "Camel version used for internal Camel JBang CLI commands execution. As default Camel Version is used `#kaoto.camelJbang.version#`.",
-            "order": 2
+            "default": "description",
+            "markdownDescription": "Node label, which will be used for nodes in the canvas. Can be either `description` or `id`. If `description` is selected, it will be displayed only if it is available, otherwise `id` will be displayed by default.\n\nIt requires to reopen the Kaoto editors to be effective.",
+            "enum": [
+              "description",
+              "id"
+            ],
+            "scope": "window"
           },
+          "kaoto.nodeToolbarTrigger": {
+            "type": "string",
+            "default": "onHover",
+            "markdownDescription": "Choose when to open the Node toolbar. Can be either `onHover` or `onSelection`. If `onHover` is selected, the toolbar will be automatically open upon hovering a node, otherwise, it will be open when selecting a node.\n\nIt requires to reopen the Kaoto editors to be effective.",
+            "enum": [
+              "onHover",
+              "onSelection"
+            ]
+          },
+          "kaoto.colorTheme": {
+            "type": "string",
+            "markdownDescription": "Choose the color theme for the UI. `auto` will follow VS Code theme, `light` and `dark` will set that theme regardless of VS Code theme.\n\nIt requires to reopen the Kaoto editors to be effective.",
+            "default": "auto",
+            "enum": [
+              "auto",
+              "light",
+              "dark"
+            ]
+          },
+          "kaoto.canvasLayoutDirection": {
+            "type": "string",
+            "markdownDescription": "Choose the layout direction for the canvas. `SelectInCanvas` will allow to select nodes in the canvas, `Horizontal` and `Vertical` will set the layout direction.\n\nIt requires to reopen the Kaoto editors to be effective.",
+            "default": "SelectInCanvas",
+            "enum": [
+              "SelectInCanvas",
+              "Horizontal",
+              "Vertical"
+            ]
+          }
+        }
+      },
+      {
+        "id": "views",
+        "title": "Views",
+        "properties": {
           "kaoto.deployments.refresh.interval": {
             "type": "number",
             "markdownDescription": "Set default auto-refresh interval in milliseconds for a `Kaoto > Deployments` view. **Default recommended interval is 30s.**",
@@ -963,7 +1020,7 @@
             ],
             "default": 30000,
             "scope": "window",
-            "order": 3
+            "order": 0
           },
           "kaoto.integrations.files.regexp": {
             "type": "array",
@@ -983,7 +1040,7 @@
             ],
             "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > Integrations` view.",
             "scope": "window",
-            "order": 4
+            "order": 1
           },
           "kaoto.tests.files.regexp": {
             "type": "array",
@@ -998,11 +1055,11 @@
               "*.citrus-test.yaml",
               "*.citrus-it.yaml",
               "jbang.properties",
-              "citrus-application.properties"
+              "citrus*.properties"
             ],
             "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > Tests` view.",
             "scope": "window",
-            "order": 5
+            "order": 2
           },
           "kaoto.openapi.files.regexp": {
             "type": "array",
@@ -1017,62 +1074,83 @@
             ],
             "markdownDescription": "Regular expression to filter files to be displayed in `Kaoto > OpenAPI` view.",
             "scope": "window",
-            "order": 6
-          },
-          "redhat.telemetry.enabled": {
-            "type": "boolean",
-            "default": null,
-            "markdownDescription": "Enable usage data and errors to be sent to Red Hat servers. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection).",
-            "tags": [
-              "telemetry"
-            ],
-            "scope": "window",
-            "order": 7
+            "order": 3
           }
         }
       },
       {
-        "id": "canvas",
-        "title": "Canvas",
+        "id": "executor",
+        "title": "Executor",
+        "order": 0,
         "properties": {
-          "kaoto.nodeLabel": {
+          "kaoto.executor.type": {
             "type": "string",
-            "default": "description",
-            "markdownDescription": "Node label, which will be used for nodes in the canvas. Can be either `description` or `id`. If `description` is selected, it will be displayed only if it is available, otherwise `id` will be displayed by default. It requires to reopen the Kaoto editors to be effective.",
             "enum": [
-              "description",
-              "id"
+              "jbang",
+              "camel-launcher"
             ],
-            "scope": "window"
+            "enumDescriptions": [
+              "Use JBang to execute Camel commands (requires JBang installation)",
+              "(experimental) Use Camel Launcher to execute Camel commands"
+            ],
+            "markdownDescription": "Select the executor type for running Camel integrations.\n\n**JBang**: Traditional approach using JBang CLI (requires JBang installation).\n\n**Camel Launcher**: (experimental) New approach using standalone Camel Launcher (no JBang required, automatically downloaded).",
+            "default": "jbang",
+            "order": 1
           },
-          "kaoto.nodeToolbarTrigger": {
-            "type": "string",
-            "default": "onHover",
-            "markdownDescription": "Choose when to open the Node toolbar. Can be either `onHover` or `onSelection`. If `onHover` is selected, the toolbar will be automatically open upon hovering a node, otherwise, it will be open when selecting a node. It requires to reopen the Kaoto editors to be effective.",
-            "enum": [
-              "onHover",
-              "onSelection"
-            ]
+          "kaoto.executor.runArguments": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "additionalProperties": false,
+            "markdownDescription": "User defined arguments to be applied at every launch. In case of spaces, the values needs to be enclosed with quotes.\n\n**User settings take priority:** If you define arguments like `--management-port`, `--port`, `--console`, `--camel-version`, or `--repos`, your values will override the extension's defaults. Warnings will be shown in the output when conflicts are detected.\n\n**Port resolution:** When you specify `--management-port` or `--port`, the Deployments view will automatically monitor the port you defined instead of the default port. This ensures proper tracking of running integrations.\n\nFor possible values see [official docs](https://camel.apache.org/manual/camel-jbang.html#_creating_and_running_camel_routes).",
+            "default": [
+              "--dev",
+              "--logging-level=info",
+              "*.xsl"
+            ],
+            "order": 2
           },
-          "kaoto.colorTheme": {
-            "type": "string",
-            "markdownDescription": "Choose the color theme for the UI. `auto` will follow VS Code theme, `light` and `dark` will set that theme regardless of VS Code theme. It requires to reopen the Kaoto editors to be effective.",
-            "default": "auto",
-            "enum": [
-              "auto",
-              "light",
-              "dark"
-            ]
+          "kaoto.executor.runFolderOrWorkspaceArguments": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "additionalProperties": false,
+            "markdownDescription": "User defined arguments to be applied at every launch of a folder or workspace. In case of spaces, the values needs to be enclosed with quotes.\n\n**User settings take priority:** If you define arguments like `--management-port`, `--port`, `--console`, `--camel-version`, or `--repos`, your values will override the extension's defaults. Warnings will be shown in the output when conflicts are detected.\n\n**Port resolution:** When you specify `--management-port` or `--port`, the Deployments view will automatically monitor the port you defined instead of the default port. This ensures proper tracking of running integrations.\n\nFor possible values see [official docs](https://camel.apache.org/manual/camel-jbang.html#_creating_and_running_camel_routes).",
+            "default": [
+              "--dev"
+            ],
+            "order": 3
           },
-          "kaoto.canvasLayoutDirection": {
+          "kaoto.executor.redHatMavenRepository": {
             "type": "string",
-            "markdownDescription": "Choose the layout direction for the canvas. `SelectInCanvas` will allow to select nodes in the canvas, `Horizontal` and `Vertical` will set the layout direction. It requires to reopen the Kaoto editors to be effective.",
-            "default": "SelectInCanvas",
-            "enum": [
-              "SelectInCanvas",
-              "Horizontal",
-              "Vertical"
-            ]
+            "markdownDescription": "Define Red Hat Maven Repository, which is used automatically in case the `#kaoto.camelVersion#` uses Red Hat productized Camel version (e.g. `4.8.0.redhat-00017`).",
+            "default": "https://maven.repository.redhat.com/ga/",
+            "order": 4
+          },
+          "kaoto.executor.redHatMavenRepository.global": {
+            "type": "boolean",
+            "markdownDescription": "The `#repos` placeholder will be added by default to use also repositories defined in global Camel configuration file.\n\n**Note**: The placeholder is available for versions `3.20.7/3.21` onwards.",
+            "default": true,
+            "order": 5
+          },
+          "kaoto.executor.kubernetesRunArguments": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "additionalProperties": false,
+            "markdownDescription": "User defined arguments to be applied at every deploy (See [Camel Kubernetes plugin](https://camel.apache.org/manual/camel-jbang-kubernetes.html)). In case of spaces, the values needs to be enclosed with quotes.\n\n**User settings take priority:** If you define `--camel-version`, your value will override the extension's default from `#kaoto.camelVersion#`. Warnings will be shown in the output when conflicts are detected.\n\nBeware that `--disable-auto`, which is provided by default, requires Camel 4.11+.",
+            "default": [
+              "--cluster-type=openshift",
+              "--disable-auto",
+              "--dev"
+            ],
+            "order": 6
           }
         }
       },
@@ -1165,6 +1243,19 @@
               "--cluster-type=openshift"
             ],
             "order": 1
+          },
+          "kaoto.maven.executor.exportProjectArguments": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            },
+            "additionalProperties": false,
+            "markdownDescription": "User defined arguments to be applied at every export of a Maven project. In case of spaces, the values needs to be enclosed with quotes.\n\n**User settings take priority:** If you define arguments like `--camel-version` or `--repos`, your values will override the extension's defaults. Warnings will be shown in the output when conflicts are detected.\n\nFor possible values see [official docs](https://camel.apache.org/manual/camel-jbang.html#_creating_projects).",
+            "default": [
+              "--cluster-type=openshift"
+            ],
+            "order": 1
           }
         }
       },
@@ -1186,6 +1277,26 @@
             "additionalProperties": false,
             "markdownDescription": "These values are available in Rest DSL Consumes/Produces fields. Add media type (e.g. `application/vnd.api+json`).",
             "default": null,
+            "order": 1
+          }
+        }
+      },
+      {
+        "id": "advanced",
+        "title": "Advanced",
+        "properties": {
+          "kaoto.runtimeCatalogName": {
+            "type": "string",
+            "default": null,
+            "markdownDescription": "⚠️ **WORKSPACE-ONLY SETTING** - This setting only works in Workspace/Folder settings, not User settings.\n\nSelected runtime catalog name for integration files (e.g., 'Camel Main 4.14.7', 'Camel Quarkus 3.35.0').\n\n**Note**: Use the status bar to select from available catalogs.",
+            "scope": "resource",
+            "order": 0
+          },
+          "kaoto.testingCatalogName": {
+            "type": "string",
+            "default": null,
+            "markdownDescription": "⚠️ **WORKSPACE-ONLY SETTING** - This setting only works in Workspace/Folder settings, not User settings.\n\nSelected testing catalog name for test files (e.g., 'Citrus 4.10.1').\n\n**Note**: Use the status bar to select from available catalogs.",
+            "scope": "resource",
             "order": 1
           }
         }
@@ -1266,6 +1377,7 @@
     "@types/openapi-v3": "^3.0.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@types/unzipper": "^0",
     "@types/vscode": "^1.100.0",
     "@types/wait-on": "^5.3.4",
     "@typescript-eslint/eslint-plugin": "^8.61.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,7 @@
+// ─── Default Values ──────────────────────────────────────────────────────────
+
+export const DEFAULT_CAMEL_VERSION_FALLBACK: string = '4.20.0';
+
 // ─── Editor Type ─────────────────────────────────────────────────────────────
 
 export const KAOTO_EDITOR_VIEW_TYPE = 'webviewEditorsKaoto';
@@ -7,6 +11,8 @@ export const KAOTO_EDITOR_VIEW_TYPE = 'webviewEditorsKaoto';
 export const KAOTO_FILE_PATH_GLOB = '**/*.{yml,yaml,xml}';
 
 export const KAOTO_EXCLUDE_PATTERN = '{**/node_modules/**,**/.vscode/**,**/out/**,**/.citrus-jbang*/**,**/.camel-jbang*/**,**/target/**,**/.mvn/**}';
+
+export const DEFAULT_KAOTO_OPENAPI_FILES_REGEXP: string[] = ['*openapi.yaml', '*openapi.yml', '*openapi.json'];
 
 // ─── Settings IDs ────────────────────────────────────────────────────────────
 
@@ -52,9 +58,25 @@ export const KAOTO_COLOR_THEME_SETTING_ID = 'kaoto.colorTheme';
 
 export const KAOTO_CANVAS_LAYOUT_DIRECTION_SETTING_ID = 'kaoto.canvasLayoutDirection';
 
-// ─── Default Values ──────────────────────────────────────────────────────────
+// ─── Executor Settings IDs ───────────────────────────────────────────────────
 
-export const DEFAULT_KAOTO_OPENAPI_FILES_REGEXP: string[] = ['*openapi.yaml', '*openapi.yml', '*openapi.json'];
+export const KAOTO_EXECUTOR_TYPE_SETTING_ID = 'kaoto.executor.type';
+
+export const KAOTO_EXECUTOR_RUN_ARGUMENTS_SETTING_ID = 'kaoto.executor.runArguments';
+
+export const KAOTO_EXECUTOR_RUN_SOURCE_DIR_ARGUMENTS_SETTING_ID = 'kaoto.executor.runFolderOrWorkspaceArguments';
+
+export const KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_SETTING_ID = 'kaoto.executor.redHatMavenRepository';
+
+export const KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID = 'kaoto.executor.redHatMavenRepository.global';
+
+export const KAOTO_EXECUTOR_KUBERNETES_RUN_ARGUMENTS_SETTING_ID = 'kaoto.executor.kubernetesRunArguments';
+
+export const KAOTO_EXECUTOR_EXPORT_ARGUMENTS_SETTING_ID = 'kaoto.maven.executor.exportProjectArguments';
+
+export const KAOTO_RUNTIME_CATALOG_NAME_SETTING_ID = 'kaoto.runtimeCatalogName';
+
+export const KAOTO_TESTING_CATALOG_NAME_SETTING_ID = 'kaoto.testingCatalogName';
 
 // ─── Command IDs ─────────────────────────────────────────────────────────────
 
@@ -155,6 +177,8 @@ export const VIEW_WHATS_NEW = 'kaoto.whatsNew';
 // ─── Context Keys ────────────────────────────────────────────────────────────
 
 export const CONTEXT_JBANG_AVAILABLE = 'kaoto.jbangAvailable';
+
+export const CONTEXT_EXECUTOR_AVAILABLE = 'kaoto.executorAvailable';
 
 export const CONTEXT_WORKSPACE_HAS_POM_XML = 'kaoto.workspaceHasPomXml';
 

--- a/src/executors/BaseExecutor.ts
+++ b/src/executors/BaseExecutor.ts
@@ -1,0 +1,44 @@
+import { ICamelExecutor } from './ICamelExecutor';
+import { CamelCommandBuilder, CommandBuilderConfig } from './builders/CamelCommandBuilder';
+import { ExecutorConfig } from './types/ExecutorConfig';
+import { CamelCommand, CommandArguments, CommandContext, CommandResult } from './types/ExecutorTypes';
+
+/**
+ * Base executor using template method pattern.
+ * Subclasses override buildCommandBuilderConfig() to provide dynamic prefix args per execution.
+ */
+export abstract class BaseExecutor implements ICamelExecutor {
+	constructor(
+		protected readonly config: ExecutorConfig,
+		private readonly defaultBuilderConfig: CommandBuilderConfig,
+	) {}
+
+	getConfig(): ExecutorConfig {
+		return this.config;
+	}
+
+	async execute(command: CamelCommand, args: CommandArguments, context?: CommandContext): Promise<CommandResult> {
+		if (!(await this.isAvailable())) {
+			throw new Error(`Executor ${this.config.type} is not available`);
+		}
+
+		const builderConfig = await this.buildCommandBuilderConfig(context);
+		const builder = new CamelCommandBuilder(builderConfig);
+		return builder.buildCommand(command, args, context);
+	}
+
+	/**
+	 * Template method: return the CommandBuilderConfig for this execution.
+	 * Default implementation returns the static config from construction.
+	 * Subclasses override to compute dynamic prefix args per execution.
+	 */
+	protected async buildCommandBuilderConfig(_context?: CommandContext): Promise<CommandBuilderConfig> {
+		return this.defaultBuilderConfig;
+	}
+
+	abstract isAvailable(): Promise<boolean>;
+
+	getVersion(): string {
+		return this.config.version;
+	}
+}

--- a/src/executors/CamelExecutorFactory.ts
+++ b/src/executors/CamelExecutorFactory.ts
@@ -1,0 +1,136 @@
+import * as vscode from 'vscode';
+import { ICamelExecutor } from './ICamelExecutor';
+import { JBangExecutor } from './JBangExecutor';
+import { CamelLauncherExecutor } from './CamelLauncherExecutor';
+import { CamelLauncherDownloader } from '../services/CamelLauncherDownloader';
+import { AnyExecutorConfig, CamelLauncherExecutorConfig } from './types/ExecutorConfig';
+import { ExecutorType } from './types/ExecutorTypes';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { KaotoCatalogService } from '../services/KaotoCatalogService';
+import { DEFAULT_CAMEL_VERSION_FALLBACK, KAOTO_EXECUTOR_TYPE_SETTING_ID } from '../constants';
+
+/**
+ * Factory for creating executor instances
+ * Type-safe and extensible
+ */
+export class CamelExecutorFactory {
+	private static executorInstance: ICamelExecutor | undefined;
+	private static currentConfig: AnyExecutorConfig | undefined;
+	private static downloader: CamelLauncherDownloader;
+	private static extensionContext: vscode.ExtensionContext | undefined;
+
+	/**
+	 * Initialize the factory with extension context
+	 * Should be called during extension activation
+	 */
+	static initialize(context: vscode.ExtensionContext): void {
+		this.extensionContext = context;
+	}
+
+	/**
+	 * Create executor based on configuration
+	 */
+	static async createExecutor(): Promise<ICamelExecutor> {
+		const config = await this.loadConfiguration();
+
+		// Reset cache if configuration changed
+		if (this.hasConfigChanged(config)) {
+			this.resetExecutor();
+		}
+
+		// Return cached instance
+		if (this.executorInstance) {
+			return this.executorInstance;
+		}
+
+		// Create new executor
+		this.currentConfig = config;
+		this.executorInstance = await this.createExecutorForType(config);
+
+		KaotoOutputChannel.logInfo(`Executor initialized: ${config.type} (version: ${config.version})`);
+
+		return this.executorInstance;
+	}
+
+	/**
+	 * Load configuration from VS Code settings
+	 * Version is determined from catalog selection
+	 */
+	private static async loadConfiguration(): Promise<AnyExecutorConfig> {
+		const vscodeConfig = vscode.workspace.getConfiguration();
+		const executorType = vscodeConfig.get<ExecutorType>(KAOTO_EXECUTOR_TYPE_SETTING_ID, 'jbang');
+
+		// Get version from catalog service - use selected catalog, not default
+		const catalogService = KaotoCatalogService.getInstance();
+		const catalog = await catalogService.getSelectedIntegrationCatalog();
+		const version = catalogService.getCamelVersionForCLI(catalog, executorType) || DEFAULT_CAMEL_VERSION_FALLBACK;
+
+		switch (executorType) {
+			case 'jbang':
+				return {
+					type: 'jbang',
+					version: version,
+				};
+
+			case 'camel-launcher':
+				return {
+					type: 'camel-launcher',
+					version: version,
+				};
+
+			default:
+				throw new Error(`Unknown executor type: ${executorType}`);
+		}
+	}
+
+	/**
+	 * Create executor for specific type
+	 */
+	private static async createExecutorForType(config: AnyExecutorConfig): Promise<ICamelExecutor> {
+		switch (config.type) {
+			case 'jbang':
+				return new JBangExecutor(config);
+
+			case 'camel-launcher':
+				return await this.createCamelLauncherExecutor(config);
+
+			default: {
+				const exhaustiveCheck: never = config;
+				throw new Error(`Unknown executor type: ${(exhaustiveCheck as AnyExecutorConfig).type}`);
+			}
+		}
+	}
+
+	/**
+	 * Create Camel Launcher executor, downloading the JAR if needed
+	 */
+	private static async createCamelLauncherExecutor(config: CamelLauncherExecutorConfig): Promise<ICamelExecutor> {
+		if (!this.downloader) {
+			this.downloader = new CamelLauncherDownloader(this.extensionContext);
+		}
+
+		const jarPath = await this.downloader.ensureLauncher(config.version);
+		KaotoOutputChannel.logInfo(`Using Camel Launcher ${config.version}: ${jarPath}`);
+
+		return new CamelLauncherExecutor(config, jarPath);
+	}
+
+	/**
+	 * Check if configuration changed
+	 */
+	private static hasConfigChanged(newConfig: AnyExecutorConfig): boolean {
+		if (!this.currentConfig) {
+			return true;
+		}
+
+		return this.currentConfig.type !== newConfig.type || this.currentConfig.version !== newConfig.version;
+	}
+
+	/**
+	 * Reset cached executor
+	 */
+	static resetExecutor(): void {
+		this.executorInstance = undefined;
+		this.currentConfig = undefined;
+	}
+}

--- a/src/executors/CamelLauncherExecutor.ts
+++ b/src/executors/CamelLauncherExecutor.ts
@@ -1,0 +1,36 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { BaseExecutor } from './BaseExecutor';
+import { CamelLauncherExecutorConfig } from './types/ExecutorConfig';
+
+/**
+ * Executes Camel Launcher JAR directly using java -jar.
+ * Uses the static builder config from BaseExecutor (no dynamic prefix args needed).
+ */
+export class CamelLauncherExecutor extends BaseExecutor {
+	private readonly jarPath: string;
+
+	constructor(config: CamelLauncherExecutorConfig, jarPath: string) {
+		super(config, {
+			executable: 'java',
+			prefixArgs: ['-jar', jarPath],
+		});
+		this.jarPath = jarPath;
+	}
+
+	getJarPath(): string {
+		return this.jarPath;
+	}
+
+	async isAvailable(): Promise<boolean> {
+		if (!existsSync(this.jarPath)) {
+			return false;
+		}
+		try {
+			execSync('java -version', { stdio: 'pipe' });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/src/executors/ExecutorInitializer.ts
+++ b/src/executors/ExecutorInitializer.ts
@@ -1,0 +1,133 @@
+import * as vscode from 'vscode';
+import { CamelExecutorFactory } from './CamelExecutorFactory';
+import { CamelLauncherDownloader } from '../services/CamelLauncherDownloader';
+import { KaotoCatalogService } from '../services/KaotoCatalogService';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { DEFAULT_CAMEL_VERSION_FALLBACK, KAOTO_EXECUTOR_TYPE_SETTING_ID } from '../constants';
+import { ExtensionContextHandler } from '../extension/ExtensionContextHandler';
+
+/**
+ * Ensure executor is available and configured.
+ * Handles both JBang and Camel Launcher setup with status bar feedback.
+ * @param context - Extension context
+ * @param contextHandler - Extension context handler
+ * @param forceReinitialize - Force re-initialization even if executor is already available
+ */
+export async function ensureExecutorAvailable(
+	context: vscode.ExtensionContext,
+	contextHandler: ExtensionContextHandler,
+	forceReinitialize: boolean = false,
+): Promise<void> {
+	try {
+		if (forceReinitialize) {
+			CamelExecutorFactory.resetExecutor();
+			KaotoOutputChannel.logInfo('Executor cache reset for re-initialization');
+		}
+
+		const config = vscode.workspace.getConfiguration();
+		const executorType = config.get<string>(KAOTO_EXECUTOR_TYPE_SETTING_ID, 'jbang');
+
+		if (executorType === 'jbang') {
+			const jbang = await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Window,
+					title: 'Kaoto: Preparing JBang',
+					cancellable: false,
+				},
+				async (progress) => {
+					KaotoOutputChannel.logInfo('Checking JBang availability...');
+					progress.report({ message: 'Checking JBang on PATH...' });
+
+					const resolvedJbang = await contextHandler.checkJbangOnPath();
+
+					if (!resolvedJbang) {
+						return undefined;
+					}
+
+					progress.report({ message: 'Configuring trusted JBang sources...' });
+					await contextHandler.checkJBangTrustedSources();
+
+					progress.report({ message: 'Verifying Camel JBang plugins...' });
+					await contextHandler.checkCamelJBangPlugins();
+
+					progress.report({ message: 'JBang is ready.' });
+					return resolvedJbang;
+				},
+			);
+
+			if (jbang) {
+				KaotoOutputChannel.logInfo('JBang is ready');
+				vscode.window.setStatusBarMessage('$(check) Kaoto: JBang ready', 3000);
+
+				await contextHandler.setExecutorAvailable(true);
+			} else {
+				KaotoOutputChannel.logWarning('JBang not found on PATH');
+				vscode.window.setStatusBarMessage('$(warning) Kaoto: JBang not found', 5000);
+
+				await contextHandler.setExecutorAvailable(false);
+			}
+		} else if (executorType === 'camel-launcher') {
+			const javaAvailable = await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Window,
+					title: 'Kaoto: Preparing Camel Launcher',
+					cancellable: false,
+				},
+				async (progress) => {
+					KaotoOutputChannel.logInfo('Checking Java availability...');
+					progress.report({ message: 'Checking Java on PATH...' });
+
+					return await contextHandler.checkJavaOnPath();
+				},
+			);
+
+			if (!javaAvailable) {
+				KaotoOutputChannel.logWarning('Java not found on PATH');
+				vscode.window.setStatusBarMessage('$(warning) Kaoto: Java not found', 5000);
+				await contextHandler.setExecutorAvailable(false);
+				return;
+			}
+
+			const catalogService = KaotoCatalogService.getInstance();
+			const catalog = await catalogService.getSelectedIntegrationCatalog();
+			const version = catalogService.getCamelVersionForCLI(catalog, 'camel-launcher') || DEFAULT_CAMEL_VERSION_FALLBACK;
+			const downloader = new CamelLauncherDownloader(context);
+
+			const launcherPath = await vscode.window.withProgress(
+				{
+					location: vscode.ProgressLocation.Window,
+					title: `Kaoto: Preparing Camel Launcher ${version}`,
+					cancellable: false,
+				},
+				async (progress) => {
+					progress.report({ message: 'Downloading Camel Launcher and preparing scripts...' });
+					KaotoOutputChannel.logInfo(`Downloading Camel Launcher ${version}...`);
+
+					const resolvedLauncherPath = await downloader.ensureLauncher(version);
+
+					progress.report({ message: 'Camel Launcher is ready.' });
+					return resolvedLauncherPath;
+				},
+			);
+
+			KaotoOutputChannel.logInfo(`Camel Launcher ${version} ready at: ${launcherPath}`);
+			vscode.window.setStatusBarMessage('$(check) Kaoto: Camel Launcher ready', 3000);
+
+			await contextHandler.setExecutorAvailable(true);
+		}
+	} catch (error) {
+		const isLauncherNotFound = error instanceof Error && error.name === 'LauncherNotFoundError';
+
+		if (isLauncherNotFound) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			KaotoOutputChannel.logWarning(errorMessage);
+			vscode.window.showWarningMessage(errorMessage);
+		} else {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			KaotoOutputChannel.logError('Failed to setup executor', error);
+			vscode.window.showWarningMessage(`Failed to setup executor: ${errorMessage}. It will be configured when first needed.`);
+		}
+
+		await contextHandler.setExecutorAvailable(false);
+	}
+}

--- a/src/executors/ICamelExecutor.ts
+++ b/src/executors/ICamelExecutor.ts
@@ -1,0 +1,36 @@
+/**
+ * Generic Camel executor interface
+ */
+
+import { CamelCommand, CommandArguments, CommandContext, CommandResult } from './types/ExecutorTypes';
+import { ExecutorConfig } from './types/ExecutorConfig';
+
+/**
+ * Generic Camel executor interface
+ * All executors implement this simple, generic API
+ */
+export interface ICamelExecutor {
+	/**
+	 * Get executor configuration
+	 */
+	getConfig(): ExecutorConfig;
+
+	/**
+	 * Execute a Camel command with arguments
+	 * @param command - Camel command to execute
+	 * @param args - Command arguments
+	 * @param context - Execution context (cwd, env, etc.)
+	 * @returns Command execution result
+	 */
+	execute(command: CamelCommand, args: CommandArguments, context?: CommandContext): Promise<CommandResult>;
+
+	/**
+	 * Check if executor is available and properly configured
+	 */
+	isAvailable(): Promise<boolean>;
+
+	/**
+	 * Get executor version
+	 */
+	getVersion(): string;
+}

--- a/src/executors/JBangExecutor.ts
+++ b/src/executors/JBangExecutor.ts
@@ -1,0 +1,75 @@
+import { execSync } from 'child_process';
+import { Uri } from 'vscode';
+import { CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { BaseExecutor } from './BaseExecutor';
+import { CommandBuilderConfig } from './builders/CamelCommandBuilder';
+import { JBangExecutorConfig } from './types/ExecutorConfig';
+import { CommandContext, RuntimeType } from './types/ExecutorTypes';
+import { KaotoCatalogService } from '../services/KaotoCatalogService';
+import { DEFAULT_CAMEL_VERSION_FALLBACK } from '../constants';
+import { isRedHatBuild } from '../helpers/helpers';
+
+export class JBangExecutor extends BaseExecutor {
+	private static readonly JBANG_EXECUTABLE = 'jbang';
+
+	constructor(config: JBangExecutorConfig) {
+		super(config, {
+			executable: JBangExecutor.JBANG_EXECUTABLE,
+			prefixArgs: [],
+		});
+	}
+
+	protected override async buildCommandBuilderConfig(context?: CommandContext): Promise<CommandBuilderConfig> {
+		const catalogService = KaotoCatalogService.getInstance();
+		const resourceUri = context?.cwd ? Uri.file(context.cwd) : undefined;
+		const catalog = await catalogService.getSelectedIntegrationCatalog(resourceUri);
+
+		const cliVersion = catalogService.getCliVersionForJBang(catalog) || DEFAULT_CAMEL_VERSION_FALLBACK;
+		const runtimeSystemProps = this.getRuntimeSystemProperties(catalogService, catalog);
+
+		return {
+			executable: JBangExecutor.JBANG_EXECUTABLE,
+			prefixArgs: [`-Dcamel.jbang.version=${cliVersion}`, ...runtimeSystemProps, 'camel@apache/camel'],
+		};
+	}
+
+	private getRuntimeSystemProperties(catalogService: KaotoCatalogService, catalog: CatalogLibraryEntry | undefined): string[] {
+		if (!catalog) {
+			return [];
+		}
+
+		const runtime = catalogService.getRuntimeForCLI(catalog);
+		const version = catalogService.getCamelVersionForCLI(catalog, 'jbang');
+
+		if (!version) {
+			return [];
+		}
+
+		const properties: string[] = [];
+
+		if (runtime === RuntimeType.QUARKUS) {
+			properties.push(`-Dcamel.jbang.quarkusVersion=${version}`);
+
+			if (isRedHatBuild(version)) {
+				properties.push(
+					'-Dcamel.jbang.quarkusGroupId=com.redhat.quarkus.platform',
+					'-Dcamel.jbang.quarkus.platform.url=https://registry.quarkus.redhat.com/client/platforms',
+					'-Dcamel.jbang.quarkusExtensionRegistryBaseUri=https://registry.quarkus.redhat.com/',
+				);
+			}
+		} else if (runtime === RuntimeType.SPRING_BOOT) {
+			properties.push(`-Dcamel.jbang.camelSpringBootVersion=${version}`, `-Dcamel.jbang.springBootVersion=${catalog.frameworkVersion}`);
+		}
+
+		return properties;
+	}
+
+	async isAvailable(): Promise<boolean> {
+		try {
+			execSync(`${JBangExecutor.JBANG_EXECUTABLE} version`, { stdio: 'pipe' });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/src/executors/api/CamelCommandAPI.ts
+++ b/src/executors/api/CamelCommandAPI.ts
@@ -1,0 +1,239 @@
+import { CamelExecutorFactory } from '../CamelExecutorFactory';
+import { CamelCommandBuilder } from '../builders/CamelCommandBuilder';
+import { CamelCommand, CommandArguments, CommandResult, RuntimeType } from '../types/ExecutorTypes';
+import { CamelSettingsHelper } from '../helpers/CamelSettingsHelper';
+import { TestFolderResolver } from '../../helpers/TestFolderResolver';
+
+interface ResolvedSettings {
+	camelVersionArg: string;
+	quarkusArgs: string[];
+	springBootArgs: string[];
+	reposArg: string;
+}
+
+/**
+ * High-level API for executing Camel commands
+ * Used by task classes to abstract executor details
+ * Integrates user settings from VS Code configuration
+ */
+export class CamelCommandAPI {
+	private static async resolveCommonSettings(settingsHelper: CamelSettingsHelper, userArgs: string[]): Promise<ResolvedSettings> {
+		const [camelVersionArg, quarkusArgs, springBootArgs, reposArg] = await Promise.all([
+			settingsHelper.getCamelVersionArgument(userArgs),
+			settingsHelper.getQuarkusArguments(userArgs),
+			settingsHelper.getSpringBootArguments(userArgs),
+			settingsHelper.getRedHatMavenRepositoryArgument(userArgs),
+		]);
+		return { camelVersionArg, quarkusArgs, springBootArgs, reposArg };
+	}
+
+	private static applyPortOverride(result: CommandResult, portArg: string, resolvedPort: number): CommandResult {
+		if (portArg) {
+			return { ...result, resolvedPort };
+		}
+		return result;
+	}
+
+	private static async executeSimple(command: CamelCommand, args: CommandArguments, cwd?: string): Promise<CommandResult> {
+		const executor = await CamelExecutorFactory.createExecutor();
+		return await executor.execute(command, args, { cwd });
+	}
+
+	/**
+	 * Run a Camel integration with user settings
+	 */
+	static async run(filePath: string, cwd: string, port?: number, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const executor = await CamelExecutorFactory.createExecutor();
+		const settingsHelper = new CamelSettingsHelper();
+
+		const { args: userArgs, conflicts } = await settingsHelper.getRunArguments(filePath, cwd);
+		const { argument: portArg, resolvedPort } = settingsHelper.getPortArgument(port, userArgs);
+		const runtimeArg = settingsHelper.getRuntimeArgument(userArgs);
+		const common = await this.resolveCommonSettings(settingsHelper, userArgs);
+
+		await settingsHelper.showConflictWarnings(conflicts);
+
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs([
+			`'${filePath}'`,
+			portArg,
+			runtimeArg,
+			...userArgs,
+			...additionalArgs,
+			common.camelVersionArg,
+			...common.quarkusArgs,
+			...common.springBootArgs,
+			common.reposArg,
+		]);
+
+		const result = await executor.execute('run', args, { cwd });
+		return this.applyPortOverride(result, portArg, resolvedPort);
+	}
+
+	/**
+	 * Run a Camel integration from source directory with user settings
+	 */
+	static async runSourceDir(sourceDir: string, port?: number, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const executor = await CamelExecutorFactory.createExecutor();
+		const settingsHelper = new CamelSettingsHelper();
+
+		const { args: userArgs, conflicts } = await settingsHelper.getRunSourceDirArguments(sourceDir);
+		const { argument: portArg, resolvedPort } = settingsHelper.getPortArgument(port, userArgs);
+		const runtimeArg = settingsHelper.getRuntimeArgument(userArgs);
+		const common = await this.resolveCommonSettings(settingsHelper, userArgs);
+
+		await settingsHelper.showConflictWarnings(conflicts);
+
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs([
+			`'--source-dir=${sourceDir}'`,
+			portArg,
+			runtimeArg,
+			...userArgs,
+			...additionalArgs,
+			common.camelVersionArg,
+			...common.quarkusArgs,
+			...common.springBootArgs,
+			common.reposArg,
+		]);
+
+		const result = await executor.execute('run', args, { cwd: sourceDir });
+		return this.applyPortOverride(result, portArg, resolvedPort);
+	}
+
+	/**
+	 * Export a Camel integration to Maven project with user settings
+	 */
+	static async export(
+		filePath: string,
+		gav: string,
+		runtime: RuntimeType,
+		outputPath: string,
+		cwd: string,
+		kubernetes?: boolean,
+		additionalArgs: CommandArguments = [],
+	): Promise<CommandResult> {
+		const executor = await CamelExecutorFactory.createExecutor();
+		const settingsHelper = new CamelSettingsHelper();
+
+		const { args: userArgs, conflicts } = await settingsHelper.getExportArguments(cwd);
+		const common = await this.resolveCommonSettings(settingsHelper, userArgs);
+
+		await settingsHelper.showConflictWarnings(conflicts);
+
+		const quarkusOpenshiftDependency = runtime === RuntimeType.QUARKUS && kubernetes ? ['--dependency=mvn:io.quarkus:quarkus-openshift'] : [];
+
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs([
+			`'${filePath}'`,
+			`--runtime=${runtime}`,
+			`--gav=${gav}`,
+			`--directory=${outputPath}`,
+			...quarkusOpenshiftDependency,
+			...userArgs,
+			...additionalArgs,
+			common.camelVersionArg,
+			...common.quarkusArgs,
+			...common.springBootArgs,
+			common.reposArg,
+		]);
+
+		if (kubernetes) {
+			return await executor.execute('kubernetes', ['export', ...args], { cwd });
+		} else {
+			return await executor.execute('export', args, { cwd });
+		}
+	}
+
+	/**
+	 * Initialize a new Camel file
+	 */
+	static async init(filePath: string, cwd?: string): Promise<CommandResult> {
+		return this.executeSimple('init', [`'${filePath}'`], cwd);
+	}
+
+	/**
+	 * Stop a running integration
+	 */
+	static async stop(name: string, cwd?: string): Promise<CommandResult> {
+		return this.executeSimple('stop', [name], cwd);
+	}
+
+	/**
+	 * Bind a Kamelet to a source/sink
+	 */
+	static async bind(file: string, source: string, sink: string, cwd?: string, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs(['--source', source, '--sink', sink, `'${file}'`, ...additionalArgs]);
+		return this.executeSimple('bind', args, cwd);
+	}
+
+	/**
+	 * Add a plugin
+	 */
+	static async pluginAdd(pluginName: string, cwd?: string, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs(['add', pluginName, ...additionalArgs]);
+		return this.executeSimple('plugin', args, cwd);
+	}
+
+	/**
+	 * Update dependencies in pom.xml
+	 */
+	static async dependencyUpdate(pomPath: string, integrationFilePath: string, cwd?: string): Promise<CommandResult> {
+		return this.executeSimple('dependency', ['update', pomPath, integrationFilePath, '--lazy-bean', '--ignore-loading-error'], cwd);
+	}
+
+	/**
+	 * Execute route operations (start, stop, suspend, resume)
+	 */
+	static async routeOperation(operation: string, integration: string, routeId: string, cwd?: string): Promise<CommandResult> {
+		return this.executeSimple('cmd', [`${operation}-route`, integration, `--id=${routeId}`], cwd);
+	}
+
+	/**
+	 * Initialize a new Camel test file
+	 */
+	static async testInit(filePath: string, cwd?: string): Promise<CommandResult> {
+		return this.executeSimple('test', ['init', `'${filePath}'`], cwd);
+	}
+
+	/**
+	 * Run Camel tests
+	 */
+	static async testRun(filePath: string, cwd?: string, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs(['run', `'${filePath}'`, ...additionalArgs]);
+		return this.executeSimple('test', args, cwd);
+	}
+
+	/**
+	 * Run all Camel tests in a folder
+	 * Automatically resolves to the actual test folder if the provided path is not a test folder
+	 */
+	static async testRunFolder(folderPath: string): Promise<CommandResult> {
+		const testFolder = await TestFolderResolver.resolveTestFolder(folderPath);
+		return this.executeSimple('test', ['run', '*'], testFolder);
+	}
+
+	/**
+	 * Execute Kubernetes run operation with user settings
+	 */
+	static async kubernetesRun(filePattern: string, cwd?: string, additionalArgs: CommandArguments = []): Promise<CommandResult> {
+		const executor = await CamelExecutorFactory.createExecutor();
+		const settingsHelper = new CamelSettingsHelper();
+
+		const { args: userArgs, conflicts } = await settingsHelper.getKubernetesRunArguments(cwd || '');
+		const runtimeArg = settingsHelper.getRuntimeArgument(userArgs);
+		const common = await this.resolveCommonSettings(settingsHelper, userArgs);
+
+		await settingsHelper.showConflictWarnings(conflicts);
+
+		const args: CommandArguments = CamelCommandBuilder.filterEmptyArgs([
+			'run',
+			filePattern,
+			...userArgs,
+			runtimeArg,
+			common.camelVersionArg,
+			...common.quarkusArgs,
+			...common.springBootArgs,
+			common.reposArg,
+			...additionalArgs,
+		]);
+		return await executor.execute('kubernetes', args, { cwd });
+	}
+}

--- a/src/executors/builders/CamelCommandBuilder.ts
+++ b/src/executors/builders/CamelCommandBuilder.ts
@@ -1,0 +1,80 @@
+/**
+ * Unified command builder for all Camel executors
+ */
+
+import { ShellExecution, ShellExecutionOptions } from 'vscode';
+import { CamelCommand, CommandArguments, CommandContext, CommandResult } from '../types/ExecutorTypes';
+
+/**
+ * Configuration for command builder
+ */
+export interface CommandBuilderConfig {
+	/** Executable path (e.g., 'jbang' or '/path/to/camel-launcher/bin/camel') */
+	executable: string;
+
+	/** Prefix arguments to add before the Camel command (e.g., JBang needs ['-Dcamel.jbang.version=X', 'camel@apache/camel']) */
+	prefixArgs?: string[];
+}
+
+/**
+ * Unified command builder for all Camel executors
+ * Handles both JBang and Camel Launcher with configuration
+ */
+export class CamelCommandBuilder {
+	constructor(private readonly config: CommandBuilderConfig) {}
+
+	/**
+	 * Build command for execution
+	 * Structure: <executable> [...prefixArgs] <command> <args>
+	 */
+	buildCommand(command: CamelCommand, args: CommandArguments, context?: CommandContext): CommandResult {
+		// Build command parts: [prefixArgs, command, args]
+		const commandParts = CamelCommandBuilder.filterEmptyArgs([...(this.config.prefixArgs || []), command, ...args]);
+
+		const execution = this.buildExecution(this.config.executable, commandParts, context);
+		const resolvedPort = this.extractPort(args);
+
+		return this.buildResult(execution, resolvedPort);
+	}
+
+	/**
+	 * Build shell execution from command components
+	 */
+	private buildExecution(executable: string, commandParts: string[], context?: CommandContext): ShellExecution {
+		const options: ShellExecutionOptions = {
+			cwd: context?.cwd,
+			env: context?.env,
+		};
+
+		return new ShellExecution(executable, commandParts, options);
+	}
+
+	/**
+	 * Filter empty/null/undefined arguments from a command args array
+	 */
+	static filterEmptyArgs(args: (string | undefined | null)[]): string[] {
+		return args.filter((arg) => arg !== undefined && arg !== null && arg !== '') as string[];
+	}
+
+	/**
+	 * Build command result
+	 */
+	private buildResult(execution: ShellExecution, resolvedPort?: number): CommandResult {
+		return {
+			execution,
+			resolvedPort,
+		};
+	}
+
+	/**
+	 * Extract port from arguments
+	 */
+	private extractPort(args: CommandArguments): number | undefined {
+		const portArg = args.find((arg) => arg.startsWith('--port=') || arg.startsWith('--management-port='));
+		if (portArg) {
+			const match = portArg.match(/=(-?\d+)/);
+			return match ? parseInt(match[1], 10) : undefined;
+		}
+		return undefined;
+	}
+}

--- a/src/executors/helpers/CamelSettingsHelper.ts
+++ b/src/executors/helpers/CamelSettingsHelper.ts
@@ -1,0 +1,307 @@
+import { workspace, window, Uri, RelativePattern } from 'vscode';
+import { dirname } from 'path';
+import { satisfies } from 'compare-versions';
+import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';
+import { ArgumentConflict, ArgumentConflictDetector } from '../../helpers/ArgumentConflictDetector';
+import { KaotoCatalogService } from '../../services/KaotoCatalogService';
+import { RuntimeType, ExecutorType } from '../types/ExecutorTypes';
+import {
+	KAOTO_EXECUTOR_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_EXECUTOR_RUN_SOURCE_DIR_ARGUMENTS_SETTING_ID,
+	KAOTO_EXECUTOR_KUBERNETES_RUN_ARGUMENTS_SETTING_ID,
+	KAOTO_EXECUTOR_EXPORT_ARGUMENTS_SETTING_ID,
+	KAOTO_LOCAL_KAMELET_DIRECTORIES_SETTING_ID,
+	KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_SETTING_ID,
+	KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID,
+	KAOTO_EXECUTOR_TYPE_SETTING_ID,
+} from '../../constants';
+import { resolvePaths, normalizeVersionForSemver, isRedHatBuild } from '../../helpers/helpers';
+
+export interface ProcessedArguments {
+	args: string[];
+	conflicts: ArgumentConflict[];
+}
+
+interface CatalogContext {
+	camelVersion: string;
+	runtime: RuntimeType | '';
+	frameworkVersion: string;
+	executorType: ExecutorType | undefined;
+}
+
+/**
+ * Helper class for processing Camel settings and arguments.
+ * Catalog context is resolved once per instance via a cached promise.
+ */
+export class CamelSettingsHelper {
+	private catalogContext: CatalogContext | undefined;
+	private catalogContextPromise: Promise<CatalogContext> | undefined;
+
+	private async ensureCatalogContext(resourceUri?: Uri): Promise<CatalogContext> {
+		if (!this.catalogContextPromise) {
+			this.catalogContextPromise = this.resolveCatalogContext(resourceUri);
+			this.catalogContext = await this.catalogContextPromise;
+		}
+		return this.catalogContextPromise;
+	}
+
+	private async resolveCatalogContext(resourceUri?: Uri): Promise<CatalogContext> {
+		const catalogService = KaotoCatalogService.getInstance();
+		const catalog = await catalogService.getSelectedIntegrationCatalog(resourceUri);
+		const executorType = workspace.getConfiguration().get<ExecutorType>(KAOTO_EXECUTOR_TYPE_SETTING_ID);
+
+		return {
+			camelVersion: catalogService.getCamelVersionForCLI(catalog, executorType) || '',
+			runtime: catalogService.getRuntimeForCLI(catalog) || '',
+			frameworkVersion: catalog?.frameworkVersion || '',
+			executorType,
+		};
+	}
+
+	async getRunArguments(filePath: string, cwd: string): Promise<ProcessedArguments> {
+		await this.ensureCatalogContext(Uri.file(filePath));
+
+		const runArgs = workspace.getConfiguration().get(KAOTO_EXECUTOR_RUN_ARGUMENTS_SETTING_ID) as string[];
+		const xslFilteredArgs = await this.handleMissingXslFiles(filePath, runArgs);
+		const processedArgs = await this.handleLocalKameletDirArgument(xslFilteredArgs, cwd);
+
+		const result = ArgumentConflictDetector.mergeArguments(['--console'], processedArgs, 'run');
+		return { args: result.merged, conflicts: result.conflicts };
+	}
+
+	async getRunSourceDirArguments(cwd: string): Promise<ProcessedArguments> {
+		await this.ensureCatalogContext(Uri.file(cwd));
+
+		const runArgs = workspace.getConfiguration().get(KAOTO_EXECUTOR_RUN_SOURCE_DIR_ARGUMENTS_SETTING_ID) as string[];
+		const processedArgs = await this.handleLocalKameletDirArgument(runArgs, cwd);
+
+		const result = ArgumentConflictDetector.mergeArguments(['--console'], processedArgs, 'runSourceDir');
+		return { args: result.merged, conflicts: result.conflicts };
+	}
+
+	async getExportArguments(cwd: string): Promise<ProcessedArguments> {
+		await this.ensureCatalogContext(Uri.file(cwd));
+
+		const exportArgs = workspace.getConfiguration().get(KAOTO_EXECUTOR_EXPORT_ARGUMENTS_SETTING_ID) as string[];
+		const processedArgs = await this.handleLocalKameletDirArgument(exportArgs, cwd);
+		return { args: processedArgs, conflicts: [] };
+	}
+
+	async getKubernetesRunArguments(cwd: string): Promise<ProcessedArguments> {
+		await this.ensureCatalogContext(Uri.file(cwd));
+
+		const kubernetesArgs = workspace.getConfiguration().get(KAOTO_EXECUTOR_KUBERNETES_RUN_ARGUMENTS_SETTING_ID) as string[];
+		const result = ArgumentConflictDetector.mergeArguments([], kubernetesArgs, 'kubernetesRun');
+		return { args: result.merged, conflicts: result.conflicts };
+	}
+
+	getPortArgument(port?: number, userArgs: string[] = []): { argument: string; resolvedPort: number } {
+		const userDefinedPort = ArgumentConflictDetector.extractPortValue(userArgs);
+
+		if (userDefinedPort !== undefined) {
+			return { argument: '', resolvedPort: userDefinedPort };
+		}
+
+		const ctx = this.getCatalogContextSync();
+		const normalizedVersion = normalizeVersionForSemver(ctx.camelVersion);
+		const useManagementPort =
+			ctx.runtime === RuntimeType.QUARKUS || ctx.runtime === RuntimeType.SPRING_BOOT || !normalizedVersion || satisfies(normalizedVersion, '>=4.14');
+		const effectivePort = port ?? 8080;
+		const argument = useManagementPort ? `--management-port=${effectivePort}` : `--port=${effectivePort}`;
+
+		return { argument, resolvedPort: effectivePort };
+	}
+
+	/**
+	 * Get Camel version argument from catalog selection.
+	 * Returns empty string for Camel Launcher (version baked into JAR) and
+	 * for JBang with Quarkus/Spring Boot (version passed via system properties).
+	 */
+	async getCamelVersionArgument(userArgs: string[] = []): Promise<string> {
+		if (ArgumentConflictDetector.hasArgument(userArgs, 'camel-version')) {
+			return '';
+		}
+
+		const ctx = await this.ensureCatalogContext();
+
+		if (ctx.executorType === 'camel-launcher') {
+			return '';
+		}
+
+		if (ctx.runtime === RuntimeType.QUARKUS || ctx.runtime === RuntimeType.SPRING_BOOT) {
+			return '';
+		}
+
+		return ctx.camelVersion ? `--camel-version=${ctx.camelVersion}` : '';
+	}
+
+	/**
+	 * Get Quarkus-related CLI arguments for JBang.
+	 * Due to Camel JBang CLI bugs, these need to be provided as CLI arguments in addition to system properties.
+	 */
+	async getQuarkusArguments(userArgs: string[] = []): Promise<string[]> {
+		const ctx = await this.ensureCatalogContext();
+
+		if (ctx.runtime !== RuntimeType.QUARKUS || !ctx.camelVersion) {
+			return [];
+		}
+
+		const args: string[] = [];
+
+		if (!ArgumentConflictDetector.hasArgument(userArgs, 'quarkus-version')) {
+			args.push(`--quarkus-version=${ctx.frameworkVersion}`);
+		}
+
+		if (isRedHatBuild(ctx.camelVersion) && !ArgumentConflictDetector.hasArgument(userArgs, 'quarkus-group-id')) {
+			args.push('--quarkus-group-id=com.redhat.quarkus.platform');
+		}
+
+		return args;
+	}
+
+	/**
+	 * Get Spring Boot-related CLI arguments for JBang.
+	 * Due to Camel JBang CLI bugs, these need to be provided as CLI arguments in addition to system properties.
+	 */
+	async getSpringBootArguments(userArgs: string[] = []): Promise<string[]> {
+		const ctx = await this.ensureCatalogContext();
+
+		if (ctx.runtime !== RuntimeType.SPRING_BOOT || !ctx.camelVersion) {
+			return [];
+		}
+
+		const args: string[] = [];
+
+		if (!ArgumentConflictDetector.hasArgument(userArgs, 'camel-spring-boot-version')) {
+			args.push(`--camel-spring-boot-version=${ctx.camelVersion}`);
+		}
+
+		if (ctx.frameworkVersion && !ArgumentConflictDetector.hasArgument(userArgs, 'spring-boot-version')) {
+			args.push(`--spring-boot-version=${ctx.frameworkVersion}`);
+		}
+
+		return args;
+	}
+
+	getRuntimeArgument(userArgs: string[] = []): string {
+		if (ArgumentConflictDetector.hasArgument(userArgs, 'runtime')) {
+			return '';
+		}
+
+		const ctx = this.getCatalogContextSync();
+		return ctx.runtime ? `--runtime=${ctx.runtime}` : '';
+	}
+
+	async getRedHatMavenRepositoryArgument(userArgs: string[] = []): Promise<string> {
+		if (ArgumentConflictDetector.hasArgument(userArgs, 'repos')) {
+			return '';
+		}
+
+		const ctx = await this.ensureCatalogContext();
+		if (isRedHatBuild(ctx.camelVersion)) {
+			const url = workspace.getConfiguration().get(KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_SETTING_ID) as string;
+			const reposPlaceholder = this.getCamelGlobalRepos();
+			return url ? `--repos=${reposPlaceholder}${url}` : '';
+		}
+		return '';
+	}
+
+	/**
+	 * Synchronous access to already-resolved catalog context.
+	 * Only safe to call after ensureCatalogContext() has been awaited
+	 * (guaranteed by getRunArguments/getRunSourceDirArguments/etc. calling it first).
+	 */
+	private getCatalogContextSync(): CatalogContext {
+		return this.catalogContext ?? { camelVersion: '', runtime: '', frameworkVersion: '', executorType: undefined };
+	}
+
+	/**
+	 * Show warnings for detected argument conflicts
+	 */
+	async showConflictWarnings(conflicts: ArgumentConflict[]): Promise<void> {
+		if (conflicts.length === 0) {
+			return;
+		}
+
+		const message =
+			`Camel argument conflicts detected (user settings override code defaults):\n` +
+			conflicts.map((c) => `  - ${c.argument}: code="${c.codeValue}" overridden by user="${c.userValue}"`).join('\n');
+
+		KaotoOutputChannel.logWarning(message);
+
+		const selection = await window.showInformationMessage(
+			`Camel: ${conflicts.length} argument(s) overridden by user settings. Check output for details.`,
+			'View Output',
+		);
+		if (selection === 'View Output') {
+			KaotoOutputChannel.getInstance().show();
+		}
+	}
+
+	/**
+	 * Handle local kamelet directory argument
+	 */
+	private async handleLocalKameletDirArgument(runArgs: string[], cwd: string): Promise<string[]> {
+		const localKameletDirIndex = runArgs.findIndex((parameter) => parameter.startsWith('--local-kamelet-dir'));
+
+		// If already present, resolve paths
+		if (localKameletDirIndex !== -1) {
+			runArgs[localKameletDirIndex] = await this.resolveAlreadyExistingLocalKameletDirArgument(runArgs[localKameletDirIndex], cwd);
+			return runArgs;
+		}
+
+		// Try to get from global setting
+		const localKameletDirectoriesGlobalArgument = await this.resolveLocalKameletDirsFromGlobalSetting(cwd);
+		if (!localKameletDirectoriesGlobalArgument) {
+			return runArgs;
+		}
+
+		return [...runArgs, localKameletDirectoriesGlobalArgument];
+	}
+
+	/**
+	 * Resolve existing local kamelet directory argument
+	 */
+	private async resolveAlreadyExistingLocalKameletDirArgument(existingKameletDirArgument: string, cwd: string): Promise<string> {
+		const kameletDirPaths = existingKameletDirArgument
+			.replace('--local-kamelet-dir=', '')
+			.split(',')
+			.map((path) => path.trim());
+		const resolvedKameletDirPaths = resolvePaths(kameletDirPaths, cwd);
+		return `'--local-kamelet-dir=${Array.from(resolvedKameletDirPaths).join(',')}'`;
+	}
+
+	/**
+	 * Resolve local kamelet directories from global setting
+	 */
+	private async resolveLocalKameletDirsFromGlobalSetting(cwd: string): Promise<string | undefined> {
+		const localKameletDirectories = workspace.getConfiguration().get(KAOTO_LOCAL_KAMELET_DIRECTORIES_SETTING_ID) as string[];
+		if (localKameletDirectories.length > 0) {
+			return `'--local-kamelet-dir=${Array.from(resolvePaths(localKameletDirectories, cwd)).join(',')}'`;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Get Camel global repos prefix
+	 */
+	private getCamelGlobalRepos(): string {
+		const globalRepos = workspace.getConfiguration().get(KAOTO_EXECUTOR_RED_HAT_MAVEN_REPOSITORY_GLOBAL_SETTING_ID) as boolean;
+		return globalRepos ? '#repos,' : '';
+	}
+
+	/**
+	 * Handle missing XSL files in run arguments
+	 * Mainly in ZSH shell there is problem when Camel is executed with non existing files
+	 * added using '*.xsl' file pattern - it is caused by null glob option disabled by default for ZSH shell
+	 */
+	private async handleMissingXslFiles(filePath: string, runArgs: string[]): Promise<string[]> {
+		const folderUri = Uri.file(dirname(filePath));
+		const xsls = await workspace.findFiles(new RelativePattern(folderUri, '*.xsl'));
+		if (xsls.length > 0) {
+			return runArgs; // don't modify default run arguments which should contain *.xsl
+		} else {
+			return runArgs.filter((parameter) => parameter !== '*.xsl');
+		}
+	}
+}

--- a/src/executors/types/ExecutorConfig.ts
+++ b/src/executors/types/ExecutorConfig.ts
@@ -1,0 +1,33 @@
+/**
+ * Executor configuration types
+ */
+
+import { ExecutorType } from './ExecutorTypes';
+
+/**
+ * Base executor configuration
+ */
+export interface ExecutorConfig {
+	readonly type: ExecutorType;
+	readonly version: string;
+}
+
+/**
+ * JBang executor configuration
+ */
+export interface JBangExecutorConfig extends ExecutorConfig {
+	readonly type: 'jbang';
+}
+
+/**
+ * Camel Launcher executor configuration
+ */
+export interface CamelLauncherExecutorConfig extends ExecutorConfig {
+	readonly type: 'camel-launcher';
+}
+
+/**
+ * Union type for all executor configurations
+ * Note: Extensible for future executor types (e.g., Kaoto Companion)
+ */
+export type AnyExecutorConfig = JBangExecutorConfig | CamelLauncherExecutorConfig;

--- a/src/executors/types/ExecutorTypes.ts
+++ b/src/executors/types/ExecutorTypes.ts
@@ -1,0 +1,46 @@
+/**
+ * Core types for the Camel executor system
+ */
+
+import { ShellExecution } from 'vscode';
+
+/**
+ * Supported executor types
+ */
+export type ExecutorType = 'jbang' | 'camel-launcher';
+
+/**
+ * Supported runtime types
+ */
+export enum RuntimeType {
+	QUARKUS = 'quarkus',
+	SPRING_BOOT = 'spring-boot',
+	MAIN = 'camel-main',
+	CITRUS = 'citrus',
+}
+
+/**
+ * Camel command types
+ */
+export type CamelCommand = 'run' | 'export' | 'init' | 'bind' | 'stop' | 'dependency' | 'cmd' | 'plugin' | 'test' | 'kubernetes';
+
+/**
+ * Command execution context
+ */
+export interface CommandContext {
+	readonly cwd?: string;
+	readonly env?: Record<string, string>;
+}
+
+/**
+ * Command execution result
+ */
+export interface CommandResult {
+	readonly execution: ShellExecution;
+	readonly resolvedPort?: number;
+}
+
+/**
+ * Generic command arguments
+ */
+export type CommandArguments = string[];

--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -61,6 +61,7 @@ import {
 	COMMAND_TESTS_RUN_FOLDER,
 	COMMAND_UNDO,
 	COMMAND_WHATS_NEW_SHOW,
+	CONTEXT_EXECUTOR_AVAILABLE,
 	CONTEXT_JBANG_AVAILABLE,
 	CONTEXT_WORKSPACE_HAS_POM_XML,
 	KAOTO_EDITOR_VIEW_TYPE,
@@ -76,6 +77,7 @@ import {
 import {
 	findFolderOfPomXml,
 	runJBangCommandWithStatusBar,
+	verifyJavaExists,
 	verifyJBangExists,
 	verifyJBangTrustedSources,
 	verifyCamelPluginsAreInstalled,
@@ -219,6 +221,27 @@ export class ExtensionContextHandler {
 			return false;
 		}
 		return true;
+	}
+
+	public async checkJavaOnPath(): Promise<boolean> {
+		const javaExists = await verifyJavaExists();
+		if (!javaExists) {
+			const javaInstallationLink: string = 'https://adoptium.net/installation/';
+			const msg: string = `Java is missing on a system PATH. Camel Launcher requires Java to run. [Java Installation Guide](${javaInstallationLink}).`;
+			KaotoOutputChannel.logWarning(msg);
+			const selection = await vscode.window.showWarningMessage(msg, 'Install');
+			if (selection === undefined) {
+				await vscode.window.showWarningMessage('Java is not installed. Some Kaoto extension features may not work properly.', 'OK');
+			} else {
+				await vscode.commands.executeCommand('vscode.open', `${javaInstallationLink}`);
+			}
+			return false;
+		}
+		return true;
+	}
+
+	public async setExecutorAvailable(available: boolean): Promise<void> {
+		await vscode.commands.executeCommand('setContext', CONTEXT_EXECUTOR_AVAILABLE, available);
 	}
 
 	public async checkJBangTrustedSources() {

--- a/src/helpers/ArgumentConflictDetector.ts
+++ b/src/helpers/ArgumentConflictDetector.ts
@@ -29,7 +29,7 @@ interface ParsedArgument {
 }
 
 /**
- * Utility class for detecting and resolving argument conflicts in Camel JBang commands
+ * Utility class for detecting and resolving argument conflicts in Camel commands
  */
 export class ArgumentConflictDetector {
 	/** Cache for parsed arguments to avoid redundant parsing */
@@ -216,7 +216,7 @@ export class ArgumentConflictDetector {
 	 * @returns Port number if found, undefined otherwise
 	 */
 	static extractPortValue(args: string[]): number | undefined {
-		// Check for --management-port first (takes priority in Camel JBang 4.14+)
+		// Check for --management-port first (takes priority in Camel 4.14+)
 		const managementPort = this.getArgumentValue(args, 'management-port');
 		if (managementPort !== undefined) {
 			const port = Number.parseInt(managementPort, 10);

--- a/src/helpers/MavenRuntimeDetector.ts
+++ b/src/helpers/MavenRuntimeDetector.ts
@@ -1,0 +1,59 @@
+import { execSync } from 'child_process';
+import { satisfies } from 'compare-versions';
+import { RuntimeMavenInformation } from '@kaoto/kaoto';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { KaotoCatalogService } from '../services/KaotoCatalogService';
+import { CamelExecutorFactory } from '../executors/CamelExecutorFactory';
+import { CamelLauncherExecutor } from '../executors/CamelLauncherExecutor';
+import { findFolderOfPomXml, normalizeVersionForSemver } from './helpers';
+import { DEFAULT_CAMEL_VERSION_FALLBACK } from '../constants';
+
+/**
+ * Utility for detecting Maven runtime information from pom.xml
+ */
+export class MavenRuntimeDetector {
+	/**
+	 * Get runtime information from Maven context using the configured executor
+	 * This uses the Camel CLI to detect existing Maven project configuration
+	 */
+	public static async getRuntimeInfoFromMavenContext(integrationFilePath: string): Promise<RuntimeMavenInformation | undefined> {
+		const folderOfPomXml = findFolderOfPomXml(integrationFilePath);
+		if (folderOfPomXml === undefined) {
+			return undefined;
+		}
+
+		try {
+			// Get executor configuration to build the correct command
+			const executor = await CamelExecutorFactory.createExecutor();
+			const config = executor.getConfig();
+
+			// Get Camel version from catalog service - use selected catalog
+			const catalogService = KaotoCatalogService.getInstance();
+			const catalog = await catalogService.getSelectedIntegrationCatalog();
+			const camelVersion = catalogService.getCamelVersionForCLI(catalog, config.type) || DEFAULT_CAMEL_VERSION_FALLBACK;
+
+			// Ensure minimum version 4.13 for dependency runtime --json support
+			const camelVersionToUse = satisfies(normalizeVersionForSemver(camelVersion), '>=4.13') ? camelVersion : '4.13.0';
+
+			// Build command string based on executor type
+			let fullCommand: string;
+			if (config.type === 'jbang') {
+				fullCommand = `jbang -Dcamel.jbang.version=${camelVersionToUse} camel@apache/camel dependency runtime --json pom.xml`;
+			} else {
+				// For camel-launcher, use java -jar <jarPath>
+				const jarPath = (executor as CamelLauncherExecutor).getJarPath();
+				fullCommand = `java -jar ${jarPath} dependency runtime --json pom.xml`;
+			}
+
+			const response: string = execSync(fullCommand, {
+				stdio: 'pipe',
+				cwd: folderOfPomXml,
+			}).toString();
+
+			return JSON.parse(response) as RuntimeMavenInformation;
+		} catch (ex) {
+			KaotoOutputChannel.logError('Error while trying to retrieve the runtime information from Maven context', ex);
+			return undefined;
+		}
+	}
+}

--- a/src/helpers/TestFolderResolver.ts
+++ b/src/helpers/TestFolderResolver.ts
@@ -1,0 +1,84 @@
+import * as path from 'path';
+import { readdir } from 'fs/promises';
+import { Dirent } from 'fs';
+
+/**
+ * Utility class for resolving test folders in a project structure.
+ * Uses BFS (Breadth-First Search) to find test directories.
+ */
+export class TestFolderResolver {
+	private static readonly EXCLUDED_DIRS = new Set([
+		'node_modules',
+		'.git',
+		'dist',
+		'lib',
+		'target',
+		'.citrus-jbang',
+		'.camel-jbang',
+		'.vscode',
+		'.mvn',
+		'out',
+	]);
+
+	/**
+	 * Resolves the test folder from a given base directory.
+	 * Uses BFS to find the first subdirectory whose name contains 'test'.
+	 * Returns baseDir itself if it already contains 'test' in its name,
+	 * or falls back to baseDir when no test directory is found.
+	 *
+	 * @param baseDir - The base directory to start searching from
+	 * @returns The resolved test folder path
+	 */
+	static async resolveTestFolder(baseDir: string): Promise<string> {
+		// Check if the base directory itself is a test folder
+		if (this.isTestFolder(path.basename(baseDir))) {
+			return baseDir;
+		}
+
+		// BFS through the directory hierarchy
+		const queue: string[] = [baseDir];
+
+		while (queue.length > 0) {
+			const current = queue.shift()!;
+			let entries: Dirent[] = [];
+
+			try {
+				entries = await readdir(current, { withFileTypes: true });
+			} catch {
+				// Skip directories we can't read
+				continue;
+			}
+
+			for (const entry of entries) {
+				// Skip non-directories and excluded directories
+				if (!entry.isDirectory() || TestFolderResolver.EXCLUDED_DIRS.has(entry.name)) {
+					continue;
+				}
+
+				const fullPath = path.join(current, entry.name);
+
+				// Check if this is a test folder
+				if (this.isTestFolder(entry.name)) {
+					return fullPath;
+				}
+
+				// Add to queue for further exploration
+				queue.push(fullPath);
+			}
+		}
+
+		// No test folder found, return the base directory
+		return baseDir;
+	}
+
+	/**
+	 * Checks if a directory name indicates it's a test folder.
+	 *
+	 * @param name - The directory name to check
+	 * @returns true if the name indicates a test folder
+	 */
+	private static isTestFolder(name: string): boolean {
+		const n = name.toLowerCase();
+		return n === 'test' || n === 'tests' || n.endsWith('-test') || n.endsWith('-tests');
+	}
+}

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -14,18 +14,50 @@
  * limitations under the License.
  */
 
-import { ProgressLocation, window, workspace, WorkspaceFolder } from 'vscode';
+import { ExtensionContext, ProgressLocation, window, workspace, WorkspaceFolder } from 'vscode';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import fs from 'fs';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
 
 /**
  * Utilizes helper methods used in both, desktop or web extension context
  */
 
+export function safeGlobalStateGet<T>(context: ExtensionContext, key: string, defaultValue: T): T {
+	try {
+		return context.globalState.get<T>(key, defaultValue);
+	} catch (err) {
+		KaotoOutputChannel.logWarning(`Unable to read global state for key '${key}': ${String(err)}`);
+		return defaultValue;
+	}
+}
+
+export async function safeGlobalStateUpdate(context: ExtensionContext, key: string, value: any): Promise<void> {
+	try {
+		await context.globalState.update(key, value);
+	} catch (err) {
+		KaotoOutputChannel.logWarning(`Unable to update global state for key '${key}': ${String(err)}`);
+	}
+}
+
+export function normalizeVersionForSemver(version: string): string {
+	return version.replace(/\.redhat-\d+$/, '');
+}
+
+export function isRedHatBuild(version: string): boolean {
+	return version.includes('.redhat-');
+}
+
 export async function verifyJBangExists(): Promise<boolean> {
-	return await runJBangCommandWithStatusBar(`version`, `Checking JBang executable on PATH...`).then((output) => !output.stderr.includes('command not found')); // JBang exists
+	const output = await runJBangCommandWithStatusBar(`version`, `Checking JBang executable on PATH...`);
+	return output.success;
+}
+
+export async function verifyJavaExists(): Promise<boolean> {
+	const output = await runCommandWithStatusBar('java -version', 'Checking Java executable on PATH...');
+	return output.success;
 }
 
 export async function verifyCamelPluginsAreInstalled(plugins: string[]): Promise<{ plugin: string; installed: boolean }[]> {
@@ -40,7 +72,17 @@ export async function verifyJBangTrustedSources(urls: string[]): Promise<{ url: 
 	});
 }
 
-export async function runJBangCommandWithStatusBar(args: string, msg: string): Promise<{ stdout: string; stderr: string }> {
+export interface CommandOutput {
+	stdout: string;
+	stderr: string;
+	success: boolean;
+}
+
+export async function runJBangCommandWithStatusBar(args: string, msg: string): Promise<CommandOutput> {
+	return runCommandWithStatusBar(`jbang ${args}`, msg);
+}
+
+export async function runCommandWithStatusBar(command: string, msg: string): Promise<CommandOutput> {
 	const execPromise = promisify(exec);
 	return await window.withProgress(
 		{
@@ -51,11 +93,12 @@ export async function runJBangCommandWithStatusBar(args: string, msg: string): P
 		async (progress) => {
 			progress.report({ increment: 0 });
 			try {
-				const { stdout, stderr } = await execPromise(`jbang ${args}`);
+				const { stdout, stderr } = await execPromise(command);
 				progress.report({ increment: 100 });
-				return { stdout, stderr };
+				return { stdout, stderr, success: true };
 			} catch (error) {
-				return { stdout: '', stderr: error instanceof Error ? error.message : String(error) };
+				const message = error instanceof Error ? error.message : String(error);
+				return { stdout: '', stderr: message, success: false };
 			}
 		},
 	);

--- a/src/services/CamelLauncherDownloader.ts
+++ b/src/services/CamelLauncherDownloader.ts
@@ -1,0 +1,157 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as https from 'https';
+import * as os from 'os';
+import { ExtensionContext } from 'vscode';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { isRedHatBuild } from '../helpers/helpers';
+
+/**
+ * Error thrown when Camel Launcher version is not found (404)
+ */
+export class LauncherNotFoundError extends Error {
+	constructor(version: string, url: string) {
+		super(`Camel Launcher ${version} is not available. ` + `This version may not exist in the repository. ` + `Attempted URL: ${url}`);
+		this.name = 'LauncherNotFoundError';
+	}
+}
+
+/**
+ * Service for downloading and managing Camel Launcher JAR distributions
+ */
+export class CamelLauncherDownloader {
+	private static readonly MAVEN_CENTRAL_BASE = 'https://repo1.maven.org/maven2/org/apache/camel/camel-launcher';
+	private static readonly REDHAT_MAVEN_BASE = 'https://maven.repository.redhat.com/ga/org/apache/camel/camel-launcher';
+	private readonly storageDir: string;
+
+	constructor(context?: ExtensionContext, customStorageDir?: string) {
+		// Use custom storage dir, extension global storage, or fallback to temp
+		this.storageDir = customStorageDir || context?.globalStorageUri.fsPath || path.join(os.tmpdir(), 'vscode-kaoto-camel-launcher');
+
+		// Ensure storage directory exists
+		if (!fs.existsSync(this.storageDir)) {
+			fs.mkdirSync(this.storageDir, { recursive: true });
+		}
+	}
+
+	/**
+	 * Ensure Camel Launcher is available, downloading if necessary
+	 * @param version - Camel version to download
+	 * @returns Path to the camel launcher JAR file
+	 */
+	async ensureLauncher(version: string): Promise<string> {
+		const launcherDir = this.getLauncherDirectory(version);
+		const jarPath = path.join(launcherDir, `camel-launcher-${version}.jar`);
+
+		// Check if JAR already exists
+		if (fs.existsSync(jarPath)) {
+			KaotoOutputChannel.logInfo(`Camel Launcher ${version} already available at: ${jarPath}`);
+			return jarPath;
+		}
+
+		// Download JAR
+		KaotoOutputChannel.logInfo(`Downloading Camel Launcher ${version}...`);
+		await this.downloadLauncher(version, launcherDir);
+
+		// Verify JAR was downloaded
+		if (!fs.existsSync(jarPath)) {
+			throw new Error(`Camel Launcher JAR not found after download in ${launcherDir}`);
+		}
+
+		return jarPath;
+	}
+
+	/**
+	 * Get Maven repository base URL for the version
+	 */
+	private getMavenBaseUrl(version: string): string {
+		return isRedHatBuild(version) ? CamelLauncherDownloader.REDHAT_MAVEN_BASE : CamelLauncherDownloader.MAVEN_CENTRAL_BASE;
+	}
+
+	/**
+	 * Download Camel Launcher JAR from appropriate Maven repository
+	 */
+	private async downloadLauncher(version: string, targetDir: string): Promise<void> {
+		const jarPath = path.join(targetDir, `camel-launcher-${version}.jar`);
+		const mavenBaseUrl = this.getMavenBaseUrl(version);
+
+		// Ensure target directory exists
+		if (!fs.existsSync(targetDir)) {
+			fs.mkdirSync(targetDir, { recursive: true });
+		}
+
+		// Download JAR file
+		const downloadUrl = `${mavenBaseUrl}/${version}/camel-launcher-${version}.jar`;
+
+		try {
+			KaotoOutputChannel.logInfo(`Downloading JAR from: ${downloadUrl}`);
+			await this.downloadFile(downloadUrl, jarPath);
+			KaotoOutputChannel.logInfo(`JAR downloaded successfully to: ${jarPath}`);
+		} catch (error) {
+			// Handle 404 errors with a specific error type
+			if (error instanceof Error && error.message.includes('HTTP 404')) {
+				throw new LauncherNotFoundError(version, downloadUrl);
+			}
+			// For other errors, throw with details
+			throw new Error(`Failed to download Camel Launcher ${version} from ${downloadUrl}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	/**
+	 * Download file from URL
+	 */
+	private downloadFile(url: string, targetPath: string): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const file = fs.createWriteStream(targetPath);
+
+			https
+				.get(url, (response) => {
+					// Handle redirects
+					if (response.statusCode === 301 || response.statusCode === 302) {
+						const redirectUrl = response.headers.location;
+						if (redirectUrl) {
+							file.close();
+							fs.unlinkSync(targetPath);
+							this.downloadFile(redirectUrl, targetPath).then(resolve).catch(reject);
+							return;
+						}
+					}
+
+					if (response.statusCode !== 200) {
+						file.close();
+						fs.unlinkSync(targetPath);
+						reject(new Error(`Failed to download: HTTP ${response.statusCode}`));
+						return;
+					}
+
+					response.pipe(file);
+
+					file.on('finish', () => {
+						file.close();
+						resolve();
+					});
+				})
+				.on('error', (error) => {
+					file.close();
+					if (fs.existsSync(targetPath)) {
+						fs.unlinkSync(targetPath);
+					}
+					reject(error);
+				});
+		});
+	}
+
+	/**
+	 * Get launcher directory for specific version
+	 */
+	private getLauncherDirectory(version: string): string {
+		return path.join(this.storageDir, `camel-launcher-${version}`);
+	}
+
+	/**
+	 * Get storage directory
+	 */
+	getStorageDirectory(): string {
+		return this.storageDir;
+	}
+}

--- a/src/services/KaotoCatalogService.ts
+++ b/src/services/KaotoCatalogService.ts
@@ -1,0 +1,710 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { RedHatMavenNotificationService } from './RedHatMavenNotificationService';
+import { RuntimeType, ExecutorType } from '../executors/types/ExecutorTypes';
+import { isRedHatBuild } from '../helpers/helpers';
+
+/**
+ * Grouped catalogs by runtime type
+ */
+interface GroupedCatalogs {
+	[runtime: string]: CatalogLibraryEntry[];
+}
+
+/**
+ * Extended QuickPickItem with catalog data
+ */
+interface CatalogQuickPickItem extends vscode.QuickPickItem {
+	catalog?: CatalogLibraryEntry;
+}
+
+/**
+ * Service for managing Kaoto catalog selection and operations (Camel and Citrus)
+ */
+export class KaotoCatalogService {
+	private static instance: KaotoCatalogService;
+	private catalogs: CatalogLibraryEntry[] = [];
+	private statusBarItem: vscode.StatusBarItem | undefined;
+	private readonly catalogBasePath: string;
+	private readonly catalogIndexPath: string;
+	private readonly redHatNotificationService: RedHatMavenNotificationService;
+
+	constructor(private readonly context: vscode.ExtensionContext) {
+		// Path to the catalog directory copied by webpack during build
+		this.catalogBasePath = path.join(context.extensionPath, 'dist', 'webview', 'editors', 'kaoto', 'camel-catalog');
+		this.catalogIndexPath = path.join(this.catalogBasePath, 'index.json');
+		this.redHatNotificationService = new RedHatMavenNotificationService(context);
+		KaotoCatalogService.instance = this;
+	}
+
+	/**
+	 * Get the singleton instance
+	 */
+	public static getInstance(): KaotoCatalogService {
+		if (!KaotoCatalogService.instance) {
+			throw new Error('KaotoCatalogService not initialized. Call initialize() first.');
+		}
+		return KaotoCatalogService.instance;
+	}
+
+	/**
+	 * Initialize the catalog service by loading available catalogs
+	 */
+	public async initialize(): Promise<void> {
+		try {
+			await this.loadCatalogs();
+			KaotoOutputChannel.logInfo(`Loaded ${this.catalogs.length} Camel catalog definitions`);
+
+			// Log default catalog
+			const defaultCatalog = this.getDefaultCatalog();
+			if (defaultCatalog) {
+				KaotoOutputChannel.logInfo(`Default catalog: ${defaultCatalog.name}`);
+			} else {
+				KaotoOutputChannel.logWarning('No default catalog found');
+			}
+		} catch (error) {
+			KaotoOutputChannel.logError('Failed to initialize KaotoCatalogService', error);
+			vscode.window.showErrorMessage('Failed to load Camel catalogs. Some features may not work correctly.');
+		}
+	}
+
+	/**
+	 * Load catalogs from custom URL when configured, otherwise from local index.json
+	 */
+	private getCustomCatalogUrl(): string | undefined {
+		return vscode.workspace.getConfiguration('kaoto').get<string | null>('catalog.url')?.trim() || undefined;
+	}
+
+	private async loadCatalogs(): Promise<void> {
+		const customCatalogUrl = this.getCustomCatalogUrl();
+
+		if (customCatalogUrl) {
+			try {
+				const response = await fetch(customCatalogUrl);
+
+				if (!response.ok) {
+					throw new Error(`HTTP ${response.status} ${response.statusText}`.trim());
+				}
+
+				const catalogIndex = (await response.json()) as CatalogLibrary;
+				this.catalogs = catalogIndex.definitions || [];
+				KaotoOutputChannel.logInfo(`Loaded catalog index from custom URL: ${customCatalogUrl}`);
+				return;
+			} catch (error) {
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				KaotoOutputChannel.logWarning(`Failed to load catalog index from custom URL ${customCatalogUrl}: ${errorMessage}`);
+				void vscode.window.showWarningMessage(
+					`Failed to fetch Kaoto catalog from setting "kaoto.catalog.url". Falling back to local node_modules catalog. ${errorMessage}`,
+				);
+			}
+		}
+
+		try {
+			const indexContent = await fs.promises.readFile(this.catalogIndexPath, 'utf-8');
+			const catalogIndex: CatalogLibrary = JSON.parse(indexContent);
+			this.catalogs = catalogIndex.definitions || [];
+		} catch (error) {
+			KaotoOutputChannel.logError(`Failed to load catalog index from ${this.catalogIndexPath}`, error);
+			throw error;
+		}
+	}
+
+	/**
+	 * Get all available catalogs
+	 */
+	public getCatalogs(): CatalogLibraryEntry[] {
+		return [...this.catalogs];
+	}
+
+	/**
+	 * Group catalogs by runtime type
+	 */
+	public getCatalogsByRuntime(): GroupedCatalogs {
+		const grouped: GroupedCatalogs = {};
+
+		for (const catalog of this.catalogs) {
+			const runtime = catalog.runtime;
+			if (!grouped[runtime]) {
+				grouped[runtime] = [];
+			}
+			grouped[runtime].push(catalog);
+		}
+
+		return grouped;
+	}
+
+	/**
+	 * Normalize runtime name from index.json to simplified format
+	 */
+	private normalizeRuntime(runtime: string): RuntimeType {
+		const normalized = runtime.toLowerCase().replaceAll(/\s+/g, '-');
+		if (normalized.includes('citrus')) {
+			return RuntimeType.CITRUS;
+		} else if (normalized.includes('spring')) {
+			return RuntimeType.SPRING_BOOT;
+		} else if (normalized.includes('quarkus')) {
+			return RuntimeType.QUARKUS;
+		}
+		return RuntimeType.MAIN;
+	}
+
+	/**
+	 * Build display label from catalog definition
+	 */
+	public static buildDisplayLabel(catalog: CatalogLibraryEntry): string {
+		return `Camel ${catalog.runtime} ${catalog.version}`;
+	}
+
+	/**
+	 * Find catalog definition by name (e.g., "Camel Main 4.14.7" or "Citrus 4.10.1")
+	 */
+	private findCatalogByName(name: string): CatalogLibraryEntry | undefined {
+		return this.catalogs.find((c) => c.name === name);
+	}
+
+	/**
+	 * Get the selected catalog for a workspace, or default if none selected
+	 * Automatically determines whether to use integration or test catalog based on file type
+	 */
+	public async getSelectedCatalog(resourceUri?: vscode.Uri): Promise<CatalogLibraryEntry | undefined> {
+		// Determine file type and delegate to appropriate method
+		if (resourceUri && this.isKaotoCitrusTestFile(resourceUri)) {
+			return this.getSelectedTestCatalog(resourceUri);
+		} else {
+			return this.getSelectedIntegrationCatalog(resourceUri);
+		}
+	}
+
+	private async getSelectedCatalogByKey(
+		settingKey: string,
+		catalogTypeLabel: string,
+		getDefault: () => CatalogLibraryEntry | undefined,
+		resourceUri?: vscode.Uri,
+	): Promise<CatalogLibraryEntry | undefined> {
+		const config = vscode.workspace.getConfiguration('kaoto', resourceUri);
+		const catalogName = config.get<string>(settingKey);
+
+		if (catalogName) {
+			const catalog = this.findCatalogByName(catalogName);
+			if (catalog) {
+				return catalog;
+			}
+			KaotoOutputChannel.logWarning(
+				`Invalid ${catalogTypeLabel} catalog name in settings: "${catalogName}". ` +
+					`This catalog is not available. Using default catalog instead. ` +
+					`Use the status bar or command palette to select a valid catalog.`,
+			);
+			vscode.window
+				.showWarningMessage(`Kaoto: Invalid ${catalogTypeLabel} catalog name "${catalogName}". Using default instead.`, 'Select Valid Catalog')
+				.then((choice) => {
+					if (choice === 'Select Valid Catalog') {
+						vscode.commands.executeCommand('kaoto.selectCamelCatalog');
+					}
+				});
+		}
+
+		return getDefault();
+	}
+
+	/**
+	 * Get the selected integration catalog for a workspace, or default if none selected
+	 */
+	public async getSelectedIntegrationCatalog(resourceUri?: vscode.Uri): Promise<CatalogLibraryEntry | undefined> {
+		return this.getSelectedCatalogByKey('runtimeCatalogName', 'runtime', () => this.getDefaultIntegrationCatalog(), resourceUri);
+	}
+
+	/**
+	 * Get the selected test catalog for a workspace, or default if none selected
+	 */
+	public async getSelectedTestCatalog(resourceUri?: vscode.Uri): Promise<CatalogLibraryEntry | undefined> {
+		return this.getSelectedCatalogByKey('testingCatalogName', 'testing', () => this.getDefaultTestCatalog(), resourceUri);
+	}
+
+	/**
+	 * Set the selected catalog for a workspace
+	 * Automatically determines whether to store as integration or test catalog based on catalog runtime
+	 */
+	public async setSelectedCatalog(catalog: CatalogLibraryEntry, resourceUri?: vscode.Uri): Promise<void> {
+		// Determine if this is a Citrus catalog
+		const isCitrusCatalog = this.normalizeRuntime(catalog.runtime) === RuntimeType.CITRUS;
+
+		if (isCitrusCatalog) {
+			await this.setSelectedTestCatalog(catalog, resourceUri);
+		} else {
+			await this.setSelectedIntegrationCatalog(catalog, resourceUri);
+		}
+	}
+
+	private applyStatusBarLabel(displayLabel: string): void {
+		if (this.statusBarItem) {
+			this.statusBarItem.text = `$(package) ${displayLabel}`;
+			this.statusBarItem.tooltip = 'Select Camel Catalog Version';
+			this.statusBarItem.command = 'kaoto.selectCamelCatalog';
+			this.statusBarItem.show();
+		}
+	}
+
+	private async setSelectedCatalogByType(
+		catalog: CatalogLibraryEntry,
+		resourceUri: vscode.Uri | undefined,
+		options: {
+			settingKey: string;
+			logLabel: string;
+			getPrevious: (uri?: vscode.Uri) => Promise<CatalogLibraryEntry | undefined>;
+			isActiveFileMatch: (uri: vscode.Uri) => boolean;
+			reopenMessage: string;
+		},
+	): Promise<void> {
+		const previousCatalog = await options.getPrevious(resourceUri);
+
+		const isCatalogChanging =
+			previousCatalog?.version !== catalog.version || this.normalizeRuntime(previousCatalog.runtime) !== this.normalizeRuntime(catalog.runtime);
+
+		const config = vscode.workspace.getConfiguration('kaoto', resourceUri);
+		await config.update(options.settingKey, catalog.name, vscode.ConfigurationTarget.Workspace);
+
+		const displayLabel = KaotoCatalogService.buildDisplayLabel(catalog);
+		KaotoOutputChannel.logInfo(`Selected ${options.logLabel} catalog: ${displayLabel}`);
+
+		this.applyStatusBarLabel(displayLabel);
+
+		const activeKaotoUri = this.getActiveKaotoDocumentUri();
+		if (isCatalogChanging && activeKaotoUri && options.isActiveFileMatch(activeKaotoUri)) {
+			const action = await vscode.window.showInformationMessage(options.reopenMessage, 'Reopen');
+			if (action === 'Reopen') {
+				await this.reopenCurrentEditor(activeKaotoUri);
+			}
+		}
+	}
+
+	/**
+	 * Set the selected integration catalog for a workspace
+	 */
+	public async setSelectedIntegrationCatalog(catalog: CatalogLibraryEntry, resourceUri?: vscode.Uri): Promise<void> {
+		return this.setSelectedCatalogByType(catalog, resourceUri, {
+			settingKey: 'runtimeCatalogName',
+			logLabel: 'integration',
+			getPrevious: (uri) => this.getSelectedIntegrationCatalog(uri),
+			isActiveFileMatch: (uri) => this.isKaotoIntegrationFile(uri),
+			reopenMessage: 'Integration catalog version changed. Reopen editor to apply changes.',
+		});
+	}
+
+	/**
+	 * Set the selected test catalog for a workspace
+	 */
+	public async setSelectedTestCatalog(catalog: CatalogLibraryEntry, resourceUri?: vscode.Uri): Promise<void> {
+		return this.setSelectedCatalogByType(catalog, resourceUri, {
+			settingKey: 'testingCatalogName',
+			logLabel: 'test',
+			getPrevious: (uri) => this.getSelectedTestCatalog(uri),
+			isActiveFileMatch: (uri) => this.isKaotoCitrusTestFile(uri),
+			reopenMessage: 'Test catalog version changed. Reopen editor to apply changes.',
+		});
+	}
+
+	/**
+	 * Get the default catalog based on file type
+	 * - For test files: latest Citrus catalog
+	 * - For integration files: latest Camel Main RedHat version (or latest Main if no RedHat version available)
+	 */
+	public getDefaultCatalog(resourceUri?: vscode.Uri): CatalogLibraryEntry | undefined {
+		// Check if this is a Citrus test file
+		const isCitrusTest = resourceUri ? this.isKaotoCitrusTestFile(resourceUri) : false;
+
+		if (isCitrusTest) {
+			return this.getDefaultTestCatalog();
+		} else {
+			return this.getDefaultIntegrationCatalog();
+		}
+	}
+
+	private static getLatestByVersion(catalogs: CatalogLibraryEntry[]): CatalogLibraryEntry | undefined {
+		if (catalogs.length === 0) {
+			return undefined;
+		}
+		return catalogs.toSorted((a, b) => b.version.localeCompare(a.version, undefined, { numeric: true }))[0];
+	}
+
+	/**
+	 * Get the default integration catalog (latest Camel Main RedHat version, or latest Main if no RedHat version available)
+	 */
+	public getDefaultIntegrationCatalog(): CatalogLibraryEntry | undefined {
+		const mainCatalogs = this.catalogs.filter((c) => c.runtime === 'Main');
+
+		if (mainCatalogs.length === 0) {
+			return this.catalogs[0];
+		}
+
+		const redhatCatalogs = mainCatalogs.filter((c) => isRedHatBuild(c.version));
+		return KaotoCatalogService.getLatestByVersion(redhatCatalogs) ?? KaotoCatalogService.getLatestByVersion(mainCatalogs);
+	}
+
+	/**
+	 * Get the default test catalog (latest Citrus catalog)
+	 */
+	public getDefaultTestCatalog(): CatalogLibraryEntry | undefined {
+		const citrusCatalogs = this.catalogs.filter((c) => c.runtime.toLowerCase() === RuntimeType.CITRUS);
+		return KaotoCatalogService.getLatestByVersion(citrusCatalogs);
+	}
+	/**
+	 * Get the CLI version (JBang version) from catalog selection
+	 * This is used for the -Dcamel.jbang.version system property in JBang executor
+	 *
+	 * @param catalog The catalog definition to get CLI version for
+	 * @returns The CLI version to use with -Dcamel.jbang.version, or undefined if not found
+	 */
+	public getCliVersionForJBang(catalog: CatalogLibraryEntry | undefined): string | undefined {
+		if (!catalog) {
+			return undefined;
+		}
+
+		return catalog.cliVersion;
+	}
+
+	/**
+	 * Get the Camel version for CLI from catalog selection
+	 * For Camel Launcher: Uses the executorVersion field (JAR version)
+	 * For JBang: Uses the catalog version directly (for --camel-version flag)
+	 * (handles cases where catalog version != Camel version, e.g., Quarkus platform BOM versions, RedHat build numbers)
+	 *
+	 * @param catalog The catalog definition to get Camel version for
+	 * @param executorType The type of executor being used (optional, defaults to current executor)
+	 * @returns The Camel version to use with --camel-version parameter, or undefined if not found
+	 */
+	public getCamelVersionForCLI(catalog: CatalogLibraryEntry | undefined, executorType?: ExecutorType): string | undefined {
+		if (!catalog) {
+			return undefined;
+		}
+
+		// For Camel Launcher, use executorVersion if available (JAR is version-specific)
+		// For JBang, always use catalog version (--camel-version flag needs catalog version)
+		if (executorType === 'camel-launcher' && catalog.executorVersion) {
+			return catalog.executorVersion;
+		}
+
+		// For JBang with Quarkus runtime, use frameworkVersion (Quarkus platform version)
+		const runtime = this.getRuntimeForCLI(catalog);
+		if (executorType === 'jbang' && runtime === RuntimeType.QUARKUS && catalog.frameworkVersion) {
+			return catalog.frameworkVersion;
+		}
+
+		// For JBang or when executorVersion is not available, use Camel catalog version
+		return catalog.camelCatalogVersion ? catalog.camelCatalogVersion : catalog.version;
+	}
+
+	/**
+	 * Get the runtime parameter for CLI from catalog selection
+	 * Normalizes the runtime name to the format expected by Camel CLI
+	 *
+	 * @param catalog The catalog definition to get runtime for
+	 * @returns The runtime to use with --runtime parameter, or undefined if not found
+	 */
+	public getRuntimeForCLI(catalog: CatalogLibraryEntry | undefined): RuntimeType | undefined {
+		if (!catalog) {
+			return undefined;
+		}
+
+		// Use normalized runtime
+		return this.normalizeRuntime(catalog.runtime);
+	}
+
+	/**
+	 * Get both Camel version and runtime for CLI from catalog selection
+	 * Convenience method that combines getCamelVersionForCLI and getRuntimeForCLI
+	 *
+	 * @param catalog The catalog definition to get CLI parameters for
+	 * @param executorType The type of executor being used (optional)
+	 * @returns Object with executorVersion and runtime, or empty object if catalog is undefined
+	 */
+	public getCLIParameters(catalog: CatalogLibraryEntry | undefined, executorType?: ExecutorType): { executorVersion?: string; runtime?: RuntimeType } {
+		if (!catalog) {
+			return {};
+		}
+
+		return {
+			executorVersion: this.getCamelVersionForCLI(catalog, executorType),
+			runtime: this.getRuntimeForCLI(catalog),
+		};
+	}
+
+	/**
+	 * Check if a workspace is a Maven project
+	 */
+	public static async isMavenProject(resourceUri: vscode.Uri): Promise<boolean> {
+		const workspaceFolder = vscode.workspace.getWorkspaceFolder(resourceUri);
+		if (!workspaceFolder) {
+			return false;
+		}
+
+		const pomPath = path.join(workspaceFolder.uri.fsPath, 'pom.xml');
+		try {
+			await fs.promises.access(pomPath);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Create and show the status bar item
+	 */
+	public createStatusBarItem(): vscode.StatusBarItem {
+		this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+
+		this.statusBarItem.command = 'kaoto.selectCamelCatalog';
+		this.statusBarItem.tooltip = 'Select Camel Catalog Version';
+
+		// Don't show status bar initially - wait for Kaoto editor to be active
+		KaotoOutputChannel.logInfo('Status bar created (hidden until Kaoto editor is active)');
+
+		// Update status bar based on current editor
+		void this.updateStatusBar();
+
+		// Listen for workspace folder changes
+		this.context.subscriptions.push(
+			vscode.workspace.onDidChangeWorkspaceFolders(() => {
+				void this.updateStatusBar();
+			}),
+			vscode.workspace.onDidChangeConfiguration((e) => {
+				if (
+					e.affectsConfiguration('kaoto.runtimeCatalogName') ||
+					e.affectsConfiguration('kaoto.testingCatalogName') ||
+					e.affectsConfiguration('kaoto.catalog.url')
+				) {
+					void this.loadCatalogs();
+					void this.updateStatusBar();
+				}
+			}),
+			vscode.window.onDidChangeActiveTextEditor(() => {
+				void this.updateStatusBar();
+			}),
+			vscode.window.tabGroups.onDidChangeTabGroups(() => {
+				void this.updateStatusBar();
+			}),
+		);
+
+		return this.statusBarItem;
+	}
+
+	/**
+	 * Update the status bar item text and visibility
+	 * Status bar is visible when:
+	 * - A Kaoto editor is actively open/focused
+	 * - The workspace is not a Maven project
+	 */
+	private async updateStatusBar(): Promise<void> {
+		if (!this.statusBarItem) {
+			return;
+		}
+
+		const documentUri = this.getActiveKaotoDocumentUri();
+
+		// If no active Kaoto editor found, hide status bar
+		if (!documentUri) {
+			this.statusBarItem.hide();
+			return;
+		}
+
+		// Check if Maven project
+		const isMaven = await KaotoCatalogService.isMavenProject(documentUri);
+		if (isMaven) {
+			KaotoOutputChannel.logInfo('Status bar: Maven project detected, hiding status bar');
+			this.statusBarItem.hide();
+			return;
+		}
+
+		const catalog = (await this.getSelectedCatalog(documentUri)) ?? this.getDefaultCatalog(documentUri);
+		if (!catalog) {
+			KaotoOutputChannel.logWarning('Status bar: No catalog available, hiding');
+			this.statusBarItem.hide();
+			return;
+		}
+
+		if (!(await this.getSelectedCatalog(documentUri))) {
+			KaotoOutputChannel.logWarning('No catalog found for Kaoto file, using default');
+		}
+
+		this.applyStatusBarLabel(KaotoCatalogService.buildDisplayLabel(catalog));
+		await this.checkAndShowRedHatNotification();
+	}
+
+	/**
+	 * Get the active Kaoto document URI from either the focused webview tab or text editor
+	 */
+	private getActiveKaotoDocumentUri(): vscode.Uri | undefined {
+		const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+		if (activeTab?.input && typeof activeTab.input === 'object' && activeTab.input !== null && 'uri' in activeTab.input) {
+			const tabUri = (activeTab.input as { uri: vscode.Uri }).uri;
+			if (this.isKaotoFile(tabUri)) {
+				return tabUri;
+			}
+		}
+
+		const activeEditor = vscode.window.activeTextEditor;
+		if (activeEditor && this.isKaotoFile(activeEditor.document.uri)) {
+			return activeEditor.document.uri;
+		}
+
+		return undefined;
+	}
+
+	/**
+	 * Check if a file is a Kaoto-supported file (integration or test)
+	 */
+	private isKaotoFile(uri: vscode.Uri): boolean {
+		return this.isKaotoIntegrationFile(uri) || this.isKaotoCitrusTestFile(uri);
+	}
+
+	/**
+	 * Check if a file is a Kaoto integration file (camel, kamelet, pipe)
+	 */
+	private isKaotoIntegrationFile(uri: vscode.Uri): boolean {
+		const fileName = path.basename(uri.fsPath);
+		return /\.(camel|kamelet|pipe)\.(yaml|yml)$/.test(fileName) || /-pipe\.(yaml|yml)$/.test(fileName) || fileName.endsWith('.camel.xml');
+	}
+
+	/**
+	 * Check if a file is a Kaoto Citrus test file
+	 */
+	private isKaotoCitrusTestFile(uri: vscode.Uri): boolean {
+		const fileName = path.basename(uri.fsPath);
+		return /\.citrus\.(yaml|yml)$/.test(fileName) || /\.citrus[.-](test|it)\.(yaml|yml)$/.test(fileName);
+	}
+
+	/**
+	 * Show the catalog picker QuickPick
+	 * @returns true if a catalog was selected, false if cancelled or no selection made
+	 */
+	public async showCatalogPicker(): Promise<boolean> {
+		const resourceUri = this.getActiveKaotoDocumentUri();
+
+		// Check if Maven project
+		if (resourceUri && (await KaotoCatalogService.isMavenProject(resourceUri))) {
+			vscode.window.showInformationMessage('Catalog version is managed by pom.xml in Maven projects.');
+			return false;
+		}
+
+		if (this.getCustomCatalogUrl()) {
+			await this.loadCatalogs();
+		}
+
+		// Determine if current file is a Citrus test file
+		const isCitrusTestFile = resourceUri ? this.isKaotoCitrusTestFile(resourceUri) : false;
+
+		const groupedCatalogs = this.getCatalogsByRuntime();
+		const currentCatalog = await this.getSelectedCatalog(resourceUri);
+
+		// Create QuickPick items grouped by runtime
+		const items: CatalogQuickPickItem[] = [];
+
+		for (const [runtime, catalogs] of Object.entries(groupedCatalogs)) {
+			// Filter catalogs based on file type:
+			// - For Citrus test files: show ONLY Citrus catalogs
+			// - For integration files: show all catalogs EXCEPT Citrus
+			const filteredCatalogs = catalogs.filter((catalog) => {
+				const isCitrusCatalog = catalog.runtime.toLowerCase() === RuntimeType.CITRUS;
+				if (isCitrusTestFile) {
+					// For test files, only show Citrus catalogs
+					return isCitrusCatalog;
+				} else {
+					// For integration files, exclude Citrus catalogs
+					return !isCitrusCatalog;
+				}
+			});
+
+			// Skip runtime group if no catalogs after filtering
+			if (filteredCatalogs.length === 0) {
+				continue;
+			}
+
+			// Add runtime header
+			items.push({
+				label: runtime,
+				kind: vscode.QuickPickItemKind.Separator,
+			});
+
+			// Add catalog items for this runtime
+			for (const catalog of filteredCatalogs) {
+				const displayLabel = KaotoCatalogService.buildDisplayLabel(catalog);
+				const isCurrent =
+					currentCatalog?.version === catalog.version && this.normalizeRuntime(currentCatalog.runtime) === this.normalizeRuntime(catalog.runtime);
+				items.push({
+					label: isCurrent ? `$(check) ${displayLabel}` : displayLabel,
+					detail: isCurrent ? 'Currently selected' : undefined,
+					catalog: catalog,
+				});
+			}
+		}
+
+		const selected = await vscode.window.showQuickPick(items, {
+			placeHolder: isCitrusTestFile ? 'Select Citrus Catalog Version' : 'Select Camel Catalog Version',
+			matchOnDescription: true,
+			matchOnDetail: true,
+		});
+
+		if (selected?.catalog) {
+			const catalog = selected.catalog;
+			await this.setSelectedCatalog(catalog, resourceUri);
+
+			// Show Red Hat Maven notification if the selected catalog is a Red Hat version
+			await this.checkAndShowRedHatNotification();
+
+			return true; // Catalog was selected
+		}
+
+		return false; // No selection made (cancelled or closed)
+	}
+
+	/**
+	 * Reopen the current editor (close and open again)
+	 * This is used to apply catalog version changes to the active editor
+	 */
+	private async reopenCurrentEditor(uri: vscode.Uri): Promise<void> {
+		try {
+			// Close the current editor
+			await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+
+			// Small delay to ensure the editor is fully closed
+			await new Promise((resolve) => setTimeout(resolve, 100));
+
+			// Reopen the editor
+			await vscode.commands.executeCommand('vscode.open', uri);
+
+			KaotoOutputChannel.logInfo(`Reopened editor for ${uri.fsPath}`);
+		} catch (error) {
+			KaotoOutputChannel.logError(`Failed to reopen editor for ${uri.fsPath}`, error);
+			vscode.window.showErrorMessage('Failed to reopen editor. Please close and reopen manually.');
+		}
+	}
+
+	/**
+	 * Check if the current catalog is Red Hat and show notification if needed
+	 * Called during initialization and when opening editors
+	 */
+	private async checkAndShowRedHatNotification(): Promise<void> {
+		try {
+			// Get the currently selected integration catalog
+			const catalog = await this.getSelectedIntegrationCatalog();
+
+			if (catalog && this.redHatNotificationService.isRedHatCatalog(catalog.version)) {
+				const executorType = vscode.workspace.getConfiguration('kaoto').get<string>('executor.type') || 'jbang';
+				await this.redHatNotificationService.showRedHatMavenNotification(catalog.version, executorType);
+			}
+		} catch (error) {
+			// Don't fail initialization if notification check fails
+			const errorMsg = error instanceof Error ? error.message : String(error);
+			KaotoOutputChannel.logWarning(`Failed to check Red Hat catalog notification: ${errorMsg}`);
+		}
+	}
+
+	/**
+	 * Dispose of resources
+	 */
+	public dispose(): void {
+		this.statusBarItem?.dispose();
+	}
+}

--- a/src/services/RedHatMavenNotificationService.ts
+++ b/src/services/RedHatMavenNotificationService.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { safeGlobalStateGet, safeGlobalStateUpdate, isRedHatBuild } from '../helpers/helpers';
+
+const DONT_SHOW_AGAIN_KEY = 'kaoto.redhat.maven.notification.dontShowAgain';
+
+const RED_HAT_MAVEN_DOCS_URL =
+	'https://docs.redhat.com/es/documentation/red_hat_build_of_apache_camel/4.18/html/getting_started_with_red_hat_build_of_apache_camel_for_spring_boot/set-up-maven-locally#add-red-hat-repositories-to-maven';
+
+/**
+ * Manages Red Hat Maven settings notifications.
+ * Owned by KaotoCatalogService -- no singleton needed.
+ */
+export class RedHatMavenNotificationService {
+	constructor(private readonly context: vscode.ExtensionContext) {}
+
+	private isDontShowAgainEnabled(): boolean {
+		return safeGlobalStateGet(this.context, DONT_SHOW_AGAIN_KEY, false);
+	}
+
+	private async setDontShowAgain(value: boolean): Promise<void> {
+		await safeGlobalStateUpdate(this.context, DONT_SHOW_AGAIN_KEY, value);
+		KaotoOutputChannel.logInfo(`Red Hat Maven notification preference updated: dontShowAgain=${value}`);
+	}
+
+	public isRedHatCatalog(catalogVersion: string): boolean {
+		return isRedHatBuild(catalogVersion);
+	}
+
+	/**
+	 * Show notification about Red Hat Maven settings requirement.
+	 * Only shown for JBang executor with Red Hat catalog when user hasn't dismissed it.
+	 */
+	public async showRedHatMavenNotification(catalogVersion: string, executorType: string): Promise<void> {
+		if (this.isDontShowAgainEnabled()) {
+			KaotoOutputChannel.logInfo('Red Hat Maven notification suppressed (user selected "Don\'t show again")');
+			return;
+		}
+
+		if (executorType !== 'jbang') {
+			return;
+		}
+
+		if (!this.isRedHatCatalog(catalogVersion)) {
+			return;
+		}
+
+		KaotoOutputChannel.logInfo(`Showing Red Hat Maven notification for catalog version: ${catalogVersion}`);
+
+		const message =
+			`You are using Red Hat Camel catalog (${catalogVersion}) with JBang CLI. ` +
+			`Specific Maven settings.xml configuration is required for proper functionality.`;
+
+		const action = await vscode.window.showInformationMessage(message, 'View Documentation', "Don't Show Again");
+
+		if (action === 'View Documentation') {
+			await vscode.env.openExternal(vscode.Uri.parse(RED_HAT_MAVEN_DOCS_URL));
+			KaotoOutputChannel.logInfo('User opened Red Hat Maven documentation');
+		} else if (action === "Don't Show Again") {
+			await this.setDontShowAgain(true);
+			vscode.window.showInformationMessage('Red Hat Maven notification disabled. You can re-enable it in extension settings.');
+		}
+	}
+}

--- a/src/tasks/CamelTask.ts
+++ b/src/tasks/CamelTask.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
+import { ProgressLocation, ShellExecution, Task, TaskDefinition, TaskPanelKind, TaskRevealKind, tasks, TaskScope, window, WorkspaceFolder } from 'vscode';
+
+export interface CamelTaskDefinition extends TaskDefinition {
+	label: string;
+	type: 'camel';
+	port: number;
+}
+
+/**
+ * This class represents implementation of vscode.task for Camel commands.
+ * Uses the generic executor abstraction (JBang or Camel Launcher).
+ */
+export class CamelTask extends Task {
+	// Constant for indicating no port is specified
+	public static readonly NO_PORT = -1;
+
+	protected label: string;
+
+	constructor(
+		scope: WorkspaceFolder | TaskScope.Workspace,
+		label: string,
+		shellExecution: ShellExecution,
+		closePanel: boolean = false,
+		revealTask: TaskRevealKind = TaskRevealKind.Always,
+		port: number = CamelTask.NO_PORT,
+	) {
+		const taskDefinition: CamelTaskDefinition = {
+			label,
+			type: 'camel',
+			port: port,
+		};
+
+		super(taskDefinition, scope, label, 'kaoto', shellExecution);
+		this.label = label;
+		this.presentationOptions = {
+			clear: true, // clear terminal before task execution
+			echo: false, // do not echo task command into terminal
+			showReuseMessage: false, // do not show "Terminal will be reused by tasks, press any key to close it" message at the end of each task
+			panel: TaskPanelKind.New,
+			close: closePanel, // (optional) the terminal is closed after executing the task, default is false = not to close
+			reveal: revealTask, // task output is reveal in the user interface, default is RevealKind.Always
+		};
+	}
+
+	/**
+	 * Execute and wait till the end of the task
+	 */
+	public async executeAndWait(): Promise<void> {
+		await this.execute();
+		await this.waitForEnd();
+	}
+
+	public async executeAndWaitWithProgress(message: string): Promise<void> {
+		await this.execute();
+		await window.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: message,
+				cancellable: false,
+			},
+			(progress) => {
+				progress.report({ increment: 0 });
+				return new Promise<void>((resolve, reject) => {
+					progress.report({ increment: 50 });
+					const disposable = tasks.onDidEndTaskProcess((e) => {
+						if (e.execution.task.name === this.label) {
+							disposable.dispose();
+							progress.report({ increment: 100 });
+							if (e.exitCode === 0) {
+								resolve();
+							} else {
+								reject(new Error(`Task "${this.label}" failed with exit code ${e.exitCode}`));
+							}
+						}
+					});
+				});
+			},
+		);
+	}
+
+	/**
+	 * Execute without waiting for end of the task
+	 */
+	public async execute(): Promise<void> {
+		if (this.execution) {
+			const exec = this.execution as ShellExecution;
+			const cmd = typeof exec.command === 'string' ? exec.command : (exec.command?.value ?? '');
+			const argsStr = exec.args?.map((a) => (typeof a === 'string' ? a : a.value)).join(' ');
+			KaotoOutputChannel.logInfo(`${this.label}: "${cmd} ${argsStr}"`);
+		}
+		await tasks.executeTask(this);
+	}
+
+	private async waitForEnd(): Promise<void> {
+		await new Promise<void>((resolve, reject) => {
+			const disposable = tasks.onDidEndTaskProcess((e) => {
+				if (e.execution.task.name === this.label) {
+					disposable.dispose();
+					if (e.exitCode === 0) {
+						resolve();
+					} else {
+						reject(new Error(`Task "${this.label}" failed with exit code ${e.exitCode}`));
+					}
+				}
+			});
+		});
+	}
+}

--- a/src/tasks/CamelTaskFactory.ts
+++ b/src/tasks/CamelTaskFactory.ts
@@ -1,0 +1,60 @@
+import { TaskRevealKind, TaskScope, WorkspaceFolder } from 'vscode';
+import { CamelTask } from './CamelTask';
+import { CommandResult } from '../executors/types/ExecutorTypes';
+
+export enum TaskPanelBehavior {
+	KeepOpen = 'keep-open',
+	CloseOnFinish = 'close-on-finish',
+}
+
+export enum TaskLifecycle {
+	Foreground = 'foreground',
+	Background = 'background',
+}
+
+export interface CamelTaskOptions {
+	label: string;
+	scope?: WorkspaceFolder | TaskScope.Workspace;
+	panel?: TaskPanelBehavior;
+	reveal?: TaskRevealKind;
+	lifecycle?: TaskLifecycle;
+}
+
+/**
+ * Factory for creating CamelTask instances without requiring individual subclasses.
+ */
+export class CamelTaskFactory {
+	/**
+	 * Creates a silent one-shot task (panel closes, reveal silent).
+	 * Used for init, bind, export, stop, route operations, dependency updates, etc.
+	 */
+	static createSilent(label: string, result: CommandResult, scope?: WorkspaceFolder | TaskScope.Workspace): CamelTask {
+		return CamelTaskFactory.create({ label, scope, panel: TaskPanelBehavior.CloseOnFinish, reveal: TaskRevealKind.Silent }, result);
+	}
+
+	/**
+	 * Creates a background long-running task (panel stays open, always revealed).
+	 * Used for run, test run, source dir run tasks.
+	 */
+	static createBackground(label: string, result: CommandResult): CamelTask {
+		return CamelTaskFactory.create({ label, lifecycle: TaskLifecycle.Background }, result);
+	}
+
+	/**
+	 * Creates a task with full control over presentation options.
+	 */
+	static create(options: CamelTaskOptions, result: CommandResult): CamelTask {
+		const task = new CamelTask(
+			options.scope ?? TaskScope.Workspace,
+			options.label,
+			result.execution,
+			options.panel === TaskPanelBehavior.CloseOnFinish,
+			options.reveal ?? TaskRevealKind.Always,
+			result.resolvedPort ?? CamelTask.NO_PORT,
+		);
+		if (options.lifecycle === TaskLifecycle.Background) {
+			task.isBackground = true;
+		}
+		return task;
+	}
+}

--- a/src/test/executors/CamelCommandBuilder.test.ts
+++ b/src/test/executors/CamelCommandBuilder.test.ts
@@ -1,0 +1,97 @@
+import { assert } from 'chai';
+import { CamelCommandBuilder } from '../../executors/builders/CamelCommandBuilder';
+
+suite('CamelCommandBuilder Tests', () => {
+	test('Should build command with JBang prefix args', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'jbang',
+			prefixArgs: ['-Dcamel.jbang.version=4.18.0', 'camel@apache/camel'],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml', '--port=8080']);
+
+		// Verify execution is created
+		assert.isDefined(result.execution);
+		assert.equal(result.resolvedPort, 8080);
+	});
+
+	test('Should build command without prefix args for Camel Launcher', () => {
+		const builder = new CamelCommandBuilder({
+			executable: '/path/to/camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml', '--management-port=8080']);
+
+		// Verify execution is created
+		assert.isDefined(result.execution);
+		assert.equal(result.resolvedPort, 8080);
+	});
+
+	test('Should filter empty arguments', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('export', ['test.yaml', '', '--runtime=quarkus']);
+
+		// Verify execution is created (empty args should be filtered)
+		assert.isDefined(result.execution);
+	});
+
+	test('Should extract port from --port argument', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml', '--port=8080']);
+
+		assert.equal(result.resolvedPort, 8080);
+	});
+
+	test('Should extract port from --management-port argument', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml', '--management-port=9090']);
+
+		assert.equal(result.resolvedPort, 9090);
+	});
+
+	test('Should return undefined port when no port argument', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml']);
+
+		assert.isUndefined(result.resolvedPort);
+	});
+
+	test('Should include context cwd in execution options', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml'], { cwd: '/project/path' });
+
+		assert.equal(result.execution.options?.cwd, '/project/path');
+	});
+
+	test('Should include context env in execution options', () => {
+		const builder = new CamelCommandBuilder({
+			executable: 'camel',
+			prefixArgs: [],
+		});
+
+		const result = builder.buildCommand('run', ['test.yaml'], { env: { TEST_VAR: 'value' } });
+
+		assert.deepEqual(result.execution.options?.env, { TEST_VAR: 'value' });
+	});
+});

--- a/src/test/executors/CamelExecutorFactory.test.ts
+++ b/src/test/executors/CamelExecutorFactory.test.ts
@@ -1,0 +1,62 @@
+import { assert } from 'chai';
+import * as vscode from 'vscode';
+import { CamelExecutorFactory } from '../../executors/CamelExecutorFactory';
+import { JBangExecutor } from '../../executors/JBangExecutor';
+import { CamelLauncherExecutor } from '../../executors/CamelLauncherExecutor';
+import { initializeKaotoCatalogService } from '../helpers/TestSetup';
+
+suite('CamelExecutorFactory Tests', () => {
+	let originalConfig: vscode.WorkspaceConfiguration;
+
+	suiteSetup(async () => {
+		// Initialize KaotoCatalogService for tests
+		await initializeKaotoCatalogService();
+
+		// Store original configuration
+		originalConfig = vscode.workspace.getConfiguration();
+	});
+
+	suiteTeardown(() => {
+		// Restore original configuration
+		originalConfig.update('kaoto.executor.type', undefined, vscode.ConfigurationTarget.Global);
+	});
+
+	test('Should create JBangExecutor when type is jbang', async () => {
+		await vscode.workspace.getConfiguration().update('kaoto.executor.type', 'jbang', vscode.ConfigurationTarget.Global);
+
+		const executor = await CamelExecutorFactory.createExecutor();
+
+		assert.instanceOf(executor, JBangExecutor);
+	});
+
+	test('Should create CamelLauncherExecutor when type is camel-launcher', async () => {
+		await vscode.workspace.getConfiguration().update('kaoto.executor.type', 'camel-launcher', vscode.ConfigurationTarget.Global);
+
+		const executor = await CamelExecutorFactory.createExecutor();
+
+		assert.instanceOf(executor, CamelLauncherExecutor);
+	});
+
+	test('Should use jbang as default when no type specified', async () => {
+		await vscode.workspace.getConfiguration().update('kaoto.executor.type', undefined, vscode.ConfigurationTarget.Global);
+
+		const executor = await CamelExecutorFactory.createExecutor();
+
+		assert.instanceOf(executor, JBangExecutor);
+	});
+
+	test('Should check if executor is available', async () => {
+		await vscode.workspace.getConfiguration().update('kaoto.executor.type', 'jbang', vscode.ConfigurationTarget.Global);
+
+		const executor = await CamelExecutorFactory.createExecutor();
+		const isAvailable = await executor.isAvailable();
+
+		// JBang availability depends on system installation
+		assert.isBoolean(isAvailable);
+	});
+
+	suiteTeardown(async () => {
+		// Restore original configuration
+		await vscode.workspace.getConfiguration().update('kaoto.executor.type', undefined, vscode.ConfigurationTarget.Global);
+	});
+});

--- a/src/test/executors/CamelExecutors.test.ts
+++ b/src/test/executors/CamelExecutors.test.ts
@@ -1,0 +1,245 @@
+import { assert } from 'chai';
+import { JBangExecutor } from '../../executors/JBangExecutor';
+import { CamelLauncherExecutor } from '../../executors/CamelLauncherExecutor';
+import * as path from 'path';
+import * as fs from 'fs';
+
+suite('Executor Implementation Tests', () => {
+	suite('JBangExecutor Tests', () => {
+		let executor: JBangExecutor;
+
+		setup(() => {
+			executor = new JBangExecutor({
+				type: 'jbang',
+				version: '4.18.0',
+			});
+		});
+
+		test('Should have correct configuration', () => {
+			const config = executor.getConfig();
+			assert.equal(config.type, 'jbang');
+			assert.equal(config.version, '4.18.0');
+		});
+
+		test('Should get version from config', () => {
+			assert.equal(executor.getVersion(), '4.18.0');
+		});
+
+		test('Should check availability', async () => {
+			// This will check if jbang is actually installed
+			const isAvailable = await executor.isAvailable();
+
+			// We can't assert true/false as it depends on the environment
+			// Just verify it returns a boolean
+			assert.isBoolean(isAvailable);
+		});
+
+		test('Should execute run command', async () => {
+			try {
+				const result = await executor.execute('run', ['/path/to/file.yaml', '--console'], {
+					cwd: '/workspace',
+				});
+
+				// Should return a CommandResult with execution
+				assert.isDefined(result.execution);
+			} catch (error) {
+				// Expected if jbang is not available
+				assert.include((error as Error).message, 'not available');
+			}
+		});
+
+		test('Should execute export command', async () => {
+			try {
+				const result = await executor.execute('export', ['--runtime=quarkus'], {
+					cwd: '/workspace',
+				});
+
+				// Should return a CommandResult with execution
+				assert.isDefined(result.execution);
+			} catch (error) {
+				// Expected if jbang is not available
+				assert.include((error as Error).message, 'not available');
+			}
+		});
+
+		test('Should execute init command', async () => {
+			try {
+				const result = await executor.execute('init', ['com.example:my-app:1.0.0'], {
+					cwd: '/workspace',
+				});
+
+				// Should return a CommandResult with execution
+				assert.isDefined(result.execution);
+			} catch (error) {
+				// Expected if jbang is not available
+				assert.include((error as Error).message, 'not available');
+			}
+		});
+	});
+
+	suite('CamelLauncherExecutor Tests', () => {
+		let executor: CamelLauncherExecutor;
+		let testLauncherPath: string;
+
+		setup(() => {
+			// Create a mock launcher executable for testing
+			const testDir = path.join(__dirname, '..', '..', '..', 'test-launcher');
+			if (!fs.existsSync(testDir)) {
+				fs.mkdirSync(testDir, { recursive: true });
+			}
+
+			testLauncherPath = path.join(testDir, process.platform === 'win32' ? 'camel.cmd' : 'camel');
+			fs.writeFileSync(testLauncherPath, '#!/bin/bash\necho "test"');
+
+			if (process.platform !== 'win32') {
+				fs.chmodSync(testLauncherPath, 0o755);
+			}
+
+			executor = new CamelLauncherExecutor(
+				{
+					type: 'camel-launcher',
+					version: '4.18.0',
+				},
+				testLauncherPath,
+			);
+		});
+
+		teardown(() => {
+			// Cleanup test launcher
+			const testDir = path.join(__dirname, '..', '..', '..', 'test-launcher');
+			if (fs.existsSync(testDir)) {
+				fs.rmSync(testDir, { recursive: true, force: true });
+			}
+		});
+
+		test('Should have correct configuration', () => {
+			const config = executor.getConfig();
+			assert.equal(config.type, 'camel-launcher');
+			assert.equal(config.version, '4.18.0');
+		});
+
+		test('Should get version from config', () => {
+			assert.equal(executor.getVersion(), '4.18.0');
+		});
+
+		test('Should be available when launcher path exists', async () => {
+			const isAvailable = await executor.isAvailable();
+
+			// Should be available since we created the file
+			assert.isTrue(isAvailable);
+		});
+
+		test('Should not be available when launcher path does not exist', async () => {
+			const nonExistentExecutor = new CamelLauncherExecutor(
+				{
+					type: 'camel-launcher',
+					version: '4.18.0',
+				},
+				'/non/existent/path/camel',
+			);
+
+			const isAvailable = await nonExistentExecutor.isAvailable();
+
+			// Should not be available
+			assert.isFalse(isAvailable);
+		});
+
+		test('Should execute run command', async () => {
+			const result = await executor.execute('run', ['/path/to/file.yaml', '--console'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute export command', async () => {
+			const result = await executor.execute('export', ['--runtime=quarkus'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute kubernetes command', async () => {
+			const result = await executor.execute('kubernetes', ['run', '/path/to/file.yaml'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute init command', async () => {
+			const result = await executor.execute('init', ['com.example:my-app:1.0.0'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute bind command', async () => {
+			const result = await executor.execute('bind', ['source', 'sink', '--output=pipe.yaml'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute stop command', async () => {
+			const result = await executor.execute('stop', ['my-route'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute dependency command', async () => {
+			const result = await executor.execute('dependency', ['update', '/path/to/file.yaml'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute cmd command', async () => {
+			const result = await executor.execute('cmd', ['route-start', 'my-route'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should execute plugin command', async () => {
+			const result = await executor.execute('plugin', ['add', 'my-plugin'], {
+				cwd: '/workspace',
+			});
+
+			// Should return a CommandResult with execution
+			assert.isDefined(result.execution);
+		});
+
+		test('Should throw error when executor is not available', async () => {
+			const nonExistentExecutor = new CamelLauncherExecutor(
+				{
+					type: 'camel-launcher',
+					version: '4.18.0',
+				},
+				'/non/existent/path/camel',
+			);
+
+			try {
+				await nonExistentExecutor.execute('run', ['/path/to/file.yaml']);
+				assert.fail('Should have thrown an error');
+			} catch (error) {
+				assert.include((error as Error).message, 'not available');
+			}
+		});
+	});
+});

--- a/src/test/executors/CamelSettingsHelper.test.ts
+++ b/src/test/executors/CamelSettingsHelper.test.ts
@@ -1,0 +1,117 @@
+import { assert } from 'chai';
+import { CamelSettingsHelper } from '../../executors/helpers/CamelSettingsHelper';
+import * as path from 'path';
+import { initializeKaotoCatalogService } from '../helpers/TestSetup';
+
+suite('CamelSettingsHelper Tests', () => {
+	let helper: CamelSettingsHelper;
+
+	suiteSetup(async () => {
+		// Initialize KaotoCatalogService for tests
+		await initializeKaotoCatalogService();
+	});
+
+	setup(() => {
+		helper = new CamelSettingsHelper();
+	});
+
+	test('Should get run arguments with console flag', async () => {
+		const testFile = path.join(__dirname, 'test.yaml');
+		const result = await helper.getRunArguments(testFile, __dirname);
+
+		// Should include --console from code defaults
+		assert.include(result.args, '--console');
+	});
+
+	test('Should get run source dir arguments with console flag', async () => {
+		const result = await helper.getRunSourceDirArguments(__dirname);
+
+		// Should include --console from code defaults
+		assert.include(result.args, '--console');
+	});
+
+	test('Should get export arguments', async () => {
+		const result = await helper.getExportArguments(__dirname);
+
+		// Should return array (may be empty if no user settings)
+		assert.isArray(result.args);
+		assert.isArray(result.conflicts);
+	});
+
+	test('Should get port argument for Camel 4.14+', () => {
+		const result = helper.getPortArgument(8080);
+
+		// Should use --management-port for 4.14+
+		assert.include(result.argument, '--management-port=8080');
+		assert.equal(result.resolvedPort, 8080);
+	});
+
+	test('Should always use management port for Quarkus runtime', () => {
+		(helper as unknown as { runtime: string; camelVersion: string }).runtime = 'quarkus';
+		(helper as unknown as { runtime: string; camelVersion: string }).camelVersion = '3.20.0';
+
+		const result = helper.getPortArgument(8080);
+
+		assert.equal(result.argument, '--management-port=8080');
+		assert.equal(result.resolvedPort, 8080);
+	});
+
+	test('Should respect user-defined port in arguments', () => {
+		const userArgs = ['--management-port=9090'];
+		const result = helper.getPortArgument(8080, userArgs);
+
+		// Should not add port argument when user already defined it
+		assert.equal(result.argument, '');
+		assert.equal(result.resolvedPort, 9090);
+	});
+
+	test('Should get Camel version argument from configuration', async () => {
+		const result = await helper.getCamelVersionArgument();
+
+		// May return version if configured in test environment, or empty string
+		// Just verify it returns a string
+		assert.isString(result);
+	});
+
+	test('Should not add Camel version when user already defined it', async () => {
+		const userArgs = ['--camel-version=4.17.0'];
+		const result = await helper.getCamelVersionArgument(userArgs);
+
+		// Should return empty string to avoid conflict
+		assert.equal(result, '');
+	});
+
+	test('Should get Red Hat Maven repository argument based on version', async () => {
+		const result = await helper.getRedHatMavenRepositoryArgument();
+
+		// May return repos URL if redhat version is configured, or empty string
+		// Just verify it returns a string
+		assert.isString(result);
+	});
+
+	test('Should not add repos when user already defined it', async () => {
+		const userArgs = ['--repos=https://custom.repo.com'];
+		const result = await helper.getRedHatMavenRepositoryArgument(userArgs);
+
+		// Should return empty string to avoid conflict
+		assert.equal(result, '');
+	});
+
+	test('Should handle port extraction from --port argument', () => {
+		const userArgs = ['--port=8080'];
+		const result = helper.getPortArgument(9090, userArgs);
+
+		// Should extract port from user args
+		assert.equal(result.resolvedPort, 8080);
+		assert.equal(result.argument, '');
+	});
+
+	test('Should handle port extraction from --management-port argument', () => {
+		const userArgs = ['--management-port=8080'];
+		const result = helper.getPortArgument(9090, userArgs);
+
+		// Should extract port from user args
+		assert.equal(result.resolvedPort, 8080);
+		assert.equal(result.argument, '');
+	});
+});

--- a/src/test/helpers/TestSetup.ts
+++ b/src/test/helpers/TestSetup.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { KaotoCatalogService } from '../../services/KaotoCatalogService';
+
+/**
+ * Get or create extension context for tests
+ */
+export async function getExtensionContext(): Promise<vscode.ExtensionContext> {
+	const extension = vscode.extensions.getExtension('redhat.vscode-kaoto');
+	if (!extension) {
+		throw new Error('Extension not found');
+	}
+	await extension.activate();
+
+	// Get context from extension exports or create a minimal mock context
+	let context = extension.exports?.context;
+	if (!context?.extensionPath) {
+		// Create a minimal mock context for tests
+		const extensionPath = extension.extensionPath;
+		context = {
+			extensionPath: extensionPath,
+			globalState: {
+				get: () => undefined,
+				update: async () => {},
+				keys: () => [],
+				setKeysForSync: () => {},
+			},
+			workspaceState: {
+				get: () => undefined,
+				update: async () => {},
+				keys: () => [],
+				setKeysForSync: () => {},
+			},
+		} as any;
+	}
+
+	return context;
+}
+
+/**
+ * Initialize KaotoCatalogService for tests
+ * This should be called in test setup/suiteSetup
+ */
+export async function initializeKaotoCatalogService(): Promise<KaotoCatalogService> {
+	const context = await getExtensionContext();
+	const catalogService = new KaotoCatalogService(context);
+	await catalogService.initialize();
+
+	return catalogService;
+}

--- a/src/test/services/CamelLauncherDownloader.test.ts
+++ b/src/test/services/CamelLauncherDownloader.test.ts
@@ -1,0 +1,139 @@
+import { assert } from 'chai';
+import * as path from 'path';
+import * as fs from 'fs';
+import { CamelLauncherDownloader, LauncherNotFoundError } from '../../services/CamelLauncherDownloader';
+import { isRedHatBuild } from '../../helpers/helpers';
+
+suite('CamelLauncherDownloader Tests', () => {
+	let downloader: CamelLauncherDownloader;
+	let testStoragePath: string;
+
+	setup(() => {
+		// Create a temporary storage path for testing
+		testStoragePath = path.join(__dirname, '..', '..', '..', 'test-storage');
+		if (!fs.existsSync(testStoragePath)) {
+			fs.mkdirSync(testStoragePath, { recursive: true });
+		}
+		// Pass undefined for context and use custom storage dir
+		downloader = new CamelLauncherDownloader(undefined, testStoragePath);
+	});
+
+	teardown(() => {
+		// Cleanup test storage
+		if (fs.existsSync(testStoragePath)) {
+			fs.rmSync(testStoragePath, { recursive: true, force: true });
+		}
+	});
+
+	test('Should get storage directory', () => {
+		const storageDir = downloader.getStorageDirectory();
+
+		assert.equal(storageDir, testStoragePath);
+	});
+
+	test('Should create storage directory if it does not exist', () => {
+		const newStoragePath = path.join(__dirname, '..', '..', '..', 'new-test-storage');
+
+		// Remove if exists
+		if (fs.existsSync(newStoragePath)) {
+			fs.rmSync(newStoragePath, { recursive: true, force: true });
+		}
+
+		const newDownloader = new CamelLauncherDownloader(undefined, newStoragePath);
+
+		// Storage path should be created
+		assert.isTrue(fs.existsSync(newStoragePath));
+		assert.equal(newDownloader.getStorageDirectory(), newStoragePath);
+
+		// Cleanup
+		fs.rmSync(newStoragePath, { recursive: true, force: true });
+	});
+
+	test('Should return cached JAR path if launcher already exists', async () => {
+		const version = '4.18.0';
+		const launcherDir = path.join(testStoragePath, `camel-launcher-${version}`);
+
+		// Create the directory structure with JAR
+		fs.mkdirSync(launcherDir, { recursive: true });
+
+		// Create JAR file
+		const jarPath = path.join(launcherDir, `camel-launcher-${version}.jar`);
+		fs.writeFileSync(jarPath, 'fake jar content');
+
+		// Should return cached JAR path without downloading
+		const result = await downloader.ensureLauncher(version);
+
+		assert.equal(result, jarPath);
+	});
+
+	test('Should find launcher JAR in directory', async () => {
+		const version = '4.18.0';
+		const launcherDir = path.join(testStoragePath, `camel-launcher-${version}`);
+
+		// Create the directory structure
+		fs.mkdirSync(launcherDir, { recursive: true });
+
+		// Create JAR file
+		const jarPath = path.join(launcherDir, `camel-launcher-${version}.jar`);
+		fs.writeFileSync(jarPath, 'fake jar content');
+
+		// Should find the JAR
+		const result = await downloader.ensureLauncher(version);
+
+		assert.equal(result, jarPath);
+		assert.isTrue(fs.existsSync(result));
+	});
+
+	test('Should handle missing launcher directory gracefully', async () => {
+		const version = '999.999.999';
+		const launcherDir = path.join(testStoragePath, `camel-launcher-${version}`);
+
+		// Ensure directory doesn't exist
+		if (fs.existsSync(launcherDir)) {
+			fs.rmSync(launcherDir, { recursive: true, force: true });
+		}
+
+		try {
+			// This should attempt to download, which will fail for invalid version
+			await downloader.ensureLauncher(version);
+			assert.fail('Should have thrown an error');
+		} catch (error) {
+			assert.instanceOf(error, LauncherNotFoundError);
+			assert.include(error.message, 'is not available');
+		}
+	});
+
+	test('Should return JAR path directly', async () => {
+		const version = '4.18.0';
+		const launcherDir = path.join(testStoragePath, `camel-launcher-${version}`);
+		fs.mkdirSync(launcherDir, { recursive: true });
+
+		// Create JAR file
+		const jarPath = path.join(launcherDir, `camel-launcher-${version}.jar`);
+		fs.writeFileSync(jarPath, 'fake jar content');
+
+		const result = await downloader.ensureLauncher(version);
+
+		// Should return JAR path directly (not wrapper script)
+		assert.equal(result, jarPath);
+		assert.isTrue(result.endsWith('.jar'));
+	});
+
+	test('Should detect RedHat build versions', () => {
+		assert.isTrue(isRedHatBuild('4.14.2.redhat-00006'));
+		assert.isTrue(isRedHatBuild('4.14.2.redhat-00019'));
+		assert.isFalse(isRedHatBuild('4.18.0'));
+		assert.isFalse(isRedHatBuild('4.14.5'));
+	});
+
+	test('Should use RedHat Maven repository for RedHat builds', () => {
+		// Access private method through any cast for testing
+		const downloaderAny = downloader as any;
+
+		const redhatUrl = downloaderAny.getMavenBaseUrl('4.14.2.redhat-00006');
+		const communityUrl = downloaderAny.getMavenBaseUrl('4.18.0');
+
+		assert.include(redhatUrl, 'maven.repository.redhat.com');
+		assert.include(communityUrl, 'repo1.maven.org');
+	});
+});

--- a/src/test/services/KaotoCatalogService.test.ts
+++ b/src/test/services/KaotoCatalogService.test.ts
@@ -1,0 +1,541 @@
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+import { CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
+import { KaotoCatalogService } from '../../services/KaotoCatalogService';
+import { initializeKaotoCatalogService, getExtensionContext } from '../helpers/TestSetup';
+import { RuntimeType } from '../../executors/types/ExecutorTypes';
+
+suite('KaotoCatalogService Test Suite', () => {
+	let catalogService: KaotoCatalogService;
+	let context: vscode.ExtensionContext;
+	let originalGetConfiguration: typeof vscode.workspace.getConfiguration;
+	let originalShowWarningMessage: typeof vscode.window.showWarningMessage;
+	let originalFetch: typeof globalThis.fetch;
+
+	suiteSetup(async () => {
+		// Get extension context for tests that need to create custom instances
+		context = await getExtensionContext();
+		// Initialize KaotoCatalogService using the test helper
+		catalogService = await initializeKaotoCatalogService();
+	});
+
+	setup(async () => {
+		originalGetConfiguration = vscode.workspace.getConfiguration;
+		originalShowWarningMessage = vscode.window.showWarningMessage;
+		originalFetch = globalThis.fetch;
+		// Re-initialize for each test to ensure clean state
+		catalogService = await initializeKaotoCatalogService();
+	});
+
+	teardown(() => {
+		Object.defineProperty(vscode.workspace, 'getConfiguration', {
+			value: originalGetConfiguration,
+			configurable: true,
+		});
+		Object.defineProperty(vscode.window, 'showWarningMessage', {
+			value: originalShowWarningMessage,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'fetch', {
+			value: originalFetch,
+			configurable: true,
+		});
+	});
+
+	test('should load catalogs from index.json', () => {
+		const catalogs = catalogService.getCatalogs();
+		expect(catalogs).to.be.an('array');
+		expect(catalogs.length).to.be.greaterThan(0);
+	});
+
+	test('should load catalogs from custom URL when kaoto.catalog.url is configured', async () => {
+		const remoteCatalogs: CatalogLibraryEntry[] = [
+			{
+				name: 'Camel Main 9.9.9',
+				version: '9.9.9',
+				runtime: 'Main',
+				fileName: 'camel-main/9.9.9/index.json',
+				executorVersion: '9.9.9',
+				camelCatalogVersion: '9.9.9',
+				frameworkVersion: '9.9.9',
+				runtimeProviderVersion: '9.9.9',
+			},
+		];
+
+		Object.defineProperty(vscode.workspace, 'getConfiguration', {
+			value: () =>
+				({
+					get: (key: string) => (key === 'catalog.url' ? 'https://example.com/catalog/index.json' : undefined),
+				}) as vscode.WorkspaceConfiguration,
+			configurable: true,
+		});
+
+		Object.defineProperty(globalThis, 'fetch', {
+			value: async () =>
+				({
+					ok: true,
+					json: async () => ({
+						definitions: remoteCatalogs,
+						version: 1,
+						name: 'remote-catalog',
+					}),
+				}) as Response,
+			configurable: true,
+		});
+
+		catalogService = new KaotoCatalogService(context);
+		await catalogService.initialize();
+
+		expect(catalogService.getCatalogs()).to.deep.equal(remoteCatalogs);
+	});
+
+	test('should fallback to local catalogs when custom URL fetch fails', async () => {
+		const warningMessages: string[] = [];
+		Object.defineProperty(vscode.window, 'showWarningMessage', {
+			value: async (message: string) => {
+				warningMessages.push(message);
+				return undefined;
+			},
+			configurable: true,
+		});
+
+		Object.defineProperty(vscode.workspace, 'getConfiguration', {
+			value: () =>
+				({
+					get: (key: string) => (key === 'catalog.url' ? 'https://example.com/catalog/index.json' : undefined),
+				}) as vscode.WorkspaceConfiguration,
+			configurable: true,
+		});
+
+		Object.defineProperty(globalThis, 'fetch', {
+			value: async () => {
+				throw new Error('network failure');
+			},
+			configurable: true,
+		});
+
+		catalogService = new KaotoCatalogService(context);
+		await catalogService.initialize();
+
+		expect(catalogService.getCatalogs().length).to.be.greaterThan(0);
+		expect(warningMessages).to.have.lengthOf(1);
+		expect(warningMessages[0]).to.include('kaoto.catalog.url');
+		expect(warningMessages[0]).to.include('Falling back to local node_modules catalog');
+	});
+
+	test('should group catalogs by runtime', () => {
+		const grouped = catalogService.getCatalogsByRuntime();
+		expect(grouped).to.be.an('object');
+		expect(grouped).to.have.property('Main');
+		expect(grouped).to.have.property('Quarkus');
+		expect(grouped).to.have.property('Spring Boot');
+	});
+
+	test('should return default catalog (latest Camel Main RedHat version)', () => {
+		const defaultCatalog = catalogService.getDefaultCatalog();
+		expect(defaultCatalog).to.not.be.undefined;
+		expect(defaultCatalog?.runtime).to.equal('Main');
+
+		// Should prioritize RedHat versions if available
+		const allMainCatalogs = catalogService.getCatalogs().filter((c) => c.runtime === 'Main');
+		const hasRedHatVersions = allMainCatalogs.some((c) => c.version.toLowerCase().includes('redhat'));
+
+		if (hasRedHatVersions) {
+			expect(defaultCatalog?.version.toLowerCase()).to.include('redhat');
+		}
+	});
+
+	test('should return default Citrus catalog for test files', () => {
+		const testFileUri = vscode.Uri.file('/path/to/test.citrus.yaml');
+		const defaultCatalog = catalogService.getDefaultCatalog(testFileUri);
+
+		// Should return a Citrus catalog for test files
+		const citrusCatalogs = catalogService.getCatalogs().filter((c) => c.runtime.toLowerCase() === RuntimeType.CITRUS);
+		if (citrusCatalogs.length > 0) {
+			expect(defaultCatalog).to.not.be.undefined;
+			expect(defaultCatalog?.runtime.toLowerCase()).to.equal('citrus');
+
+			// Should be the latest version
+			const sorted = citrusCatalogs.toSorted((a, b) => {
+				return b.version.localeCompare(a.version, undefined, { numeric: true });
+			});
+			expect(defaultCatalog?.version).to.equal(sorted[0].version);
+		}
+	});
+
+	test('should detect Maven projects', async () => {
+		// Test isMavenProject method - it requires files to be in workspace folders
+		// Since test fixtures may not be in workspace folders, we test the method exists and returns boolean
+		const testUri = vscode.Uri.file('/path/to/test.camel.yaml');
+		const result = await KaotoCatalogService.isMavenProject(testUri);
+		expect(result).to.be.a('boolean');
+		// Method should return false for non-workspace files
+		expect(result).to.be.false;
+	});
+
+	test('should not detect non-Maven projects', async () => {
+		// Test with a non-existent path - should return false
+		const testUri = vscode.Uri.file('/non/existent/path/test.camel.yaml');
+		const result = await KaotoCatalogService.isMavenProject(testUri);
+		expect(result).to.be.false;
+	});
+
+	test('should validate catalog definitions', () => {
+		const catalogs = catalogService.getCatalogs();
+		catalogs.forEach((catalog) => {
+			expect(catalog).to.have.property('name');
+			expect(catalog).to.have.property('version');
+			expect(catalog).to.have.property('runtime');
+			expect(catalog).to.have.property('fileName');
+			expect(catalog.name).to.be.a('string');
+			expect(catalog.version).to.be.a('string');
+			expect(catalog.runtime).to.be.a('string');
+			expect(catalog.fileName).to.be.a('string');
+		});
+	});
+
+	test('should detect Kaoto integration files', () => {
+		// Test .camel.yaml files
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/route.camel.yaml'))).to.be.true;
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/route.camel.yml'))).to.be.true;
+
+		// Test .kamelet.yaml files
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/source.kamelet.yaml'))).to.be.true;
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/source.kamelet.yml'))).to.be.true;
+
+		// Test .pipe.yaml files
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/integration.pipe.yaml'))).to.be.true;
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/integration-pipe.yaml'))).to.be.true;
+
+		// Test .camel.xml files
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/route.camel.xml'))).to.be.true;
+
+		// Test non-integration files
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/test.citrus.yaml'))).to.be.false;
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/random.yaml'))).to.be.false;
+		expect(catalogService['isKaotoIntegrationFile'](vscode.Uri.file('/path/to/pom.xml'))).to.be.false;
+	});
+
+	test('should detect Citrus test files', () => {
+		// Test .citrus.yaml files
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus.yaml'))).to.be.true;
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus.yml'))).to.be.true;
+
+		// Test .citrus.test.yaml files
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus.test.yaml'))).to.be.true;
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus-test.yaml'))).to.be.true;
+
+		// Test .citrus.it.yaml files
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus.it.yaml'))).to.be.true;
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/test.citrus-it.yaml'))).to.be.true;
+
+		// Test non-test files
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/route.camel.yaml'))).to.be.false;
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/random.yaml'))).to.be.false;
+		expect(catalogService['isKaotoCitrusTestFile'](vscode.Uri.file('/path/to/pom.xml'))).to.be.false;
+	});
+
+	test('should detect any Kaoto file (integration or test)', () => {
+		// Test integration files
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/route.camel.yaml'))).to.be.true;
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/source.kamelet.yaml'))).to.be.true;
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/integration.pipe.yaml'))).to.be.true;
+
+		// Test Citrus test files
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/test.citrus.yaml'))).to.be.true;
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/test.citrus.test.yaml'))).to.be.true;
+
+		// Test non-Kaoto files
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/random.yaml'))).to.be.false;
+		expect(catalogService['isKaotoFile'](vscode.Uri.file('/path/to/pom.xml'))).to.be.false;
+	});
+
+	test('should have Main runtime catalogs', () => {
+		const grouped = catalogService.getCatalogsByRuntime();
+		const mainCatalogs = grouped['Main'];
+		expect(mainCatalogs).to.be.an('array');
+		expect(mainCatalogs.length).to.be.greaterThan(0);
+	});
+
+	test('should have Quarkus runtime catalogs', () => {
+		const grouped = catalogService.getCatalogsByRuntime();
+		const quarkusCatalogs = grouped['Quarkus'];
+		expect(quarkusCatalogs).to.be.an('array');
+		expect(quarkusCatalogs.length).to.be.greaterThan(0);
+	});
+
+	test('should have Spring Boot runtime catalogs', () => {
+		const grouped = catalogService.getCatalogsByRuntime();
+		const springBootCatalogs = grouped['Spring Boot'];
+		expect(springBootCatalogs).to.be.an('array');
+		expect(springBootCatalogs.length).to.be.greaterThan(0);
+	});
+
+	test('should build display label from catalog definition', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.0',
+			version: '4.18.0',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.0/index-825a64c8dcfd946d5eb88a96e71f6589.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const label = KaotoCatalogService.buildDisplayLabel(catalog);
+		expect(label).to.equal('Camel Main 4.18.0');
+	});
+
+	test('should get Camel version for CLI from catalog (Main with executorVersion) - JBang', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.0',
+			version: '4.18.0',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.0/index-825a64c8dcfd946d5eb88a96e71f6589.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'jbang');
+		// JBang should use catalog version for --camel-version flag
+		expect(camelVersion).to.equal('4.18.0');
+	});
+
+	test('should get Camel version for CLI from catalog (Main with executorVersion) - Camel Launcher', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.0',
+			version: '4.18.0',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.0/index-825a64c8dcfd946d5eb88a96e71f6589.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'camel-launcher');
+		// Camel Launcher should use executorVersion for JAR download
+		expect(camelVersion).to.equal('4.18.0');
+	});
+
+	test('should get Camel version for CLI from catalog (Quarkus with executorVersion) - JBang', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Quarkus 3.32.0',
+			version: '3.32.0',
+			runtime: 'Quarkus',
+			fileName: 'camel-quarkus/3.32.0/index-xxx.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '3.32.0',
+			frameworkVersion: '3.32.2',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'jbang');
+		// JBang with Quarkus should use frameworkVersion (Quarkus platform version)
+		expect(camelVersion).to.equal('3.32.2');
+	});
+
+	test('should get Camel version for CLI from catalog (Quarkus with executorVersion) - Camel Launcher', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Quarkus 3.32.0',
+			version: '3.32.0',
+			runtime: 'Quarkus',
+			fileName: 'camel-quarkus/3.32.0/index-xxx.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '3.32.0',
+			frameworkVersion: '3.32.2',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'camel-launcher');
+		// Camel Launcher should use executorVersion (4.18.0) for JAR download
+		expect(camelVersion).to.equal('4.18.0');
+	});
+
+	test('should get Camel version for CLI from catalog (RedHat with executorVersion) - JBang', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.1.redhat-00019',
+			version: '4.18.1.redhat-00019',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.1.redhat-00019/index-xxx.json',
+			executorVersion: '4.18.1.redhat-00016',
+			camelCatalogVersion: '4.18.1.redhat-00019',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'jbang');
+		// JBang should use catalog version for --camel-version flag
+		expect(camelVersion).to.equal('4.18.1.redhat-00019');
+	});
+
+	test('should get Camel version for CLI from catalog (RedHat with executorVersion) - Camel Launcher', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.1.redhat-00019',
+			version: '4.18.1.redhat-00019',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.1.redhat-00019/index-xxx.json',
+			executorVersion: '4.18.1.redhat-00016',
+			camelCatalogVersion: '4.18.1.redhat-00019',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const camelVersion = catalogService.getCamelVersionForCLI(catalog, 'camel-launcher');
+		// Camel Launcher should use executorVersion which differs from catalog version
+		expect(camelVersion).to.equal('4.18.1.redhat-00016');
+	});
+
+	test('should return undefined Camel version for undefined catalog', () => {
+		const camelVersion = catalogService.getCamelVersionForCLI(undefined);
+		expect(camelVersion).to.be.undefined;
+	});
+
+	test('should get runtime for CLI from catalog (Main)', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.0',
+			version: '4.18.0',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.0/index-825a64c8dcfd946d5eb88a96e71f6589.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const runtime = catalogService.getRuntimeForCLI(catalog);
+		expect(runtime).to.equal('camel-main');
+	});
+
+	test('should get runtime for CLI from catalog (Quarkus)', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Quarkus 3.32.0',
+			version: '3.32.0',
+			runtime: 'Quarkus',
+			fileName: 'camel-quarkus/3.32.0/index-xxx.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '3.32.0',
+			frameworkVersion: '3.32.2',
+		};
+
+		const runtime = catalogService.getRuntimeForCLI(catalog);
+		expect(runtime).to.equal('quarkus');
+	});
+
+	test('should get runtime for CLI from catalog (Spring Boot)', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Spring Boot 4.18.0',
+			version: '4.18.0',
+			runtime: 'Spring Boot',
+			fileName: 'camel-springboot/4.18.0/index-xxx.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '3.4.3',
+		};
+
+		const runtime = catalogService.getRuntimeForCLI(catalog);
+		expect(runtime).to.equal('spring-boot');
+	});
+
+	test('should return undefined runtime for undefined catalog', () => {
+		const runtime = catalogService.getRuntimeForCLI(undefined);
+		expect(runtime).to.be.undefined;
+	});
+
+	test('should get CLI parameters from catalog', () => {
+		const catalog: CatalogLibraryEntry = {
+			name: 'Camel Main 4.18.0',
+			version: '4.18.0',
+			runtime: 'Main',
+			fileName: 'camel-main/4.18.0/index-825a64c8dcfd946d5eb88a96e71f6589.json',
+			executorVersion: '4.18.0',
+			camelCatalogVersion: '4.18.0',
+			runtimeProviderVersion: '',
+			frameworkVersion: '',
+		};
+
+		const params = catalogService.getCLIParameters(catalog);
+		expect(params.executorVersion).to.equal('4.18.0');
+		expect(params.runtime).to.equal('camel-main');
+	});
+
+	test('should return empty CLI parameters for undefined catalog', () => {
+		const params = catalogService.getCLIParameters(undefined);
+		expect(params.executorVersion).to.be.undefined;
+		expect(params.runtime).to.be.undefined;
+	});
+
+	// Note: Active document resolution tests removed due to complexity of mocking VSCode API
+	// These scenarios are better tested through integration tests
+
+	suite('Separate Integration and Test Catalog Storage', () => {
+		test('should store integration and test catalogs separately', async () => {
+			// Get an integration catalog (Main)
+			const integrationCatalog = catalogService.getCatalogs().find((c) => c.runtime === 'Main');
+			expect(integrationCatalog).to.not.be.undefined;
+
+			// Get a test catalog (Citrus)
+			const testCatalog = catalogService.getCatalogs().find((c) => c.runtime.toLowerCase() === RuntimeType.CITRUS);
+			expect(testCatalog).to.not.be.undefined;
+
+			if (integrationCatalog && testCatalog) {
+				// Set integration catalog
+				await catalogService.setSelectedIntegrationCatalog(integrationCatalog);
+
+				// Set test catalog
+				await catalogService.setSelectedTestCatalog(testCatalog);
+
+				// Verify both are stored correctly
+				const storedIntegration = await catalogService.getSelectedIntegrationCatalog();
+				const storedTest = await catalogService.getSelectedTestCatalog();
+
+				expect(storedIntegration?.version).to.equal(integrationCatalog.version);
+				expect(storedTest?.version).to.equal(testCatalog.version);
+
+				// Verify they are different
+				expect(storedIntegration?.runtime).to.not.equal(storedTest?.runtime);
+			}
+		});
+
+		test('should return integration catalog for integration file URI', async () => {
+			const integrationFileUri = vscode.Uri.file('/path/to/route.camel.yaml');
+			const catalog = await catalogService.getSelectedCatalog(integrationFileUri);
+
+			// Should return integration catalog (not Citrus)
+			if (catalog) {
+				expect(catalog.runtime.toLowerCase()).to.not.equal('citrus');
+			}
+		});
+
+		test('should return test catalog for test file URI', async () => {
+			const testFileUri = vscode.Uri.file('/path/to/test.citrus.yaml');
+			const catalog = await catalogService.getSelectedCatalog(testFileUri);
+
+			// Should return test catalog (Citrus) if available
+			const citrusCatalogs = catalogService.getCatalogs().filter((c) => c.runtime.toLowerCase() === RuntimeType.CITRUS);
+			if (citrusCatalogs.length > 0 && catalog) {
+				expect(catalog.runtime.toLowerCase()).to.equal('citrus');
+			}
+		});
+
+		test('should have separate default catalogs for integration and test', () => {
+			const integrationDefault = catalogService.getDefaultIntegrationCatalog();
+			const testDefault = catalogService.getDefaultTestCatalog();
+
+			expect(integrationDefault).to.not.be.undefined;
+			expect(integrationDefault?.runtime).to.equal('Main');
+
+			// Test default may be undefined if no Citrus catalogs available
+			const citrusCatalogs = catalogService.getCatalogs().filter((c) => c.runtime.toLowerCase() === RuntimeType.CITRUS);
+			if (citrusCatalogs.length > 0) {
+				expect(testDefault).to.not.be.undefined;
+				expect(testDefault?.runtime.toLowerCase()).to.equal('citrus');
+			}
+		});
+	});
+});

--- a/src/types/RouteOperation.ts
+++ b/src/types/RouteOperation.ts
@@ -1,0 +1,9 @@
+/**
+ * Route operations supported by Camel
+ */
+export enum RouteOperation {
+	start = 'start',
+	stop = 'stop',
+	suspend = 'suspend',
+	resume = 'resume',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,6 +2626,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/unzipper@npm:^0":
+  version: 0.10.11
+  resolution: "@types/unzipper@npm:0.10.11"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/c11c0e072556038730b218ccf8af849911ed8a1338e6db863bdf4c44d53d83dd23e3de4752322b1e19cf0205ed6eaf8746e25aa3c2b38e419da457f9d6be7b4e
+  languageName: node
+  linkType: hard
+
 "@types/vscode@npm:1.67.0":
   version: 1.67.0
   resolution: "@types/vscode@npm:1.67.0"
@@ -13670,6 +13679,7 @@ __metadata:
     "@types/openapi-v3": "npm:^3.0.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
+    "@types/unzipper": "npm:^0"
     "@types/vscode": "npm:^1.100.0"
     "@types/wait-on": "npm:^5.3.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.61.0"
@@ -13711,6 +13721,7 @@ __metadata:
     ts-loader: "npm:9.4.4"
     tsconfig-paths-webpack-plugin: "npm:^4.2.0"
     typescript: "npm:^5.9.3"
+    unzipper: "npm:^0.12.3"
     valid-filename: "npm:4.0.0"
     vscode-extension-tester: "npm:^8.23.0"
     wait-on: "npm:^9.0.10"


### PR DESCRIPTION
Introduce a new executor abstraction layer that supports both JBang and Camel Launcher backends. Add catalog service for runtime version selection, launcher downloader, and Red Hat Maven notification service.

New components:
- Executor interfaces, base classes, factory, command API and builder
- ExecutorInitializer for non-blocking executor setup
- CamelSettingsHelper for executor configuration
- KaotoCatalogService for catalog version management
- CamelLauncherDownloader for automatic JAR downloads
- RedHatMavenNotificationService for maven settings guidance
- MavenRuntimeDetector and TestFolderResolver helpers
- CamelTask and CamelTaskFactory for generic task execution
- Comprehensive unit tests for all new components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Camel Launcher executor support as an alternative to JBang, with automatic JAR download capability
  * New executor configuration settings allowing users to select between JBang and Camel Launcher
  * Separate test and runtime catalog selection for different Camel integration types
  * Added Maven executor configuration options for customizing build arguments

* **Configuration Updates**
  * Enhanced local kamelet directory and catalog URL configuration guidance
  * New advanced settings group for runtime and testing catalog management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->