### PR TITLE
fix: close source code button is not visible for test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
         "command": "kaoto.close.source",
         "title": "Close Source Code",
         "shortTitle": "Close Source",
-        "enablement": "(resourceFilename =~ /\\.(camel|kamelet|pipe).yaml$/ || resourceFilename =~ /\\-pipe.yaml$/ || resourceFilename =~ /\\.camel.xml$/)",
+        "enablement": "(resourceFilename =~ /\\.(camel|kamelet|pipe).yaml$/ || resourceFilename =~ /\\-pipe.yaml$/ || resourceFilename =~ /\\.camel.xml$/ || resourceFilename =~ /\\.citrus(-test|-it|\\.test|\\.it)?\\.yaml$/)",
         "category": "Kaoto",
         "icon": "./icons/commands/source_active.png"
       },
@@ -716,7 +716,7 @@
         },
         {
           "command": "kaoto.close.source",
-          "when": "(resourceFilename =~ /\\.(camel|kamelet|pipe).yaml$/ || resourceFilename =~ /\\-pipe.yaml$/ || resourceFilename =~ /\\.camel.xml$/) && activeCustomEditorId !== webviewEditorsKaoto",
+          "when": "(resourceFilename =~ /\\.(camel|kamelet|pipe).yaml$/ || resourceFilename =~ /\\-pipe.yaml$/ || resourceFilename =~ /\\.camel.xml$/ || resourceFilename =~ /\\.citrus(-test|-it|\\.test|\\.it)?\\.yaml$/) && activeCustomEditorId !== webviewEditorsKaoto",
           "group": "navigation@1"
         }
       ],


### PR DESCRIPTION
closing #1410 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Citrus test YAML file formats (`.citrus-test.yaml`, `.citrus-it.yaml`, `.citrus.test.yaml`, `.citrus.it.yaml`) in the close source functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->