### PR TITLE
chore: bump Kaoto UI to 2.11.0-RC6

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@kaoto/camel-catalog": "^0.5.5",
-    "@kaoto/kaoto": "2.11.0-RC5",
+    "@kaoto/kaoto": "2.11.0-RC6",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",
     "@kie-tools-core/i18n": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,9 +916,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/kaoto@npm:2.11.0-RC5":
-  version: 2.11.0-RC5
-  resolution: "@kaoto/kaoto@npm:2.11.0-RC5"
+"@kaoto/kaoto@npm:2.11.0-RC6":
+  version: 2.11.0-RC6
+  resolution: "@kaoto/kaoto@npm:2.11.0-RC6"
   dependencies:
     "@carbon/icons-react": "npm:^11.67.0"
     "@carbon/react": "npm:^1.102.0"
@@ -964,7 +964,7 @@ __metadata:
     monaco-yaml: ^5.5.1
     react: ^19.2.4
     react-dom: ^19.2.4
-  checksum: 10/2432f0fe591ccb2baa355c32b836d81b277b8eca4a8083f15d5e119de10fbdf984093b57adb0296eb9b0c3be0fd8954d7c7218c6714b7130897b7498458c086d
+  checksum: 10/bde6863bf2ad6921522944a2e949fe3146cc28e49da33e666b7185de4d1152880fbd5b1f6f5f7a7a53ec1b271b40c6d831f6c46dabc5e97b7464f49eec881094
   languageName: node
   linkType: hard
 
@@ -13638,7 +13638,7 @@ __metadata:
   resolution: "vscode-kaoto@workspace:."
   dependencies:
     "@kaoto/camel-catalog": "npm:^0.5.5"
-    "@kaoto/kaoto": "npm:2.11.0-RC5"
+    "@kaoto/kaoto": "npm:2.11.0-RC6"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"
     "@kie-tools-core/i18n": "npm:10.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated a core dependency to the latest release candidate version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->