### PR TITLE
feat: add openapi view welcome content

### DIFF
--- a/package.json
+++ b/package.json
@@ -923,6 +923,16 @@
         "view": "kaoto.tests",
         "contents": "In order to start with Citrus, you can create a new Citrus Test file.\n[New Citrus Test...](command:kaoto.citrus.jbang.init.test)\nTo learn more about Camel Testing [read docs](https://camel.apache.org/manual/camel-jbang-test.html).",
         "when": "!virtualWorkspace && kaoto.executorAvailable && workspaceFolderCount > 0"
+      },
+      {
+        "view": "kaoto.openapi",
+        "contents": "You have not yet added a folder to the workspace.\n[Open Folder](command:vscode.openFolder)",
+        "when": "workspaceFolderCount == 0"
+      },
+      {
+        "view": "kaoto.openapi",
+        "contents": "You can import an existing OpenAPI specification to use with your Camel integrations.\n[Import...](command:kaoto.openapi.import)\nTo learn more about OpenAPI and Kaoto [read docs](https://kaoto.io/docs/rest/).",
+        "when": "!virtualWorkspace && workspaceFolderCount > 0"
       }
     ],
     "configuration": [

--- a/src/views/providers/OpenApiProvider.ts
+++ b/src/views/providers/OpenApiProvider.ts
@@ -102,7 +102,7 @@ export class OpenApiProvider extends AbstractFolderTreeProvider<OpenApiFolder> {
 
 		if (!element) {
 			if (files.length === 0) {
-				return [new TreeItem('No OpenAPI files')];
+				return [];
 			}
 			return await this.getRootChildren(files);
 		}


### PR DESCRIPTION
BEFORE:
<img width="372" height="195" alt="openapi-before" src="https://github.com/user-attachments/assets/8611991b-249e-4e13-8fb3-2b444c7b5850" />


AFTER:
<img width="256" height="225" alt="Screenshot 2026-06-23 at 13 47 58" src="https://github.com/user-attachments/assets/59b45f28-ba9c-449f-b6b9-5e0d457b8a3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added welcome prompts for the OpenAPI view to guide users when starting with no workspace folder, and to suggest importing an OpenAPI specification for non-virtual workspaces.

* **Bug Fixes**
  * Fixed the OpenAPI tree to no longer show a placeholder “No OpenAPI files” item when filtering results in zero matches, avoiding an unnecessary entry in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->