### PR TITLE
fix: Deployments > Follow logs button is not working for integrations…

### DIFF
--- a/src/extension/ExtensionContextHandler.ts
+++ b/src/extension/ExtensionContextHandler.ts
@@ -682,12 +682,12 @@ export class ExtensionContextHandler {
 
 		this.context.subscriptions.push(
 			vscode.commands.registerCommand(COMMAND_DEPLOYMENTS_LOGS, async (integration: ParentItem) => {
-				const runningLabel = `Running - ${integration.description as string}::${integration.port}`;
-				const terminal = vscode.window.terminals.find((t) => t.name === runningLabel);
+				const portSuffix = `::${integration.port}`;
+				const terminal = vscode.window.terminals.find((t) => t.name.startsWith('Running - ') && t.name.endsWith(portSuffix));
 				if (terminal) {
 					terminal.show();
 				} else {
-					KaotoOutputChannel.logWarning(`Terminal with a name "${runningLabel}" was not found.`);
+					KaotoOutputChannel.logWarning(`Terminal for integration on port ${integration.port} was not found.`);
 				}
 				await this.sendCommandTrackingEvent(COMMAND_DEPLOYMENTS_LOGS);
 			}),


### PR DESCRIPTION
… executed using "Run: Folder" or "Run: Workspace"

The fix matches the terminal by its Running - prefix and ::${port} suffix instead of relying on the full name. Since each port uniquely identifies a running integration, this correctly finds the terminal regardless of whether the middle part is a filename (single file run) or a folder name (runFolder/runWorkspace).