### PR TITLE
feat: add launch config for a simple run of exported maven project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.12.0
 
+- Add launch config for a simple run of exported Camel (Maven) Application
+
 # 2.11.0
 
 - Upgrade default Camel JBang version from 4.18.0 to 4.20.0

--- a/resources/maven-export/quarkus/launch.json
+++ b/resources/maven-export/quarkus/launch.json
@@ -2,6 +2,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Run (quarkus:dev)",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": ["-e", "process.exit(0)"],
+            "preLaunchTask": "Run (quarkus:dev)",
+            "console": "internalConsole",
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Deploy on OpenShift (Quarkus)",
             "type": "node",
             "request": "launch",

--- a/resources/maven-export/quarkus/tasks.json
+++ b/resources/maven-export/quarkus/tasks.json
@@ -1,6 +1,33 @@
 {
     "version": "2.0.0",
     "tasks": [
+        {
+            "label": "Run (quarkus:dev)",
+            "type": "shell",
+            "command": "./mvnw",
+            "args": [
+                "quarkus:dev"
+            ],
+            "isBackground": true,
+            "problemMatcher": [
+                {
+                    "pattern": {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    },
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": ".",
+                        "endsPattern": "Started"
+                    }
+                }
+            ],
+            "presentation": {
+                "reveal": "always"
+            }
+        },
 		{
             "label": "Deploy on OpenShift (Quarkus)",
             "type": "shell",

--- a/resources/maven-export/spring-boot/launch.json
+++ b/resources/maven-export/spring-boot/launch.json
@@ -2,6 +2,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Run (spring-boot:run)",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": ["-e", "process.exit(0)"],
+            "preLaunchTask": "Run (spring-boot:run)",
+            "console": "internalConsole",
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Deploy on OpenShift (Spring Boot)",
             "type": "node",
             "request": "launch",

--- a/resources/maven-export/spring-boot/tasks.json
+++ b/resources/maven-export/spring-boot/tasks.json
@@ -2,6 +2,33 @@
     "version": "2.0.0",
     "tasks": [
 		{
+            "label": "Run (spring-boot:run)",
+            "type": "shell",
+            "command": "./mvnw",
+            "args": [
+                "spring-boot:run"
+            ],
+            "isBackground": true,
+            "problemMatcher": [
+                {
+                    "pattern": {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    },
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": ".",
+                        "endsPattern": "Started"
+                    }
+                }
+            ],
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
             "label": "Deploy on OpenShift (Spring Boot)",
             "type": "shell",
             "command": "./mvnw",


### PR DESCRIPTION
Quarkus:

https://github.com/user-attachments/assets/c4653dee-8954-4570-a95b-bc144a56c2fa


Spring Boot:

https://github.com/user-attachments/assets/c62bfca3-3c24-472d-99ad-043bcc2cfb37



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new one-click run/debug options for exported Maven applications in both Quarkus and Spring Boot templates.
  * Included matching background tasks so the apps can start directly from the editor.
* **Bug Fixes**
  * Improved launch behavior so these run configurations open more cleanly and do not interrupt the editor unexpectedly.
* **Documentation**
  * Updated the changelog with the new release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->