### PR TITLE
TEMP: isolate #1468 — CODE_VERSION A/B on webview suites (not for merge)

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -1,3 +1,8 @@
+# TEMP (#1468): this branch trims CI to isolate the blank-webview reproduction.
+# Only the webview-dependent suites run (see the test:it:with-prebuilt-vsix glob),
+# each matrix job is a single attempt (no retry) so every job is one clean sample,
+# and CODE_VERSION is A/B'd between `max` (VS Code >= 1.123.0, Chromium 148) and
+# 1.122.0 (Chromium 142, known good). Not for merge.
 on:
   workflow_call:
     inputs:
@@ -68,9 +73,15 @@ jobs:
     if: ${{ inputs.run-ubuntu }}
     runs-on: ${{ inputs.runner-ubuntu }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        code-version: [max, "1.122.0"]
+        sample: [1, 2, 3]
+    name: ubuntu / ${{ matrix.code-version }} / sample ${{ matrix.sample }}
 
     env:
-      CODE_VERSION: max
+      CODE_VERSION: ${{ matrix.code-version }}
       TEST_RESOURCES: test-resources
 
     steps:
@@ -78,12 +89,6 @@ jobs:
       - uses: ./.github/actions/setup-tools
         with:
           cache: yarn
-      - uses: ./.github/actions/setup-minikube
-        with:
-          enable-qemu: ${{ inputs.enable-qemu && 'true' || 'false' }}
-      - name: Install Yarn
-        if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
         with:
@@ -92,63 +97,25 @@ jobs:
         run: yarn install --mode=skip-build
       - name: Allow unprivileged user namespace
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      - name: Run Integration Tests
-        uses: nick-fields/retry@v4.0.0
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: ${{ inputs.retry-wait-ubuntu }}
-          max_attempts: 2
-          command: |
-            eval $(minikube -p minikube docker-env)
-            xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
+      - name: Run Integration Tests (single attempt)
+        run: xvfb-run -a yarn run test:it:with-prebuilt-vsix
       - uses: ./.github/actions/upload-test-artifacts
         if: failure()
         with:
-          os-name: ubuntu
-
-  test-macos:
-    if: ${{ inputs.run-macos }}
-    runs-on: ${{ inputs.runner-macos }}
-    timeout-minutes: 60
-
-    env:
-      CODE_VERSION: max
-      TEST_RESOURCES: test-resources
-
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup-tools
-        with:
-          cache: yarn
-      - name: Install Yarn
-        if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
-      - name: Download VSIX artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ inputs.vsix-artifact-name }}
-      - name: Install test dependencies
-        run: yarn install --mode=skip-build
-      - name: Run Integration Tests
-        uses: nick-fields/retry@v4.0.0
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: ${{ inputs.retry-wait-macos }}
-          max_attempts: 2
-          command: yarn run test:it:with-prebuilt-vsix
-          on_retry_command: rm -rf "${RUNNER_TEMP}/extest-code"
-      - uses: ./.github/actions/upload-test-artifacts
-        if: failure()
-        with:
-          os-name: macos
+          os-name: ubuntu-${{ matrix.code-version }}-${{ matrix.sample }}
 
   test-windows:
     if: ${{ inputs.run-windows }}
     runs-on: ${{ inputs.runner-windows }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        code-version: [max, "1.122.0"]
+    name: windows / ${{ matrix.code-version }}
 
     env:
-      CODE_VERSION: max
+      CODE_VERSION: ${{ matrix.code-version }}
       TEST_RESOURCES: test-resources
 
     steps:
@@ -156,25 +123,17 @@ jobs:
       - uses: ./.github/actions/setup-tools
         with:
           cache: yarn
-      - name: Install Yarn
-        if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.vsix-artifact-name }}
       - name: Install test dependencies
         run: yarn install --mode=skip-build
-      - name: Run Integration Tests
-        uses: nick-fields/retry@v4.0.0
-        with:
-          timeout_minutes: 30
-          retry_wait_seconds: ${{ inputs.retry-wait-windows }}
-          max_attempts: 2
-          command: |
-            Set-DisplayResolution -Width 1920 -Height 1080 -Force
-            yarn run test:it:with-prebuilt-vsix
+      - name: Run Integration Tests (single attempt)
+        run: |
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+          yarn run test:it:with-prebuilt-vsix
       - uses: ./.github/actions/upload-test-artifacts
         if: failure()
         with:
