### PR TITLE
chore: What's New > breaking changes and migration guide

### DIFF
--- a/resources/whats-new/2.11/index.md
+++ b/resources/whats-new/2.11/index.md
@@ -8,6 +8,52 @@ We are happy to announce that new version of extension was released!
 
 This release brings significant enhancements to testing capabilities with Citrus framework integration, expanded DataMapper functionality for complex schema handling, improved runtime management with multiple executor options, and visual editor improvements. Powered by Apache Camel 4.20.0, Kaoto continues to make visual integration design more powerful and intuitive.
 
+---
+
+## ⚠️ Breaking Changes & Migration Guide
+
+This release includes settings renames and removals. **If you customized any JBang-related settings, you must update them manually after upgrading.**
+
+### Renamed Settings
+
+The `kaoto.camelJbang.*` settings namespace has been replaced with `kaoto.executor.*`:
+
+| Old Setting (v2.10.x) | New Setting (v2.11.0) |
+| --- | --- |
+| `kaoto.camelJbang.runArguments` | `kaoto.executor.runArguments` |
+| `kaoto.camelJbang.runFolderOrWorkspaceArguments` | `kaoto.executor.runFolderOrWorkspaceArguments` |
+| `kaoto.camelJbang.redHatMavenRepository` | `kaoto.executor.redHatMavenRepository` |
+| `kaoto.camelJbang.redHatMavenRepository.global` | `kaoto.executor.redHatMavenRepository.global` |
+| `kaoto.camelJbang.kubernetesRunArguments` | `kaoto.executor.kubernetesRunArguments` |
+| `kaoto.maven.camelJbang.exportProjectArguments` | `kaoto.maven.executor.exportProjectArguments` |
+
+**Action:** Open your `settings.json` and rename any `kaoto.camelJbang.*` entries to their `kaoto.executor.*` equivalents.
+
+### Removed Settings
+
+| Setting | Migration |
+| --- | --- |
+| `kaoto.camelJbang.version` | No longer needed. The Camel version is now determined by the selected catalog. Default fallback is `4.20.0`. |
+| `kaoto.camelVersion` | Replaced by the new catalog picker — use the status bar to select your runtime catalog, or set `kaoto.runtimeCatalogName` in workspace settings. |
+
+### Settings UI Reorganized
+
+- The **JBang** section has been renamed to **Executor**
+- A new **Advanced** section holds catalog-related workspace settings
+- Canvas settings (nodeLabel, colorTheme, etc.) remain unchanged under **Canvas**
+
+### Default Camel CLI Version: 4.18.0 → 4.20.0
+
+The default Camel version used for CLI operations has been updated. If your integrations depend on 4.18.x-specific behavior, verify compatibility with [Camel 4.20.0 release notes](https://camel.apache.org/releases/release-4.20.0/).
+
+### Red Hat Productized Catalog Requires Maven Configuration
+
+When using Red Hat productized Camel versions (e.g. `4.8.0.redhat-00017`), you **MUST** configure the Red Hat recommended repositories in your Maven `settings.xml`. Without this configuration, the Red Hat catalog — which is a default option — will not function correctly.
+
+The extension will show a notification guiding you through this setup when a productized catalog is selected. Refer to the [Red Hat Maven Repository documentation](https://docs.redhat.com/es/documentation/red_hat_build_of_apache_camel/4.18/html/getting_started_with_red_hat_build_of_apache_camel_for_spring_boot/set-up-maven-locally#add-red-hat-repositories-to-maven) for details on configuring your `~/.m2/settings.xml`.
+
+---
+
 ### Citrus Testing Capabilities
 
 Kaoto 2.11 introduces comprehensive Citrus framework integration, bringing automated testing capabilities directly into your visual integration design workflow:
@@ -45,10 +91,6 @@ All executor-related settings are consolidated under the `kaoto.executor.*` name
 #### Catalog Version Picker
 
 A new **status bar item** shows the currently selected Camel catalog version and lets you switch between available versions with a single click. The picker filters catalogs based on the open file — showing Camel runtimes (Main, Quarkus, Spring Boot) for integration files and Citrus versions for test files.
-
-#### Red Hat Productized Versions
-
-When using Red Hat productized Camel versions (e.g. `4.8.0.redhat-00017`), you **must** configure the Red Hat recommended repositories in your Maven `settings.xml`. The extension will show a notification guiding you through this setup when a productized catalog is selected.
 
 ---
 


### PR DESCRIPTION
# Kaoto VS Code Extension v2.11.0 — Breaking Changes & Release Notes

## Breaking Changes

### Settings Renamed

Users who customized these settings **will lose their values** after upgrading. They must re-apply them under the new names.

| Old Setting (v2.10.x)                            | New Setting (v2.11.0)                          |
| ------------------------------------------------ | ---------------------------------------------- |
| `kaoto.camelJbang.runArguments`                  | `kaoto.executor.runArguments`                  |
| `kaoto.camelJbang.runFolderOrWorkspaceArguments` | `kaoto.executor.runFolderOrWorkspaceArguments` |
| `kaoto.camelJbang.redHatMavenRepository`         | `kaoto.executor.redHatMavenRepository`         |
| `kaoto.camelJbang.redHatMavenRepository.global`  | `kaoto.executor.redHatMavenRepository.global`  |
| `kaoto.camelJbang.kubernetesRunArguments`        | `kaoto.executor.kubernetesRunArguments`        |
| `kaoto.maven.camelJbang.exportProjectArguments`  | `kaoto.maven.executor.exportProjectArguments`  |

### Settings Removed

| Removed Setting            | Previous Default | Migration Path                                                                                                                    |
| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
| `kaoto.camelJbang.version` | `4.18.0`         | No longer user-configurable. The extension now derives the Camel version from the selected catalog. Default fallback is `4.20.0`. |
| `kaoto.camelVersion`       | _(empty)_        | Replaced by catalog selection mechanism — use the new status bar picker or the workspace-only setting `kaoto.runtimeCatalogName`. |

### Settings Section Reorganized

The settings UI in VS Code has been restructured:

- **Old:** General → Canvas, JBang, Maven, REST Configuration
- **New:** General → Canvas, Views, **Executor**, Maven, REST Configuration, **Advanced**

Users looking for JBang-related settings should now look under **Executor**.

### Default Camel Version Bumped: 4.18.0 → 4.20.0

This may affect users relying on the previous default, especially if their Camel routes use features or APIs that changed between these versions.

### Context Key Renamed

The VS Code context key `kaoto.jbangAvailable` → `kaoto.executorAvailable`.

**Impact:** Users who defined custom keybindings or `when`-clause conditions referencing the old key must update them.

---

## New Features

### Executor Type Selection

New setting `kaoto.executor.type` allows choosing between two execution backends:

- **`jbang`** (default) — Traditional JBang-based execution (requires JBang installation).
- **`camel-launcher`** (experimental) — Standalone Camel Launcher that is automatically downloaded. No JBang installation required.

### Catalog Selection via Status Bar

A new status bar item allows users to pick which runtime catalog to use (e.g., _Camel Main 4.14.7_, _Camel Quarkus 3.35.0_, _Citrus 4.10.1_).

Selected catalogs are stored as **workspace-only** settings:

- `kaoto.runtimeCatalogName` — for integration files
- `kaoto.testingCatalogName` — for test files

### Citrus Test File Support

Citrus test files are now fully supported by the Kaoto editor:

- Supported patterns: `*.citrus.yaml`, `*.citrus.test.yaml`, `*.citrus.it.yaml`, `*.citrus-test.yaml`, `*.citrus-it.yaml`
- Auto-open with the Kaoto graphical editor
- Extension activates when these files are present in the workspace

---

## UI Changes

- **Open Source Code / Close Source Code** buttons moved to the end of the editor title toolbar (from `navigation@1` to `navigation@99`). No functional change — visual repositioning only.

---

## Dependency Upgrades

| Dependency          | Old Version | New Version |
| ------------------- | ----------- | ----------- |
| Kaoto UI            | 2.10.0      | 2.11.0-RC5  |
| Camel Catalog       | 0.4.3       | 0.5.5       |
| PatternFly          | 6.4.0       | 6.5.x       |
| React               | 19.2.1      | 19.2.4      |
| Default Camel JBang | 4.18.0      | 4.20.0      |

---

## Impact Summary

| Change                                             | Severity   | Who's Affected                                |
| -------------------------------------------------- | ---------- | --------------------------------------------- |
| Renamed `kaoto.camelJbang.*` → `kaoto.executor.*`  | **High**   | Users who customized run/deploy arguments     |
| Removed `kaoto.camelJbang.version`                 | **High**   | Users who pinned a specific JBang CLI version |
| Removed `kaoto.camelVersion`                       | **Medium** | Users who overrode the default Camel version  |
| Default Camel version 4.18 → 4.20                  | **Medium** | Users relying on 4.18.x-specific behavior     |
| Context key `jbangAvailable` → `executorAvailable` | **Low**    | Users with custom keybindings/when-clauses    |
| Button position change                             | **Low**    | Visual only, no functional impact             |

---

## Action Required for Existing Users

1. **Check your `settings.json`** for any `kaoto.camelJbang.*` entries and rename them to `kaoto.executor.*`.
2. **Remove `kaoto.camelJbang.version`** and `kaoto.camelVersion` if present — they are no longer recognized.
3. **Review custom keybindings** for references to `kaoto.jbangAvailable` and replace with `kaoto.executorAvailable`.
4. **Verify integration compatibility** with Camel 4.20.0 if you were relying on the default version without pinning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive breaking changes and migration guide for 2.11
  * Updated settings namespace migration path with new configuration locations
  * Removed deprecated settings from supported configuration options
  * Reorganized settings UI layout in the application
  * Default Camel CLI version bumped to 4.20.0
  * Consolidated Red Hat productized catalog migration requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->