### PR TITLE
fix: catalog selector in status bar is not showing up + maven repository notification only for integration files

### DIFF
--- a/src/services/KaotoCatalogService.ts
+++ b/src/services/KaotoCatalogService.ts
@@ -694,10 +694,15 @@ export class KaotoCatalogService {
 
 	/**
 	 * Show Red Hat Maven notification once per catalog version change.
-	 * Triggered on initialization and catalog selection change -- not on editor focus.
+	 * Only shown when a runtime integration file is active (not test files).
 	 */
 	private async checkAndShowRedHatNotification(): Promise<void> {
 		try {
+			const activeUri = this.getActiveKaotoDocumentUri();
+			if (!activeUri || !this.isKaotoIntegrationFile(activeUri)) {
+				return;
+			}
+
 			const catalog = await this.getSelectedIntegrationCatalog();
 
 			if (!catalog || !this.redHatNotificationService.isRedHatCatalog(catalog.version)) {

--- a/src/services/KaotoCatalogService.ts
+++ b/src/services/KaotoCatalogService.ts
@@ -492,6 +492,9 @@ export class KaotoCatalogService {
 			vscode.window.tabGroups.onDidChangeTabGroups(() => {
 				void this.updateStatusBar();
 			}),
+			vscode.window.tabGroups.onDidChangeTabs(() => {
+				void this.updateStatusBar();
+			}),
 		);
 
 		return this.statusBarItem;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status bar refresh behavior when switching between document tabs.
  * Refined notification display to show Red Hat Maven catalog notifications only when an active integration file is open, reducing unnecessary alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->