-          os-name: windows
+          os-name: windows-${{ matrix.code-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,32 +21,15 @@ jobs:
         run: yarn --network-timeout 1000000
       - name: yarn build:prod
         run: yarn build:prod
-      - name: Allow unprivileged user namespace
-        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-      - name: Run Unit tests
-        run: xvfb-run -a yarn test:unit
+      # TEMP (#1468): unit tests and SBOM skipped on this diagnostic branch —
+      # only the VSIX is needed to feed the integration-test A/B.
       - name: vsix package
         run: yarn build:vsix
-      - name: Generate SBOM
-        run: |
-          npm install -g @cyclonedx/cdxgen
-          cdxgen -o manifest.json
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7
         with:
           name: vscode-kaoto-vsix
           path: "*.vsix"
-      - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: sbom
-          path: manifest.json
-      - name: Store Unit Tests VS Code Logs
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: ubuntu-unit-test-logs
-          path: .vscode-test/user-data/logs/*
 
   integration-tests:
     needs: build

--- a/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch
+++ b/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch
@@ -1,0 +1,26 @@
+diff --git a/out/browser.js b/out/browser.js
+index 1bd673e101e4d1b3e8fd9ef427c4de675d3961e6..b23512577e05517b0154e7c21718bd280b1cdc9f 100644
+--- a/out/browser.js
++++ b/out/browser.js
+@@ -312,6 +312,21 @@ class VSBrowser {
+         if (paths.length === 0) {
+             return;
+         }
++        // Workaround for microsoft/vscode#330243 (see also
++        // redhat-developer/vscode-extension-tester#2454): `CodeUtil.open` spawns a
++        // second-instance CLI call, and when that lands while VS Code is still
++        // starting up, VS Code >= 1.123.0 duplicates every 256 KiB chunk of every
++        // webview resource in the window AND the webview service worker caches the
++        // corrupted responses, permanently poisoning the profile. Waiting for the
++        // workbench element alone is not enough - it appears while the race window
++        // is still open - so the first open of a session additionally waits for the
++        // instance to settle.
++        if (!VSBrowser._openResourcesSettled) {
++            await this.waitForWorkbench();
++            const settleMs = Number(process.env.EXTESTER_OPEN_RESOURCE_SETTLE_MS ?? 10000);
++            await new Promise((resolve) => setTimeout(resolve, settleMs));
++            VSBrowser._openResourcesSettled = true;
++        }
+         const code = new codeUtil_1.CodeUtil(this.storagePath, this.releaseType, this.extensionsFolder);
+         code.open(...paths);
+         await this.waitForWorkbench(undefined, waitForFn);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.5.5",
+    "@kaoto/camel-catalog": "^0.7.0",
     "@kaoto/kaoto": "2.11.0",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",
@@ -1354,7 +1354,7 @@
     "ts-loader": "9.4.4",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^5.9.3",
-    "vscode-extension-tester": "^8.23.0",
+    "vscode-extension-tester": "^8.24.0",
     "web-worker": "^1.5.0",
     "webpack": "5.108.3",
     "webpack-cli": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -1354,7 +1354,7 @@
     "ts-loader": "9.4.4",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^5.9.3",
-    "vscode-extension-tester": "^8.24.0",
+    "vscode-extension-tester": "patch:vscode-extension-tester@npm%3A8.24.0#~/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch",
     "web-worker": "^1.5.0",
     "webpack": "5.108.3",
     "webpack-cli": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:unit": "yarn build:test:unit && vscode-test",
     "test:it": "yarn build:test:it && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources --open_resource './test Fixture with speci@l chars' 'out/**/*.test.js'",
     "setup:test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources --open_resource './test Fixture with speci@l chars'",
-    "test:it:with-prebuilt-vsix": "yarn setup:test:it:with-prebuilt-vsix --code_settings ./it-tests/vscode-settings.json 'out/**/*.test.js'",
+    "test:it:with-prebuilt-vsix": "yarn setup:test:it:with-prebuilt-vsix --code_settings ./it-tests/vscode-settings.json 'out/{BasicFlow,SwitchBetweenTabs,PropertyPanelLoading,ContextualMenuOpen}.test.js'",
     "test:it:with-prebuilt-vsix:minikube": "yarn setup:test:it:with-prebuilt-vsix --code_settings ./it-tests/vscode-settings-minikube.json 'out/**/*.test.js'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },

--- a/src/services/openapi-import.service.ts
+++ b/src/services/openapi-import.service.ts
@@ -39,12 +39,7 @@ export type RestMethods = 'get' | 'head' | 'post' | 'put' | 'patch' | 'delete';
  * Union type of all REST method definition types.
  */
 export type RestMethodDefinitions =
-	| Flatten<Rest['get']>
-	| Flatten<Rest['head']>
-	| Flatten<Rest['post']>
-	| Flatten<Rest['put']>
-	| Flatten<Rest['patch']>
-	| Flatten<Rest['delete']>;
+	Flatten<Rest['get']> | Flatten<Rest['head']> | Flatten<Rest['post']> | Flatten<Rest['put']> | Flatten<Rest['patch']> | Flatten<Rest['delete']>;
 
 /**
  * Array of supported REST DSL verbs.

--- a/yarn.lock
+++ b/yarn.lock
@@ -13458,7 +13458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-extension-tester@npm:^8.24.0":
+"vscode-extension-tester@npm:8.24.0":
   version: 8.24.0
   resolution: "vscode-extension-tester@npm:8.24.0"
   dependencies:
@@ -13485,6 +13485,36 @@ __metadata:
   bin:
     extest: out/cli.js
   checksum: 10/f7592f655fe4ba22841c4cffdeb1d22f074d7a93152ae57407922f28a65580952fd355d09f896cf1b2b7c4a267386c668c3093aa04356a32afb9cded0324085d
+  languageName: node
+  linkType: hard
+
+"vscode-extension-tester@patch:vscode-extension-tester@npm%3A8.24.0#~/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch":
+  version: 8.24.0
+  resolution: "vscode-extension-tester@patch:vscode-extension-tester@npm%3A8.24.0#~/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch::version=8.24.0&hash=24b6e6"
+  dependencies:
+    "@redhat-developer/locators": "npm:^1.21.0"
+    "@redhat-developer/page-objects": "npm:^1.21.0"
+    "@types/selenium-webdriver": "npm:^4.35.6"
+    "@vscode/vsce": "npm:^3.9.2"
+    c8: "npm:^12.0.0"
+    commander: "npm:^14.0.3"
+    compare-versions: "npm:^6.1.1"
+    find-up: "npm:8.0.0"
+    fs-extra: "npm:^11.4.0"
+    glob: "npm:^13.0.6"
+    got: "npm:^15.1.0"
+    hpagent: "npm:^1.2.0"
+    js-yaml: "npm:^5.2.2"
+    sanitize-filename: "npm:^1.6.4"
+    selenium-webdriver: "npm:^4.46.0"
+    targz: "npm:^1.0.1"
+    unzipper: "npm:^0.12.5"
+  peerDependencies:
+    mocha: ">=5.2.0"
+    typescript: ">=4.6.2"
+  bin:
+    extest: out/cli.js
+  checksum: 10/481e839be0f9e95035d8d2f3a4e6f87ab6fa08aeca717379b20959b52bfdd2698f8e65ed95fe9bd590d0fd2225916ee4f310faf8432e06789426145e0d776889
   languageName: node
   linkType: hard
 
@@ -13559,7 +13589,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     unzipper: "npm:^0.12.5"
     valid-filename: "npm:4.0.0"
-    vscode-extension-tester: "npm:^8.24.0"
+    vscode-extension-tester: "patch:vscode-extension-tester@npm%3A8.24.0#~/.yarn/patches/vscode-extension-tester-npm-8.24.0-62b74258e3.patch"
     wait-on: "npm:^9.0.10"
     web-worker: "npm:^1.5.0"
     webpack: "npm:5.108.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,10 +891,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "@kaoto/camel-catalog@npm:0.5.5"
-  checksum: 10/019977e4072b2ef4993fc9a8a30dc4e33e74c754dc6d9978a4dbeadb0721bed373a346bf842a1ed6d1810b4df6dc11647cf51cae9bd598f5685e703c42628c3a
+"@kaoto/camel-catalog@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@kaoto/camel-catalog@npm:0.7.0"
+  checksum: 10/228cf4e7190700e9d16bcd8f87497cac0e886a54daf01a10213b5c1d9d5fbde9616a396686f8c967e2c5d4d1576a24e0e68893ccce6ac5c1178c789911bfdf22
   languageName: node
   linkType: hard
 
@@ -1603,29 +1603,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhat-developer/locators@npm:^1.20.0":
-  version: 1.20.0
-  resolution: "@redhat-developer/locators@npm:1.20.0"
+"@redhat-developer/locators@npm:^1.21.0":
+  version: 1.21.0
+  resolution: "@redhat-developer/locators@npm:1.21.0"
   peerDependencies:
     "@redhat-developer/page-objects": ">=1.0.0"
     selenium-webdriver: ">=4.6.1"
-  checksum: 10/c8de945ee0f693e895ceaec249dc560a644cf9842f3fd0135e8989231c09a9f267dad6ca5f4bbde58aad541a10bce0b309a9f5ce997fe7207341bccc719cf374
+  checksum: 10/5a8dd4b299583e0a777017a086f324b3f91d22fe9134cb93dd445414f64cab316137e03050d0964e73ccc1fda8e3b52135d89b8da2aab5e85ef79a432b89b6bd
   languageName: node
   linkType: hard
 
-"@redhat-developer/page-objects@npm:^1.20.0":
-  version: 1.20.0
-  resolution: "@redhat-developer/page-objects@npm:1.20.0"
+"@redhat-developer/page-objects@npm:^1.21.0":
+  version: 1.21.0
+  resolution: "@redhat-developer/page-objects@npm:1.21.0"
   dependencies:
-    clipboardy: "npm:^5.3.1"
+    clipboardy: "npm:^5.3.2"
     clone-deep: "npm:^4.0.1"
     compare-versions: "npm:^6.1.1"
-    fs-extra: "npm:^11.3.4"
-    type-fest: "npm:^4.41.0"
+    fs-extra: "npm:^11.4.0"
   peerDependencies:
     selenium-webdriver: ">=4.6.1"
     typescript: ">=4.6.2"
-  checksum: 10/52ce8129191e0c218ee4be22bc98dc54edb4da6aff3360f014e38403b4a846de10659d6a493b9d9f5a849fa57c0a4a52c05bb44e95b2086e75ab0f252925042f
+  checksum: 10/70326825567a0e2842e0e5692881077cbc498a0c18cb93406ca8dd305c1b7d9920ae4e0e6a204a2e150b8c2078b184a3f5b3808e725fd123c90328bbd25af86e
   languageName: node
   linkType: hard
 
@@ -1828,10 +1827,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "@sindresorhus/is@npm:7.0.1"
-  checksum: 10/d096d98268400c698633e620616b56dec822fd4fc55299caaf6c985e9242215c2c99f81da5701b783295c3019f6298a8299535eb9c2fcb69684fb9b5882aaedd
+"@sindresorhus/is@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "@sindresorhus/is@npm:8.1.0"
+  checksum: 10/4511f60fa5f21c28694eabff61b4c2fd7b65d7ac895a9330a2e862fd35e880b9b10393c6ccb44c94fa0a1d2320044ac413277ffbdb33e75cffcb0fca8fa56b76
   languageName: node
   linkType: hard
 
@@ -2428,10 +2427,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@types/http-cache-semantics@npm:4.0.4"
-  checksum: 10/a59566cff646025a5de396d6b3f44a39ab6a74f2ed8150692e0f31cc52f3661a68b04afe3166ebe0d566bd3259cb18522f46e949576d5204781cd6452b7fe0c5
+"@types/http-cache-semantics@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@types/http-cache-semantics@npm:4.2.0"
+  checksum: 10/01ea0dc9c1852267f5f9a0190846ac158707994b8e325bca190385ec97aa773d4a99cd333e22e838bde3c9aba59e2b5a6ac399b494c203587c6d8f28d21d6326
   languageName: node
   linkType: hard
 
@@ -2560,13 +2559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/selenium-webdriver@npm:^4.35.5":
-  version: 4.35.5
-  resolution: "@types/selenium-webdriver@npm:4.35.5"
+"@types/selenium-webdriver@npm:^4.35.6":
+  version: 4.35.6
+  resolution: "@types/selenium-webdriver@npm:4.35.6"
   dependencies:
     "@types/node": "npm:*"
     "@types/ws": "npm:*"
-  checksum: 10/87bfc4948739ab2b69d6c133dfbe7cbd3134191e5c618c571b6976bf4f3cb74ec5b493a17f53c6a80acff5f6aafb22c5e5b6a12dcf7b42486a0831316207bf85
+  checksum: 10/9b698c7d88eaaa2892a6d3a95d08ec6991ed43ed3cbdd669da1639836d3d0eed97843dd8ac052de7ce1ca610992e92ba198c1ecf066f9690470501cf71664a15
   languageName: node
   linkType: hard
 
@@ -3015,49 +3014,6 @@ __metadata:
     "@vscode/vsce-sign-win32-x64":
       optional: true
   checksum: 10/b1aaf2e7e3d8744f79a0b470b382d168bf0fc4ea71d039991408ca06dd754f1ec4ae3b2ce5613cb86c9311d745c82374e0fbdfdcb97077d0dabd321491fb2aaa
-  languageName: node
-  linkType: hard
-
-"@vscode/vsce@npm:^3.7.1":
-  version: 3.7.1
-  resolution: "@vscode/vsce@npm:3.7.1"
-  dependencies:
-    "@azure/identity": "npm:^4.1.0"
-    "@secretlint/node": "npm:^10.1.2"
-    "@secretlint/secretlint-formatter-sarif": "npm:^10.1.2"
-    "@secretlint/secretlint-rule-no-dotenv": "npm:^10.1.2"
-    "@secretlint/secretlint-rule-preset-recommend": "npm:^10.1.2"
-    "@vscode/vsce-sign": "npm:^2.0.0"
-    azure-devops-node-api: "npm:^12.5.0"
-    chalk: "npm:^4.1.2"
-    cheerio: "npm:^1.0.0-rc.9"
-    cockatiel: "npm:^3.1.2"
-    commander: "npm:^12.1.0"
-    form-data: "npm:^4.0.0"
-    glob: "npm:^11.0.0"
-    hosted-git-info: "npm:^4.0.2"
-    jsonc-parser: "npm:^3.2.0"
-    keytar: "npm:^7.7.0"
-    leven: "npm:^3.1.0"
-    markdown-it: "npm:^14.1.0"
-    mime: "npm:^1.3.4"
-    minimatch: "npm:^3.0.3"
-    parse-semver: "npm:^1.1.1"
-    read: "npm:^1.0.7"
-    secretlint: "npm:^10.1.2"
-    semver: "npm:^7.5.2"
-    tmp: "npm:^0.2.3"
-    typed-rest-client: "npm:^1.8.4"
-    url-join: "npm:^4.0.1"
-    xml2js: "npm:^0.5.0"
-    yauzl: "npm:^2.3.1"
-    yazl: "npm:^2.2.2"
-  dependenciesMeta:
-    keytar:
-      optional: true
-  bin:
-    vsce: vsce
-  checksum: 10/33fa4c24821577e4ee6e89f075b1530063fe3564300e46a14708ed283ec0a01f7626ebc859b8e6fa2f3b728de92fb9748c7124faf09d6b43100fc700484b587b
   languageName: node
   linkType: hard
 
@@ -4040,6 +3996,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"c8@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "c8@npm:12.0.0"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^1.0.1"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    find-up: "npm:^5.0.0"
+    foreground-child: "npm:^3.1.1"
+    istanbul-lib-coverage: "npm:^3.2.0"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.1.6"
+    test-exclude: "npm:^8.0.0"
+    v8-to-istanbul: "npm:^9.0.0"
+    yargs: "npm:^18.0.0"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    monocart-coverage-reports: ^2
+  peerDependenciesMeta:
+    monocart-coverage-reports:
+      optional: true
+  bin:
+    c8: bin/c8.js
+  checksum: 10/cb4b08b8170b9004766f2e51bbe41916454c0952ac5f811a11d98250fc1539704b92b65dfe6b76f1319d64d1111596b7f04fe088f6df69942345960859a65d49
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^18.0.0":
   version: 18.0.2
   resolution: "cacache@npm:18.0.2"
@@ -4067,18 +4049,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^13.0.12":
-  version: 13.0.12
-  resolution: "cacheable-request@npm:13.0.12"
+"cacheable-request@npm:^13.0.18":
+  version: 13.0.19
+  resolution: "cacheable-request@npm:13.0.19"
   dependencies:
-    "@types/http-cache-semantics": "npm:^4.0.4"
+    "@types/http-cache-semantics": "npm:^4.2.0"
     get-stream: "npm:^9.0.1"
     http-cache-semantics: "npm:^4.2.0"
-    keyv: "npm:^5.5.3"
+    keyv: "npm:^5.6.0"
     mimic-response: "npm:^4.0.0"
-    normalize-url: "npm:^8.1.0"
-    responselike: "npm:^3.0.0"
-  checksum: 10/7923a29f6283cacfb320edbabbe0ddd1f9b99233eea5494ff1f86eafc6f5a14faf784055df189999f0cc758f9abc38f95181ec1985472b35d04217cbf4c555bb
+    normalize-url: "npm:^8.1.1"
+    responselike: "npm:^4.0.2"
+  checksum: 10/d4a942cec534ebc124b25fd3881774be45ab415502597da8d928ef81aef41ed75c7c003516fa01743041715055ed585fb44ba7856e4ea252cbc217454c1d40c5
   languageName: node
   linkType: hard
 
@@ -4327,6 +4309,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chunk-data@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "chunk-data@npm:0.1.0"
+  checksum: 10/3ab3f7b7da54481bafed8f83f2d9f844b8f43f37c01f7b8079c440e10a5373b6572023743472f49304e20e6b750c8c830c42e3eff3413c073c4ba5448d64eed7
+  languageName: node
+  linkType: hard
+
 "classnames@npm:2.5.1, classnames@npm:^2.3.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
@@ -4375,9 +4364,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clipboardy@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "clipboardy@npm:5.3.1"
+"clipboardy@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "clipboardy@npm:5.3.2"
   dependencies:
     clipboard-image: "npm:^0.1.0"
     execa: "npm:^9.6.1"
@@ -4385,7 +4374,7 @@ __metadata:
     is-wsl: "npm:^3.1.0"
     is64bit: "npm:^2.0.0"
     powershell-utils: "npm:^0.2.0"
-  checksum: 10/027325dd58b6f10e84704116a461212816b420b74b44fe1c6d518a358e73525273a72d8848d358ac73ee229a35309215e803ae5f1f539c5fe51564564840ebe0
+  checksum: 10/9ae0f091179372a82ca850f9b638577d4816632cec5e4647d1fc984a7af54ac96246e88e40183d40094b1147b408f5134a5f8649b87dad431e7e1174058db349
   languageName: node
   linkType: hard
 
@@ -6380,15 +6369,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
-  languageName: node
-  linkType: hard
-
 "fdir@npm:^6.4.3":
   version: 6.4.3
   resolution: "fdir@npm:6.4.3"
@@ -6628,13 +6608,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "form-data-encoder@npm:4.0.2"
-  checksum: 10/71a00a1e954267f8b87d4301936dda7177cfe18714a92930c87ebc132acb8b19ed12e9b9f8ad47af52c1cc582fd45c1771f66f850a6d319147731160f6b9b3fa
-  languageName: node
-  linkType: hard
-
 "form-data@npm:^4.0.0":
   version: 4.0.0
   resolution: "form-data@npm:4.0.0"
@@ -6695,28 +6668,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.2.0":
-  version: 11.2.0
-  resolution: "fs-extra@npm:11.2.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10/0579bf6726a4cd054d4aa308f10b483f52478bb16284f32cf60b4ce0542063d551fca1a08a2af365e35db21a3fa5a06cf2a6ed614004b4368982bc754cb816b3
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^11.3.4":
-  version: 11.3.4
-  resolution: "fs-extra@npm:11.3.4"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10/1b8deea9c540a2efe63c750bc9e1ba6238115579d1571d67fe8fb58e3fb6df19aba29fd4ebb81217cf0bf5bce0df30ca68dbc3e06f6652b856edd385ce0ff649
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:^11.3.6":
   version: 11.3.6
   resolution: "fs-extra@npm:11.3.6"
@@ -6725,6 +6676,17 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10/34a981697b199002ea3b85c3483bcf353637d33ec4c922b136a8d8a597faa0495638d69b20c181448be041c31778c2bb7f7799d589819edf33da50f75b1abde9
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.4.0":
+  version: 11.4.0
+  resolution: "fs-extra@npm:11.4.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10/a1bd91076fe9de9114bd037a433f1f498857eb3f0cf778e647fd00dc5984374dee5e088854de3d6ca77cd9f11554a85f6f016a6004d0838bbc7cd722e33601ce
   languageName: node
   linkType: hard
 
@@ -6964,22 +6926,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "glob@npm:11.0.0"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^4.0.1"
-    minimatch: "npm:^10.0.0"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^2.0.0"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/e66939201d11ae30fe97e3364ac2be5c59d6c9bfce18ac633edfad473eb6b46a7553f6f73658f67caaf6cccc1df1ae336298a45e9021fa5695fd78754cc1603e
-  languageName: node
-  linkType: hard
-
 "glob@npm:^13.0.3":
   version: 13.0.5
   resolution: "glob@npm:13.0.5"
@@ -7042,23 +6988,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^14.6.6":
-  version: 14.6.6
-  resolution: "got@npm:14.6.6"
+"got@npm:^15.1.0":
+  version: 15.1.0
+  resolution: "got@npm:15.1.0"
   dependencies:
-    "@sindresorhus/is": "npm:^7.0.1"
+    "@sindresorhus/is": "npm:^8.0.0"
     byte-counter: "npm:^0.1.0"
     cacheable-lookup: "npm:^7.0.0"
-    cacheable-request: "npm:^13.0.12"
+    cacheable-request: "npm:^13.0.18"
+    chunk-data: "npm:^0.1.0"
     decompress-response: "npm:^10.0.0"
-    form-data-encoder: "npm:^4.0.2"
     http2-wrapper: "npm:^2.2.1"
-    keyv: "npm:^5.5.3"
-    lowercase-keys: "npm:^3.0.0"
-    p-cancelable: "npm:^4.0.1"
+    keyv: "npm:^5.6.0"
+    lowercase-keys: "npm:^4.0.1"
     responselike: "npm:^4.0.2"
-    type-fest: "npm:^4.26.1"
-  checksum: 10/b11f0fa719921da9fe6304250584eb59dca737b9bc8f846b43c1305442271ece1635adb0bb5db115db63c22c11f408bb7dd73e9bb8fb310449b9ee2b366b47d5
+    type-fest: "npm:^5.6.0"
+    uint8array-extras: "npm:^1.5.0"
+  checksum: 10/ca875c2f5df2d63558a62172dba3442d20074c1e94ec22362005a3f935021652d97e555bb46b63ea6566e9a00eebe695b4aaebdfe64119f1e959ce81b1f0086b
   languageName: node
   linkType: hard
 
@@ -8173,19 +8119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "jackspeak@npm:4.0.1"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 10/b20dc0df0dbb2903e4d540ae68308ec7d1dd60944b130e867e218c98b5d77481d65ea734b6c81c812d481500076e8b3fdfccfb38fc81cb1acf165e853da3e26c
-  languageName: node
-  linkType: hard
-
 "jest-worker@npm:^27.4.5":
   version: 27.5.1
   resolution: "jest-worker@npm:27.5.1"
@@ -8249,14 +8182,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "js-yaml@npm:5.2.3"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10/5d2562f2d7e7bc51bd678b43d2dbc3965129ac854222c794157369c8904d249cfc78325dff8fc64becb505a2506242548c54c8fa50cdb24554bb1a557e460004
   languageName: node
   linkType: hard
 
@@ -8443,12 +8376,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "keyv@npm:5.5.3"
+"keyv@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "keyv@npm:5.6.0"
   dependencies:
     "@keyv/serialize": "npm:^1.1.1"
-  checksum: 10/b8d2c354dade07cb4cb6ccffe6495c1a32a67cf9f066a9660eeaea974ab9d8b94dd568b4e71b23f217f587d3e07b558fa6e48158baea1a0bc9514bb15c1de555
+  checksum: 10/f1de999fdf635d703d091981a0a3844fb20081e01d45c6743ada7d01f3a6570dc47d1882e10d0a98d31075b342db8e62b4ebe4f5bf473dcd0903064d718709c1
   languageName: node
   linkType: hard
 
@@ -8752,6 +8685,13 @@ __metadata:
   version: 3.0.0
   resolution: "lowercase-keys@npm:3.0.0"
   checksum: 10/67a3f81409af969bc0c4ca0e76cd7d16adb1e25aa1c197229587eaf8671275c8c067cd421795dbca4c81be0098e4c426a086a05e30de8a9c587b7a13c0c7ccc5
+  languageName: node
+  linkType: hard
+
+"lowercase-keys@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lowercase-keys@npm:4.0.1"
+  checksum: 10/f9b3f00fc182a2cd0f751d633a454474c7b7d1aeff31ce6dd5f75200e72885b6501a47e473aeead5b096fbc3b064c26ba053712382248750797696d6aabe03e3
   languageName: node
   linkType: hard
 
@@ -9530,15 +9470,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^10.2.1":
   version: 10.2.1
   resolution: "minimatch@npm:10.2.1"
@@ -10097,10 +10028,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "normalize-url@npm:8.1.0"
-  checksum: 10/59b765bfe7d1768105d23a9f80716cdf1046a50a618af43eeba5e116475ff8b1a9b3e023e9c534903be436df4dac2fb9c93822cad3809fe689378945662bc8c8
+"normalize-url@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "normalize-url@npm:8.1.1"
+  checksum: 10/a96519b53692f33d5de19a8aa04fe9de4b8de1c126da89f1c47a24e48d457008867193cd9c19218810426ffabe190034249e1b82f0751c8992f2a9f716304ce0
   languageName: node
   linkType: hard
 
@@ -10348,13 +10279,6 @@ __metadata:
     object-keys: "npm:^1.1.1"
     safe-push-apply: "npm:^1.0.0"
   checksum: 10/ab4bb3b8636908554fc19bf899e225444195092864cb61503a0d048fdaf662b04be2605b636a4ffeaf6e8811f6fcfa8cbb210ec964c0eb1a41eb853e1d5d2f41
-  languageName: node
-  linkType: hard
-
-"p-cancelable@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "p-cancelable@npm:4.0.1"
-  checksum: 10/64de7b0be4c8bacc006488e0e90aa66fbcceb4da4f6fb84584573145f015f9650fe6ac26470897b3e82a3b528f6c60ea276b84cc315e35c45e9f12dec062a295
   languageName: node
   linkType: hard
 
@@ -11551,15 +11475,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"responselike@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "responselike@npm:3.0.0"
-  dependencies:
-    lowercase-keys: "npm:^3.0.0"
-  checksum: 10/e0cc9be30df4f415d6d83cdede3c5c887cd4a73e7cc1708bcaab1d50a28d15acb68460ac5b02bcc55a42f3d493729c8856427dcf6e57e6e128ad05cba4cfb95e
-  languageName: node
-  linkType: hard
-
 "responselike@npm:^4.0.2":
   version: 4.0.2
   resolution: "responselike@npm:4.0.2"
@@ -11711,12 +11626,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-filename@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "sanitize-filename@npm:1.6.3"
+"sanitize-filename@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "sanitize-filename@npm:1.6.4"
   dependencies:
     truncate-utf8-bytes: "npm:^1.0.0"
-  checksum: 10/1c162e2cffa797571221c3ed9fe796fa8c6eabb0812418b52a839e4fc63ab130093eb546ec39e1b94b8d3511c0d7de81db3e67906a7e76d7a7bcb6fbab4ed961
+  checksum: 10/9fb32f8ae51b1931eb4f780ac140f3fa9ccbfd8c746231d426cd5f0bc95608557e6e2540186bab81a702b98cd301b622f4a80d3263d82680bebca90a38158b38
   languageName: node
   linkType: hard
 
@@ -11830,15 +11745,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selenium-webdriver@npm:^4.41.0":
-  version: 4.41.0
-  resolution: "selenium-webdriver@npm:4.41.0"
+"selenium-webdriver@npm:^4.46.0":
+  version: 4.46.0
+  resolution: "selenium-webdriver@npm:4.46.0"
   dependencies:
     "@bazel/runfiles": "npm:^6.5.0"
     jszip: "npm:^3.10.1"
-    tmp: "npm:^0.2.5"
-    ws: "npm:^8.19.0"
-  checksum: 10/29eaea5f8f67d173568ffbd82534ed724dbf61aa12d5f1a1e4141f2f8e3a17ec2f1a71aa386c66442936f45e74203a8e5a6f34e9086f93ca971debb8b66f9665
+    tmp: "npm:^0.2.7"
+    ws: "npm:^8.21.0"
+  checksum: 10/f520f85c600bd3a4d388cf5abcb0a86a2aa073dbab9ab730e42a92aa26d83f07300a7c1f14ae99fe726ab75763c3b0234847ad57872e3946a780071d95aea6d6
   languageName: node
   linkType: hard
 
@@ -12639,6 +12554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10/e37653df3e495daa7ea7790cb161b810b00075bba2e4d6c93fb06a709e747e3ae9da11a120d0489833203926511b39e038a2affbd9d279cfb7a2f3fcccd30b5d
+  languageName: node
+  linkType: hard
+
 "tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
@@ -12879,10 +12801,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10/dd4b78b32385eab4899d3ae296007b34482b035b6d73e1201c4a9aede40860e90997a1452c65a2d21aee73d53e93cd167d741c3db4015d90e63b6d568a93d7ec
+"tmp@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 
@@ -13088,17 +13010,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.26.1":
-  version: 4.26.1
-  resolution: "type-fest@npm:4.26.1"
-  checksum: 10/b82676194f80af228cb852e320d2ea8381c89d667d2e4d9f2bdfc8f254bccc039c7741a90c53617a4de0c9fdca8265ed18eb0888cd628f391c5c381c33a9f94b
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.39.1, type-fest@npm:^4.41.0, type-fest@npm:^4.6.0":
+"type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10/617ace794ac0893c2986912d28b3065ad1afb484cad59297835a0807dc63286c39e8675d65f7de08fafa339afcb8fe06a36e9a188b9857756ae1e92ee8bda212
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.6.0":
+  version: 5.8.0
+  resolution: "type-fest@npm:5.8.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10/4dbe4c78ac6933d3d165b01f9d552991a84d63e5352110e01bebb5c46499fb1f44d199fc88835b18ee5662ee44c73926621f59525e46f7faa031086ac00b2686
   languageName: node
   linkType: hard
 
@@ -13210,6 +13134,13 @@ __metadata:
   version: 2.1.0
   resolution: "uc.micro@npm:2.1.0"
   checksum: 10/37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2
+  languageName: node
+  linkType: hard
+
+"uint8array-extras@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "uint8array-extras@npm:1.5.0"
+  checksum: 10/94fd56a2dda6a7445f5176f301f491814c87757d38e4b3c932299ab54d69ec504830e5d5c18ffa20cf694a69a210315be8b4a2c9952c6334da817ea2d2e1dce0
   languageName: node
   linkType: hard
 
@@ -13356,19 +13287,6 @@ __metadata:
   version: 2.0.1
   resolution: "universalify@npm:2.0.1"
   checksum: 10/ecd8469fe0db28e7de9e5289d32bd1b6ba8f7183db34f3bfc4ca53c49891c2d6aa05f3fb3936a81285a905cc509fb641a0c3fc131ec786167eff41236ae32e60
-  languageName: node
-  linkType: hard
-
-"unzipper@npm:^0.12.3":
-  version: 0.12.3
-  resolution: "unzipper@npm:0.12.3"
-  dependencies:
-    bluebird: "npm:~3.7.2"
-    duplexer2: "npm:~0.1.4"
-    fs-extra: "npm:^11.2.0"
-    graceful-fs: "npm:^4.2.2"
-    node-int64: "npm:^0.4.0"
-  checksum: 10/b210c421308e1913e01b54faad4ae79e758c674311892414a0697acacba9f82fa0051b677faa77e62fab422eef928c858f2d5cda9ddb47a2f3db95b0e9b36359
   languageName: node
   linkType: hard
 
@@ -13540,33 +13458,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-extension-tester@npm:^8.23.0":
-  version: 8.23.0
-  resolution: "vscode-extension-tester@npm:8.23.0"
+"vscode-extension-tester@npm:^8.24.0":
+  version: 8.24.0
+  resolution: "vscode-extension-tester@npm:8.24.0"
   dependencies:
-    "@redhat-developer/locators": "npm:^1.20.0"
-    "@redhat-developer/page-objects": "npm:^1.20.0"
-    "@types/selenium-webdriver": "npm:^4.35.5"
-    "@vscode/vsce": "npm:^3.7.1"
-    c8: "npm:^11.0.0"
+    "@redhat-developer/locators": "npm:^1.21.0"
+    "@redhat-developer/page-objects": "npm:^1.21.0"
+    "@types/selenium-webdriver": "npm:^4.35.6"
+    "@vscode/vsce": "npm:^3.9.2"
+    c8: "npm:^12.0.0"
     commander: "npm:^14.0.3"
     compare-versions: "npm:^6.1.1"
     find-up: "npm:8.0.0"
-    fs-extra: "npm:^11.3.4"
+    fs-extra: "npm:^11.4.0"
     glob: "npm:^13.0.6"
-    got: "npm:^14.6.6"
+    got: "npm:^15.1.0"
     hpagent: "npm:^1.2.0"
-    js-yaml: "npm:^4.1.1"
-    sanitize-filename: "npm:^1.6.3"
-    selenium-webdriver: "npm:^4.41.0"
+    js-yaml: "npm:^5.2.2"
+    sanitize-filename: "npm:^1.6.4"
+    selenium-webdriver: "npm:^4.46.0"
     targz: "npm:^1.0.1"
-    unzipper: "npm:^0.12.3"
+    unzipper: "npm:^0.12.5"
   peerDependencies:
     mocha: ">=5.2.0"
     typescript: ">=4.6.2"
   bin:
     extest: out/cli.js
-  checksum: 10/e5c2ddb99033ed13ccf8b50edf2a867f9b2c9e7e99a021b8fc8f69169d4aadfe1984589ae61e31e46a6a04a6ffc6828b67252762c09a9ea5688daaa5794b9a70
+  checksum: 10/f7592f655fe4ba22841c4cffdeb1d22f074d7a93152ae57407922f28a65580952fd355d09f896cf1b2b7c4a267386c668c3093aa04356a32afb9cded0324085d
   languageName: node
   linkType: hard
 
@@ -13574,7 +13492,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vscode-kaoto@workspace:."
   dependencies:
-    "@kaoto/camel-catalog": "npm:^0.5.5"
+    "@kaoto/camel-catalog": "npm:^0.7.0"
     "@kaoto/kaoto": "npm:2.11.0"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"
@@ -13641,7 +13559,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     unzipper: "npm:^0.12.5"
     valid-filename: "npm:4.0.0"
-    vscode-extension-tester: "npm:^8.23.0"
+    vscode-extension-tester: "npm:^8.24.0"
     wait-on: "npm:^9.0.10"
     web-worker: "npm:^1.5.0"
     webpack: "npm:5.108.3"
@@ -13984,9 +13902,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.19.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+"ws@npm:^8.21.0":
+  version: 8.21.2
+  resolution: "ws@npm:8.21.2"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -13995,7 +13913,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  checksum: 10/1fa65bfadc0dc73674638482b448e2a8cf1833d0acc2263fd27bf74b98f6f2917b2db8263b460a1ff37b6c2b8b892eba0e0eca33325a1ed7a8fe187f38550b40
   languageName: node
   linkType: hard
 
@@ -14128,16 +14046,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^22.0.0"
   checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^2.3.1":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Do not merge.** Diagnostic branch for #1468 (part of #1466).

This branch sits on the `vscode-extension-tester` 8.24.0 bump (tree-identical to `6d5e91f`) and trims CI so the blank-webview failure can be measured in isolation, away from the stacked fixes on `fix/extester-update` (#1465):

- Only the webview-dependent suites run: `BasicFlow`, `SwitchBetweenTabs`, `PropertyPanelLoading`, `ContextualMenuOpen`.
- `CODE_VERSION` is A/B'd in a matrix: `max` (VS Code ≥ 1.123.0, Chromium 148) vs `1.122.0` (Chromium 142) — 3 ubuntu samples + 1 windows sample per version.
- Single attempt per job (retry wrapper removed) so each job is one clean sample; minikube, macOS, unit tests and SBOM are dropped from the loop.

Expected outcome based on local measurements: all `1.122.0` jobs green; `max` jobs failing with `Kaoto topology was not loaded properly` because the webview bundle arrives with every 256 KiB chunk duplicated (see #1468 for the full analysis). This PR exists to measure the real CI failure rate on Chromium 148, since local reproduction is 100% deterministic but CI has shown intermittency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtvAiEuFSkrYXehmdRdbHo