### PR TITLE
fix(it-tests): resolve the Kaoto webview frame reliably

### DIFF
--- a/extester.config.json
+++ b/extester.config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/vscode-extension-tester/resources/extester.schema.json",
+  "setup": {
+    "extensionsDir": "./test-resources",
+    "packageOptions": {
+      "useYarn": true,
+      "dependencies": false
+    }
+  },
+  "run": {
+    "testFiles": ["out/**/*.test.js"],
+    "resources": ["./test Fixture with speci@l chars"],
+    "extensionsDir": "./test-resources",
+    "settings": "./it-tests/vscode-settings.json",
+    "customPageObjects": "./out/pageObjects/locators.js"
+  }
+}

--- a/it-tests/BasicFlow.test.ts
+++ b/it-tests/BasicFlow.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { By, EditorView, until, VSBrowser, WebDriver, WebView, logging, InputBox } from 'vscode-extension-tester';
+import { By, EditorView, until, VSBrowser, WebDriver, WebView, logging } from 'vscode-extension-tester';
 import { assert } from 'chai';
 import * as path from 'path';
 import {
@@ -23,6 +23,7 @@ import {
 	openResourcesAndWaitForActivation,
 	workaroundToRedrawContextualMenu,
 } from './Util';
+import { KaotoCanvas, KaotoEditor, kaotoLocators, DataMapperEditor } from './pageObjects';
 import { waitUntil } from 'async-wait-until';
 import * as fs from 'fs-extra';
 
@@ -132,7 +133,7 @@ describe('Kaoto basic development flow', function () {
 		// TODO: Add a target xsd
 		// TODO: Map an element
 
-		await (await driver.findElement(By.css('a[data-testid="design-tab"]'))).click();
+		await KaotoEditor.clickDesignTab(driver);
 
 		const files = fs.readdirSync(workspaceFolder);
 		const xslFiles = files.filter((file) => file.endsWith('.xsl'));
@@ -175,90 +176,27 @@ describe('Kaoto basic development flow', function () {
 });
 
 async function addXsdForSource(driver: WebDriver, kaotoWebview: WebView) {
-	await driver.wait(
-		until.elementLocated(By.css('button[data-testid="attach-schema-sourceBody-Body-button"]')),
-		5000,
-		'Cannot find the button to attach the schema',
-	);
-	await (await driver.findElement(By.css('button[data-testid="attach-schema-sourceBody-Body-button"]'))).click();
-
-	await waitForXsdAttachModal(driver);
-	const schemaButton = await driver.findElement(By.xpath("//button[@data-testid='attach-schema-modal-btn-file']"));
-	await schemaButton.click();
-
-	await kaotoWebview.switchBack();
-	const xsdInputbox = await InputBox.create(10000);
-	await xsdInputbox.setText('shiporder.xsd');
-	try {
-		const checkboxes = await xsdInputbox.getCheckboxes();
-		if (checkboxes.length > 0) {
-			await checkboxes[0].select();
-		}
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		if (!/NoSuchElement/i.test(message) && !/checkbox/i.test(message)) {
-			throw error;
-		}
-		// Fallback for Kaoto <2.10.0 (no checkboxes)
-	}
-	await xsdInputbox.confirm();
-	await kaotoWebview.switchToFrame();
-
-	await waitForXsdAttachModal(driver);
-	const attachButton = await driver.findElement(By.xpath("//button[@data-testid='attach-schema-modal-btn-attach']"));
-	await attachButton.click();
-
-	await driver.wait(
-		until.elementLocated(
-			// Kaoto 2.6- using -field-, Kaoto 2.7+ using -fx-
-			By.xpath('//div[starts-with(@data-testid, "node-source-field-shiporder-")] | //div[starts-with(@data-testid, "node-source-fx-shiporder-")]'),
-		),
-		5000,
-		'Root of the imported xsd is not displayed in the UI',
-	);
-}
-
-async function waitForXsdAttachModal(driver: WebDriver, timeout: number = 3_000): Promise<void> {
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-testid='attach-schema-modal']")), timeout, 'Cannot find XSD schema modal dialog');
+	await DataMapperEditor.attachXsdSchema(driver, kaotoWebview, 'sourceBody-Body', 'shiporder.xsd');
+	await DataMapperEditor.waitForSourceField(driver, 5_000);
 }
 
 async function openDataMapperEditor(driver: WebDriver) {
-	const kaotoNode = await driver.findElement(
-		By.css(
-			`g[data-testid^="custom-node__kaoto-datamapper"],g[data-testid="custom-node__route.from.steps.0.kaoto-datamapper"],g[data-testid="${DATA_TEST_ID_DATAMAPPERSTEP_2_5}"]`,
-		),
-	);
-	await kaotoNode.click();
-	await driver.wait(
-		until.elementLocated(By.css('button[title="Click to launch the Kaoto DataMapper editor"]')),
-		5000,
-		'Cannot find the button to open the datamapper',
-	);
-	await (await driver.findElement(By.css('button[title="Click to launch the Kaoto DataMapper editor"]'))).click();
+	const nodeSelector = `g[data-testid^="custom-node__kaoto-datamapper"],g[data-testid="custom-node__route.from.steps.0.kaoto-datamapper"],g[data-testid="${DATA_TEST_ID_DATAMAPPERSTEP_2_5}"]`;
+	await DataMapperEditor.openFromNode(driver, nodeSelector);
 }
 
 async function deleteDataMapperStep(driver: WebDriver, workspaceFolder: string, kaotoWebview: WebView) {
 	await checkStepWithTestIdOrNodeLabelPresent(driver, 'custom-node__kaoto-datamapper', 'kaoto-datamapper');
 
-	const kaotoNodeConfigured = await driver.findElement(
-		By.xpath(`//*[name()='g' and starts-with(@data-testid,'custom-node__kaoto-datamapper') or @data-nodelabel='kaoto-datamapper']`),
-	);
+	const kaotoNodeConfigured = await KaotoCanvas.findNodeByTestIdOrLabel(driver, 'custom-node__kaoto-datamapper', 'kaoto-datamapper');
 	await kaotoNodeConfigured.click();
 
 	await workaroundToRedrawContextualMenu(kaotoWebview);
 
-	await driver.wait(until.elementLocated(By.css("button[id='reset-view']")), 5000, 'Cannot find the reset view button');
-	await (await driver.findElement(By.css("button[id='reset-view']"))).click(); // reset view nodes position to see the delete button
+	await KaotoCanvas.resetView(driver, 5_000);
+	await KaotoCanvas.deleteStep(driver, 'kaoto-datamapper', 5_000);
+	await KaotoCanvas.confirmDeleteStepAndFile(driver, 5_000);
 
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-testid='step-toolbar']")), 5000, 'Cannot find the step toolbar');
-	await (await driver.findElement(By.css('button[data-testid="kaoto-datamapper|step-toolbar-button-delete"]'))).click();
-
-	await driver.wait(
-		until.elementLocated(By.xpath("//div[@data-ouia-component-id='ActionConfirmationModal']")),
-		5000,
-		'Cannot find the modal to delete the data mapper step',
-	);
-	await (await driver.findElement(By.css('button[data-testid="action-confirmation-modal-btn-del-step-and-file"]'))).click();
 	await driver.wait(
 		async () => {
 			const filesAfterDeletion = fs.readdirSync(workspaceFolder);
@@ -271,63 +209,50 @@ async function deleteDataMapperStep(driver: WebDriver, workspaceFolder: string, 
 }
 
 async function createNewRoute(driver: WebDriver) {
-	await (await driver.findElement(By.xpath("//button[@data-testid='dsl-list-btn']"))).click();
+	await KaotoCanvas.clickDslListButton(driver);
 }
 
 async function addAMQPStep(driver: WebDriver) {
+	const canvasNode = await KaotoCanvas.findTimerOrFromNode(driver);
+	await KaotoCanvas.openContextMenu(driver, canvasNode);
+	await KaotoCanvas.clickReplaceInContextMenu(driver);
+
 	await driver.wait(
-		until.elementLocated(By.css('g[data-testid^="custom-node__timer"],g[data-testid="custom-node__route.from"]')),
+		until.elementLocated(By.xpath(kaotoLocators.KaotoCatalog.tileHeaderByTestId('amqp'))),
 		5000,
-		'Cannot find the node for the timer',
+		'Cannot find the tile header for the AMQP step',
 	);
-
-	const canvasNode = await driver.findElement(By.css('g[data-testid^="custom-node__timer"],g[data-testid="custom-node__route.from"]'));
-	await driver.actions().contextClick(canvasNode).perform();
-
-	await driver.wait(until.elementLocated(By.className('pf-topology-context-menu__c-dropdown__menu')), 5000, 'Cannot find the context menu');
-	await (await driver.findElement(By.xpath("//\*[@data-testid='context-menu-item-replace']"))).click();
-
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-testid='tile-header-amqp']")), 5000, 'Cannot find the tile header for the AMQP step');
-	await (await driver.findElement(By.xpath("//div[@data-testid='tile-header-amqp']"))).click();
+	await (await driver.findElement(By.xpath(kaotoLocators.KaotoCatalog.tileHeaderByTestId('amqp')))).click();
 }
 
 async function addDatamapperStep(driver: WebDriver, kaotoWebview: WebView) {
-	await driver.wait(
-		until.elementLocated(By.css('g[data-testid^="custom-node__log"],g[data-testid="custom-node__route.from.steps.0.log"]')),
-		5000,
-		'Cannot find the node for the log',
-	);
-
-	const canvasNode = await driver.findElement(By.css('g[data-testid^="custom-node__log"],g[data-testid="custom-node__route.from.steps.0.log"]'));
-	await driver.actions().contextClick(canvasNode).perform();
+	const canvasNode = await KaotoCanvas.findLogNode(driver);
+	await KaotoCanvas.openContextMenu(driver, canvasNode);
 
 	await workaroundToRedrawContextualMenu(kaotoWebview);
 
-	await driver.wait(until.elementLocated(By.className('pf-topology-context-menu__c-dropdown__menu')), 5000, 'Cannot find the context menu');
-	await (await driver.findElement(By.xpath("//*[@data-testid='context-menu-item-replace']"))).click();
+	await KaotoCanvas.clickReplaceInContextMenu(driver);
 
-	await driver.wait(until.elementLocated(By.xpath("//input[@placeholder='Filter by name, description or tag']")), 5000, 'Cannot find the filter input');
-	const filterInput = await driver.findElement(By.xpath("//input[@placeholder='Filter by name, description or tag']"));
+	await driver.wait(until.elementLocated(By.xpath(kaotoLocators.KaotoCatalog.filterInput)), 5000, 'Cannot find the filter input');
+	const filterInput = await driver.findElement(By.xpath(kaotoLocators.KaotoCatalog.filterInput));
 	await filterInput.sendKeys('datamapper');
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-testid='tile-kaoto-datamapper']")), 5000, 'Cannot find the tile for the DataMapper step');
-
-	await (await driver.findElement(By.xpath("//div[@data-testid='tile-kaoto-datamapper']"))).click();
+	await driver.wait(
+		until.elementLocated(By.xpath(kaotoLocators.KaotoCatalog.tileHeaderByTestId('kaoto-datamapper'))),
+		5000,
+		'Cannot find the tile for the DataMapper step',
+	);
+	await (await driver.findElement(By.xpath(kaotoLocators.KaotoCatalog.tileHeaderByTestId('kaoto-datamapper')))).click();
 }
 
 /**
- *
  * @param driver
  * @param testId used for Kaoto 2.3
  * @param nodeLabel used for Kaoto 2.4
  */
 async function checkStepWithTestIdOrNodeLabelPresent(driver: WebDriver, testId: string, nodeLabel: string) {
-	await driver.wait(until.elementLocated(By.xpath(`//*[name()='g' and starts-with(@data-testid,'${testId}') or @data-nodelabel='${nodeLabel}']`)), 5_000);
+	await KaotoCanvas.findNodeByTestIdOrLabel(driver, testId, nodeLabel);
 }
 
 async function checkIntegrationNameInTopBarLoaded(driver: WebDriver, name: string) {
-	await driver.wait(
-		until.elementLocated(By.xpath(`//span[@data-testid='flows-list-route-id' and contains(., '${name}')]`)),
-		5_000,
-		`Unable to locate integration name '${name} in top bar!'`,
-	);
+	await KaotoEditor.waitForIntegrationName(driver, name);
 }

--- a/it-tests/MavenDependencyUpdate.test.ts
+++ b/it-tests/MavenDependencyUpdate.test.ts
@@ -27,7 +27,6 @@ import {
 import {
 	By,
 	EditorView,
-	until,
 	VSBrowser,
 	WebDriver,
 	Workbench,
@@ -38,6 +37,7 @@ import {
 	CheckboxSetting,
 	before,
 } from 'vscode-extension-tester';
+import { KaotoCanvas } from './pageObjects';
 import { assert, expect } from 'chai';
 import * as fs from 'fs';
 
@@ -255,26 +255,13 @@ describe('Maven dependency update pom.xml', function () {
 	 * Add the SQL component step to the topology.
 	 */
 	async function addSqlComponentStep() {
-		// hover over edge to show add step button
-		const setBodyToLogEdge = await driver.findElement(By.css('g[data-id^="my-camel-quarkus-route|route.from.steps.0.setBody >>> route.from.steps.1.log"]'));
-		await driver.actions().move({ origin: setBodyToLogEdge, duration: 2_000 }).perform();
-
-		// click Add Step button
-		const addStepButton = await setBodyToLogEdge.findElement(By.className('custom-edge__add-step add-step-icon'));
+		// hover over edge to show add step button and click Add Step button
+		const edgeSelector = 'g[data-id^="my-camel-quarkus-route|route.from.steps.0.setBody >>> route.from.steps.1.log"]';
+		const addStepButton = await KaotoCanvas.getAddStepButton(driver, edgeSelector);
 		await addStepButton.click();
 
-		// add text into catalog filter
-		await driver.wait(until.elementLocated(By.className('pf-v6-c-text-input-group__text-input')), 5_000);
-		const textInput = await driver.findElement(By.className('pf-v6-c-text-input-group__text-input'));
-		await textInput.click();
-		await textInput.clear();
-		await textInput.sendKeys('sql');
-
-		await driver.wait(until.elementLocated(By.css('div[data-testid="tile-sql"]')), 5_000);
-
-		// select SQL component from catalog
-		const sqlComponent = await driver.findElement(By.css('div[data-testid="tile-sql"]'));
-		await sqlComponent.click();
+		// filter catalog and select SQL component
+		await KaotoCanvas.filterCatalogAndSelectTile(driver, 'sql', 'sql');
 	}
 
 	/**
@@ -287,14 +274,13 @@ describe('Maven dependency update pom.xml', function () {
 		).kaotoWebview;
 
 		// right click on SQL component node
-		const sqlComponent = await driver.findElement(By.css('g[data-nodelabel="sql"]'));
-		await driver.actions().contextClick(sqlComponent).perform();
+		const sqlNode = await driver.findElement(By.css('g[data-nodelabel="sql"]'));
+		await KaotoCanvas.openContextMenu(driver, sqlNode);
 
 		await workaroundToRedrawContextualMenu(kaotoWebview);
 
 		// click Delete button
-		const deleteButton = await driver.findElement(By.css('li[data-testid="context-menu-item-delete"]'));
-		await deleteButton.click();
+		await KaotoCanvas.clickDeleteInContextMenu(driver);
 
 		// save editor
 		await kaotoWebview.switchBack();

--- a/it-tests/PropertyPanelLoading.test.ts
+++ b/it-tests/PropertyPanelLoading.test.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { By, EditorView, until, VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
+import { EditorView, VSBrowser, WebDriver, WebView } from 'vscode-extension-tester';
 import * as path from 'path';
-import { openAndSwitchToKaotoFrame } from './Util';
+import { clickWhenClickable, dismissHoverOverlay, openAndSwitchToKaotoFrame } from './Util';
+import { KaotoCanvas, KaotoEditor } from './pageObjects';
 
 describe('Property panel loading test', function () {
 	this.timeout(60_000);
@@ -31,44 +32,25 @@ describe('Property panel loading test', function () {
 	});
 
 	after(async function () {
-		await kaotoWebview.switchBack();
-
-		const editorView = new EditorView();
-		await editorView.closeAllEditors();
+		if (kaotoWebview) {
+			try {
+				await kaotoWebview.switchBack();
+			} catch {
+				// already on the VS Code frame — switchBack is a no-op in that case
+			}
+		}
+		await new EditorView().closeAllEditors();
 	});
 
 	it('Open "choice.camel.yaml" file and check property panel is loading and closing', async function () {
 		kaotoWebview = (await openAndSwitchToKaotoFrame(workspaceFolder, 'choice.camel.yaml', driver, true)).kaotoWebview;
-		const stepWhenXpath = By.xpath(
-			`//*[name()='g' and starts-with(@data-testid,'custom-node__when')]|//*[name()='foreignObject' and @data-nodelabel='when']/div/div`,
-		);
-		await driver.wait(until.elementLocated(stepWhenXpath), 5_000);
-		await (await driver.findElement(stepWhenXpath)).click();
-		await driver.wait(until.elementLocated(By.className('pf-v6-c-card')), 5_000);
 
-		const closeBtn = await driver.findElement(By.xpath("//button[@data-testid='close-side-bar']"));
-		await driver.wait(
-			async () => {
-				return (await closeBtn.isDisplayed()) && (await closeBtn.isEnabled());
-			},
-			5_000,
-			'Close button is not displayed!',
-		);
+		const logNode = await KaotoCanvas.findNodeByInnerTestId(driver, 'route.from.steps.0.choice.when.0.steps.0.log');
+		await dismissHoverOverlay(driver);
+		await clickWhenClickable(driver, logNode);
 
-		// It seems that the close button might not react if clicked too fast after being displayed
-		await driver.sleep(1_00);
-
-		await closeBtn.click();
-
-		await driver.sleep(1_000);
-
-		try {
-			await driver.wait(until.elementLocated(By.className('pf-v6-c-card')), 5_000);
-			throw new Error('Property panel was not closed!');
-		} catch (error) {
-			if (error instanceof Error && error.name !== 'TimeoutError') {
-				throw new Error(error.message);
-			}
-		}
+		await KaotoEditor.waitForPropertyPanel(driver);
+		await KaotoEditor.closePropertyPanel(driver);
+		await KaotoEditor.waitForPropertyPanelClosed(driver);
 	});
 });

--- a/it-tests/SwitchBetweenTabs.test.ts
+++ b/it-tests/SwitchBetweenTabs.test.ts
@@ -17,34 +17,12 @@ import { By, EditorView, until, VSBrowser, WebDriver, WebView } from 'vscode-ext
 import { openAndSwitchToKaotoFrame } from './Util';
 import { join } from 'path';
 import { expect } from 'chai';
+import { EditorTabs, kaotoLocators } from './pageObjects';
 
 describe('Switching between editor tabs', function () {
 	this.timeout(90_000);
 
 	const WORKSPACE_FOLDER = join(__dirname, '../test Fixture with speci@l chars');
-
-	const locators = {
-		EditorTabs: {
-			tabsList: 'pf-v6-c-tabs__list',
-			tabsItem: 'pf-v6-c-tabs__item',
-			activeTabAttribute: 'aria-selected',
-			tabLabelAttribute: 'aria-label',
-			tabText: 'pf-v6-c-tabs__item-text',
-			designTabLabel: 'Design canvas',
-			beansTabLabel: 'Beans editor',
-			dataMapperTabLabel: 'DataMapper',
-		},
-		DesignCanvas: {
-			canvas: 'topology',
-		},
-		BeansEditor: {
-			listView: 'metadata-editor-modal-list-view',
-			detailsView: 'metadata-editor-modal-details-view',
-		},
-		DataMapper: {
-			howTo: 'pf-v6-l-bullseye datamapper-howto',
-		},
-	};
 
 	let driver: WebDriver;
 	let kaotoWebview: WebView;
@@ -60,57 +38,29 @@ describe('Switching between editor tabs', function () {
 
 	it('Open "my.camel.yaml" file and check "Design" tab is active by default', async function () {
 		kaotoWebview = (await openAndSwitchToKaotoFrame(WORKSPACE_FOLDER, 'my.camel.yaml', driver, true)).kaotoWebview;
-		await driver.wait(until.elementLocated(By.className(locators.EditorTabs.tabsList)), 5_000, 'Editor tabs are not displayed properly!');
-		expect(await getActiveTabName()).to.equal('Design');
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.EditorTabs.tabsList)), 5_000, 'Editor tabs are not displayed properly!');
+		const tabs = new EditorTabs();
+		expect(await tabs.getActiveTabName()).to.equal('Design');
 	});
 
 	it('Switch to "Beans" tab and check it is active', async function () {
-		await switchToTab(locators.EditorTabs.beansTabLabel);
-		await waitForBeansEditorIsLoaded();
-		expect(await getActiveTabName()).to.equal('Beans');
+		const tabs = new EditorTabs();
+		await tabs.switchToTab('Beans editor');
+		await EditorTabs.waitForBeansTab(driver);
+		expect(await tabs.getActiveTabName()).to.equal('Beans');
 	});
 
 	it('Switch to "DataMapper" tab and check it is active', async function () {
-		await switchToTab(locators.EditorTabs.dataMapperTabLabel);
-		await waitForDataMapperIsLoaded();
-		expect(await getActiveTabName()).to.equal('DataMapper');
+		const tabs = new EditorTabs();
+		await tabs.switchToTab('DataMapper');
+		await EditorTabs.waitForDataMapperTab(driver);
+		expect(await tabs.getActiveTabName()).to.equal('DataMapper');
 	});
 
 	it('Switch back to "Design" tab and check it is active', async function () {
-		await switchToTab(locators.EditorTabs.designTabLabel);
-		await waitForDesignCanvasIsLoaded();
-		expect(await getActiveTabName()).to.equal('Design');
+		const tabs = new EditorTabs();
+		await tabs.switchToTab('Design canvas');
+		await EditorTabs.waitForDesignTab(driver);
+		expect(await tabs.getActiveTabName()).to.equal('Design');
 	});
-
-	async function getActiveTabName(): Promise<string> {
-		const tabName = await driver
-			.findElement(By.className(locators.EditorTabs.tabsList))
-			.findElement(By.xpath(`//button[@${locators.EditorTabs.activeTabAttribute}='true']`))
-			.findElement(By.className(locators.EditorTabs.tabText));
-		return await tabName.getText();
-	}
-
-	async function switchToTab(name: string): Promise<void> {
-		await driver
-			.findElement(By.className(locators.EditorTabs.tabsList))
-			.findElement(By.xpath(`//button[@${locators.EditorTabs.tabLabelAttribute}='${name}']`))
-			.click();
-	}
-
-	async function waitForDesignCanvasIsLoaded(): Promise<void> {
-		await driver.wait(
-			until.elementLocated(By.xpath(`//div[@data-test-id='${locators.DesignCanvas.canvas}']`)),
-			5_000,
-			'Design canvas of editor was not loaded properly!',
-		);
-	}
-
-	async function waitForBeansEditorIsLoaded(): Promise<void> {
-		await driver.wait(until.elementLocated(By.className(locators.BeansEditor.listView)), 5_000, 'Beans "list" view was not loaded properly!');
-		await driver.wait(until.elementLocated(By.className(locators.BeansEditor.detailsView)), 5_000, 'Beans "details" view was not loaded properly!');
-	}
-
-	async function waitForDataMapperIsLoaded() {
-		await driver.wait(until.elementLocated(By.className(locators.DataMapper.howTo)), 5_000, 'DataMapper "howTo" content was not loaded properly!');
-	}
 });

--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -42,6 +42,7 @@ import {
 	WebView,
 } from 'vscode-extension-tester';
 import { KaotoEditor } from './pageObjects/KaotoEditor';
+import { kaotoLocators } from './pageObjects/locators';
 
 export const CATALOG_VERSION_ID = 'kaoto.camelJbang.version';
 
@@ -121,20 +122,48 @@ export async function openAndSwitchToKaotoFrame(
 ): Promise<{ kaotoWebview: WebView; kaotoEditor: CustomEditor }> {
 	await VSBrowser.instance.openResources(path.join(workspaceFolder, fileNameToOpen), async () => {
 		await driver.sleep(interval);
+		// Only wait for the editor tab to exist. It is deliberately not required to be the
+		// *active* one here: a panel opened during extension activation (the "What's New"
+		// webview, which uses `ViewColumn.Active`) can take focus and never hand it back,
+		// which used to fail this wait outright. Making the Kaoto editor active is
+		// `switchToKaotoFrame`'s job, where it can be retried and verified.
 		await driver.wait(
-			async () => {
-				const editor = await new EditorView().getActiveTab();
-				return (await editor?.getTitle()) === fileNameToOpen;
-			},
+			async () => (await new EditorView().getOpenEditorTitles()).includes(fileNameToOpen),
 			timeout,
 			`Cannot open file '${fileNameToOpen}' in ${timeout}ms`,
 			interval,
 		);
 	});
-	return await switchToKaotoFrame(driver, checkNotDirty);
+	return await switchToKaotoFrame(driver, checkNotDirty, fileNameToOpen);
 }
 
-export async function switchToKaotoFrame(driver: WebDriver, checkNotDirty: boolean): Promise<{ kaotoWebview: WebView; kaotoEditor: CustomEditor }> {
+/**
+ * Switch the driver into the Kaoto editor webview.
+ *
+ * Two ExTester behaviours make a naive `switchToFrame()` unreliable, so the result is
+ * always verified before it is handed back:
+ *
+ * 1. `WebviewMixin.switchToFrame()` does `if (!view) return;` -- when no webview iframe
+ *    matches it resolves successfully without switching, leaving the driver in the
+ *    workbench DOM.
+ * 2. `WebView.getViewToSwitchTo()` picks the iframe with the largest rect overlap with
+ *    the editor. Two webviews stacked in one editor group (for instance the Kaoto editor
+ *    plus the "What's New" panel, which opens with `ViewColumn.Active`) have identical
+ *    rects, so geometry cannot tell them apart.
+ *
+ * Both failures otherwise surface much later as a `NoSuchElementError` naming a valid
+ * Kaoto selector. Checking for `#envelope-app` -- the Kaoto webview root, absent from the
+ * workbench DOM and from every other webview -- turns them into an immediate, honest error.
+ *
+ * @param driver The WebDriver instance.
+ * @param checkNotDirty Assert the editor is not dirty when opening it.
+ * @param expectedTitle Title of the editor tab the webview belongs to, when known.
+ */
+export async function switchToKaotoFrame(
+	driver: WebDriver,
+	checkNotDirty: boolean,
+	expectedTitle?: string,
+): Promise<{ kaotoWebview: WebView; kaotoEditor: CustomEditor }> {
 	let kaotoEditor = new CustomEditor();
 	if (checkNotDirty) {
 		assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
@@ -143,20 +172,64 @@ export async function switchToKaotoFrame(driver: WebDriver, checkNotDirty: boole
 	await driver.wait(
 		async () => {
 			try {
+				await ensureKaotoEditorIsActive(expectedTitle);
 				kaotoEditor = new CustomEditor();
 				kaotoWebview = kaotoEditor.getWebView();
 				await kaotoWebview.switchToFrame(10_000);
-				return true;
+				if (await isInsideKaotoWebview(driver)) {
+					return true;
+				}
+				// Landed in the workbench DOM or in a foreign webview -- get back out and retry.
+				await kaotoWebview.switchBack();
+				return false;
 			} catch (exception) {
 				console.log('failed to switch to frame ' + exception);
 				return false;
 			}
 		},
 		30000,
-		'Failed to switch to frame',
+		'Failed to switch to the Kaoto editor webview',
 		1000,
 	);
 	return { kaotoWebview, kaotoEditor };
+}
+
+/**
+ * Whether the driver is currently inside the Kaoto editor webview.
+ *
+ * Requires the driver to already be switched into a frame; returns false when it is
+ * still in the workbench document or inside some other extension's webview.
+ */
+async function isInsideKaotoWebview(driver: WebDriver): Promise<boolean> {
+	const envelope = await driver.findElements(By.css(kaotoLocators.KaotoEditor.envelopeApp));
+	return envelope.length > 0;
+}
+
+/**
+ * Make sure the Kaoto editor -- not some other panel that stole focus -- is the active tab
+ * before its webview is resolved, since `new CustomEditor()` binds to whatever is active.
+ *
+ * Only acts when the active tab is not already the expected one, so a suite that is behaving
+ * normally pays nothing and VS Code is not fought for focus once per second. Focusing is best
+ * effort: this runs inside a retry loop, and `#envelope-app` is what ultimately decides
+ * success, so a transient failure here is worth another attempt rather than an exception.
+ *
+ * Callers that do not know which tab to expect skip this entirely and rely on the
+ * `#envelope-app` verification alone.
+ */
+async function ensureKaotoEditorIsActive(expectedTitle?: string): Promise<void> {
+	if (expectedTitle === undefined) {
+		return;
+	}
+	try {
+		const activeTab = await new EditorView().getActiveTab();
+		if ((await activeTab?.getTitle()) === expectedTitle) {
+			return;
+		}
+		await new EditorView().openEditor(expectedTitle);
+	} catch (exception) {
+		console.log(`failed to focus editor '${expectedTitle}' ` + exception);
+	}
 }
 
 export async function checkEmptyCanvasLoaded(driver: WebDriver, timeout: number = 10_000) {

--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -21,6 +21,7 @@ import {
 	ActivityBar,
 	BottomBarPanel,
 	By,
+	createWaitHelper,
 	CustomEditor,
 	EditorView,
 	ExtensionsViewItem,
@@ -31,15 +32,16 @@ import {
 	StatusBar,
 	TerminalView,
 	TreeItem,
-	until,
 	ViewControl,
 	ViewItemAction,
 	ViewPanelAction,
 	ViewSection,
 	VSBrowser,
 	WebDriver,
+	WebElement,
 	WebView,
 } from 'vscode-extension-tester';
+import { KaotoEditor } from './pageObjects/KaotoEditor';
 
 export const CATALOG_VERSION_ID = 'kaoto.camelJbang.version';
 
@@ -143,7 +145,7 @@ export async function switchToKaotoFrame(driver: WebDriver, checkNotDirty: boole
 			try {
 				kaotoEditor = new CustomEditor();
 				kaotoWebview = kaotoEditor.getWebView();
-				await kaotoWebview.switchToFrame();
+				await kaotoWebview.switchToFrame(10_000);
 				return true;
 			} catch (exception) {
 				console.log('failed to switch to frame ' + exception);
@@ -158,12 +160,11 @@ export async function switchToKaotoFrame(driver: WebDriver, checkNotDirty: boole
 }
 
 export async function checkEmptyCanvasLoaded(driver: WebDriver, timeout: number = 10_000) {
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-testid='visualization-empty-state']")), timeout, 'Empty Kaoto Canvas was not loaded properly');
+	await KaotoEditor.waitForEmptyCanvas(driver, timeout);
 }
 
 export async function checkTopologyLoaded(driver: WebDriver, timeout: number = 10_000) {
-	await driver.wait(until.elementLocated(By.xpath("//div[@data-test-id='topology']")), timeout, 'Kaoto topology was not loaded properly');
-	await driver.sleep(1_000); // stabilize tests which are sometimes failing on macOS CI
+	await KaotoEditor.waitForTopology(driver, timeout);
 }
 
 // Enforce same default storage setup as ExTester - see https://github.com/redhat-developer/vscode-extension-tester/wiki/Test-Setup#useful-env-variables
@@ -239,6 +240,30 @@ export async function dismissBlockingModal(driver: WebDriver, preferredButton: s
 export async function closeEditor(title: string, save?: boolean) {
 	await new EditorView().closeEditor(title);
 	await dismissBlockingModal(VSBrowser.instance.driver, save ? 'Save' : "Don't Save");
+}
+
+export async function dismissHoverOverlay(driver: WebDriver) {
+	const waitHelper = createWaitHelper(driver);
+	const hoverContents = await driver.findElements(By.css('.hover-contents'));
+	for (const hoverContent of hoverContents) {
+		if (await hoverContent.isDisplayed()) {
+			await driver
+				.actions()
+				.move({ x: 5, y: 5, origin: driver.findElement(By.css('body')) })
+				.perform();
+			await waitHelper.forNotVisible(hoverContent, { timeout: 2_000, message: 'Hover overlay is still visible' });
+			break;
+		}
+	}
+}
+
+export async function clickWhenClickable(driver: WebDriver, element: WebElement, timeout = 5_000) {
+	const waitHelper = createWaitHelper(driver);
+	await waitHelper.forVisible(element, { timeout });
+	await waitHelper.forEnabled(element, { timeout });
+	await waitHelper.forStable(element, { timeout });
+	await waitHelper.forClickable(element, { timeout });
+	await element.click();
 }
 
 export async function openResourcesAndWaitForActivation(

--- a/it-tests/pageObjects/CatalogModal.ts
+++ b/it-tests/pageObjects/CatalogModal.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractElement, By, Key, until, WebDriver, WebElement } from 'vscode-extension-tester';
+import { kaotoLocators } from './locators';
+
+/**
+ * Page object for the Kaoto Catalog modal dialog.
+ *
+ * Opened by clicking the catalog button in the topology control bar.
+ * Provides helpers for:
+ * - Opening and closing the modal
+ * - Switching between List and Gallery layouts
+ * - Reading catalog item providers
+ * - Filtering by provider
+ *
+ * Must be used inside the webview frame.
+ */
+export class CatalogModal extends AbstractElement {
+	constructor() {
+		super(CatalogModal.locators.CatalogModal.constructor);
+	}
+
+	// ─── Open / close ──────────────────────────────────────────────────────────
+
+	/**
+	 * Click the topology-control-bar catalog button and wait for the modal.
+	 * Returns the catalog modal `WebElement`.
+	 */
+	static async open(driver: WebDriver, timeout = 10_000): Promise<WebElement> {
+		const catalogBtn = await driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.CatalogModal.catalogButton)),
+			timeout,
+			'Catalog button was not located',
+		);
+		await driver.wait(until.elementIsVisible(catalogBtn), timeout, 'Catalog button was not visible');
+		await driver.wait(until.elementIsEnabled(catalogBtn), timeout, 'Catalog button was not enabled');
+		await catalogBtn.click();
+
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.CatalogModal.window)), timeout);
+		return driver.findElement(By.xpath(kaotoLocators.CatalogModal.window));
+	}
+
+	/**
+	 * Close the catalog modal.
+	 */
+	static async close(catalogWindow: WebElement): Promise<void> {
+		await catalogWindow.findElement(By.xpath(kaotoLocators.CatalogModal.closeButton)).click();
+	}
+
+	// ─── Layout switching ─────────────────────────────────────────────────────
+
+	/**
+	 * Switch the catalog to List view and wait for the list to appear.
+	 * Returns the modal element.
+	 */
+	static async switchToListView(driver: WebDriver, catalogWindow: WebElement, timeout = 10_000): Promise<WebElement> {
+		await catalogWindow.findElement(By.xpath(kaotoLocators.CatalogModal.listButton)).click();
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.CatalogModal.list)), timeout);
+		return catalogWindow;
+	}
+
+	/**
+	 * Switch the catalog back to Gallery view and wait for the gallery to appear.
+	 */
+	static async switchToGalleryView(driver: WebDriver, catalogWindow: WebElement, timeout = 5_000): Promise<void> {
+		try {
+			await catalogWindow.findElement(By.xpath(kaotoLocators.CatalogModal.galleryButton)).click();
+			await driver.wait(until.elementLocated(By.className(kaotoLocators.CatalogModal.gallery)), timeout);
+		} catch {
+			// Workaround: hover text for the list button can overlap the gallery button
+			await driver.actions().sendKeys(Key.ENTER).perform();
+			await catalogWindow.findElement(By.xpath(kaotoLocators.CatalogModal.galleryButton)).click();
+			await driver.wait(until.elementLocated(By.className(kaotoLocators.CatalogModal.gallery)), timeout);
+		}
+	}
+
+	// ─── Provider filter ──────────────────────────────────────────────────────
+
+	/**
+	 * Open or close the provider filter dropdown.
+	 *
+	 * @param open  `true` to open and wait for the menu; `false` to close it.
+	 */
+	static async toggleProviderDropdown(driver: WebDriver, catalogWindow: WebElement, open: boolean, timeout = 5_000): Promise<void> {
+		const dropdown = await catalogWindow.findElement(By.xpath(kaotoLocators.CatalogModal.providerFilterDropdown));
+		await dropdown.click();
+		await driver.sleep(1_000); // allow DOM to reflect changes
+
+		if (open) {
+			await driver.wait(until.elementLocated(By.id(kaotoLocators.CatalogModal.providerSelectMenu)), timeout);
+		} else {
+			try {
+				await driver.wait(until.elementLocated(By.id(kaotoLocators.CatalogModal.providerSelectMenu)), timeout);
+			} catch (error) {
+				if (error instanceof Error && error.name !== 'TimeoutError') {
+					throw error;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Return the list of provider names shown in the provider filter menu.
+	 */
+	static async getProviderNames(driver: WebDriver, catalogWindow: WebElement): Promise<string[]> {
+		await CatalogModal.toggleProviderDropdown(driver, catalogWindow, true);
+
+		const menu = await catalogWindow.findElement(By.id(kaotoLocators.CatalogModal.providerSelectMenu));
+		const items = await menu.findElements(By.className(kaotoLocators.CatalogModal.providerMenuListItem));
+		const labels = await Promise.all(items.map((item) => item.getText()));
+
+		await CatalogModal.toggleProviderDropdown(driver, catalogWindow, false);
+		return labels;
+	}
+
+	/**
+	 * Toggle the checkbox for a given provider in the provider filter menu.
+	 *
+	 * @param provider  Provider label shown in the menu, e.g. "Community", "Red Hat"
+	 */
+	static async toggleProvider(driver: WebDriver, catalogWindow: WebElement, provider: string): Promise<void> {
+		await CatalogModal.toggleProviderDropdown(driver, catalogWindow, true);
+
+		const menu = await catalogWindow.findElement(By.id(kaotoLocators.CatalogModal.providerSelectMenu));
+		const item = await menu.findElement(By.xpath(kaotoLocators.CatalogModal.providerItem(provider)));
+		await item.click();
+
+		await CatalogModal.toggleProviderDropdown(driver, catalogWindow, false);
+	}
+
+	// ─── List item inspection ─────────────────────────────────────────────────
+
+	/**
+	 * Return the provider label string of the first visible catalog item in
+	 * List view.
+	 */
+	static async getFirstItemProvider(catalogWindow: WebElement): Promise<string> {
+		const listItem = await catalogWindow
+			.findElement(By.className(kaotoLocators.CatalogModal.list))
+			.findElement(By.className(kaotoLocators.CatalogModal.listItemRow));
+		return listItem.findElement(By.className(kaotoLocators.CatalogModal.listItemProvider)).getText();
+	}
+}

--- a/it-tests/pageObjects/DataMapperEditor.ts
+++ b/it-tests/pageObjects/DataMapperEditor.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractElement, By, until, WebDriver, WebView } from 'vscode-extension-tester';
+import { InputBox } from 'vscode-extension-tester';
+import { kaotoLocators } from './locators';
+
+/**
+ * Page object for the Kaoto DataMapper editor.
+ *
+ * Provides helpers for:
+ * - Opening the DataMapper from a canvas node
+ * - Attaching an XSD schema for the source body
+ * - Waiting for the DataMapper "how-to" content (empty state)
+ *
+ * Must be used inside the webview frame (except where noted).
+ */
+export class DataMapperEditor extends AbstractElement {
+	constructor() {
+		super(DataMapperEditor.locators.DataMapperEditor.constructor);
+	}
+
+	// ─── Open DataMapper ───────────────────────────────────────────────────────
+
+	/**
+	 * Click a DataMapper canvas node and then click the
+	 * "Click to launch the Kaoto DataMapper editor" button.
+	 *
+	 * @param nodeSelector  CSS selector that uniquely identifies the DataMapper node
+	 */
+	static async openFromNode(driver: WebDriver, nodeSelector: string, timeout = 5_000): Promise<void> {
+		const node = await driver.findElement(By.css(nodeSelector));
+		await node.click();
+		await driver.wait(
+			until.elementLocated(By.css(kaotoLocators.DataMapperEditor.openEditorButton)),
+			timeout,
+			'Cannot find the button to open the DataMapper',
+		);
+		await (await driver.findElement(By.css(kaotoLocators.DataMapperEditor.openEditorButton))).click();
+	}
+
+	// ─── Schema attachment ────────────────────────────────────────────────────
+
+	/**
+	 * Click the "Attach schema" button for a given target (e.g.
+	 * `"sourceBody-Body"`) and go through the file-picker flow to select
+	 * an XSD file by name.
+	 *
+	 * The method temporarily leaves the webview frame to interact with the
+	 * VS Code InputBox.
+	 *
+	 * @param driver
+	 * @param kaotoWebview  The active WebView — needed to switch frames
+	 * @param target        The target suffix used in the button's data-testid
+	 * @param xsdFileName   File name to type into the InputBox filter
+	 */
+	static async attachXsdSchema(driver: WebDriver, kaotoWebview: WebView, target: string, xsdFileName: string): Promise<void> {
+		// Click the attach button inside the webview
+		await driver.wait(
+			until.elementLocated(By.css(kaotoLocators.DataMapperEditor.attachSchemaButton(target))),
+			5_000,
+			'Cannot find the button to attach the schema',
+		);
+		await (await driver.findElement(By.css(kaotoLocators.DataMapperEditor.attachSchemaButton(target)))).click();
+
+		// Wait for the attach-schema modal
+		await DataMapperEditor.waitForAttachSchemaModal(driver);
+
+		// Click the "File" button to open the VS Code file picker
+		const schemaButton = await driver.findElement(By.xpath(kaotoLocators.DataMapperEditor.attachSchemaFileButton));
+		await schemaButton.click();
+
+		// Leave webview to interact with VS Code InputBox
+		await kaotoWebview.switchBack();
+		const xsdInputBox = await InputBox.create(10_000);
+		await xsdInputBox.setText(xsdFileName);
+
+		try {
+			const checkboxes = await xsdInputBox.getCheckboxes();
+			if (checkboxes.length > 0) {
+				await checkboxes[0].select();
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (!/NoSuchElement/i.test(message) && !/checkbox/i.test(message)) {
+				throw error;
+			}
+			// Fallback for Kaoto <2.10.0 (no checkboxes in InputBox)
+		}
+		await xsdInputBox.confirm();
+
+		// Switch back into the webview
+		await kaotoWebview.switchToFrame();
+
+		// Confirm attachment in the modal
+		await DataMapperEditor.waitForAttachSchemaModal(driver);
+		const attachButton = await driver.findElement(By.xpath(kaotoLocators.DataMapperEditor.attachSchemaAttachButton));
+		await attachButton.click();
+	}
+
+	/**
+	 * Wait for the attach-schema modal dialog to appear.
+	 */
+	static async waitForAttachSchemaModal(driver: WebDriver, timeout = 3_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.DataMapperEditor.attachSchemaModal)), timeout, 'Cannot find XSD schema modal dialog');
+	}
+
+	/**
+	 * Wait for the XSD source field to appear after a successful schema attach.
+	 */
+	static async waitForSourceField(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.DataMapperEditor.sourceFieldByTestId)),
+			timeout,
+			'Root of the imported XSD is not displayed in the UI',
+		);
+	}
+
+	/**
+	 * Wait for the DataMapper "how-to" empty-state content to be visible.
+	 */
+	static async waitForHowToContent(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(
+			until.elementLocated(By.className(kaotoLocators.DataMapperEditor.howTo)),
+			timeout,
+			'DataMapper "howTo" content was not loaded properly!',
+		);
+	}
+}

--- a/it-tests/pageObjects/EditorTabs.ts
+++ b/it-tests/pageObjects/EditorTabs.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractElement, By, until, WebDriver } from 'vscode-extension-tester';
+import { kaotoLocators } from './locators';
+
+/**
+ * Page object for the Kaoto editor tab bar.
+ *
+ * Represents the row of tabs at the top of the Kaoto editor webview:
+ * "Design", "Beans", "DataMapper".
+ *
+ * Must be used inside the webview frame.
+ */
+export class EditorTabs extends AbstractElement {
+	constructor() {
+		super(EditorTabs.locators.EditorTabs.constructor);
+	}
+
+	// ─── Active tab ────────────────────────────────────────────────────────────
+
+	/**
+	 * Return the text label of the currently active tab (e.g. "Design").
+	 */
+	async getActiveTabName(): Promise<string> {
+		const tabsList = await this.getDriver().findElement(By.className(kaotoLocators.EditorTabs.tabsList));
+		const activeBtn = await tabsList.findElement(By.xpath(kaotoLocators.EditorTabs.activeTabXpath));
+		const textEl = await activeBtn.findElement(By.className(kaotoLocators.EditorTabs.tabsItemText));
+		return textEl.getText();
+	}
+
+	// ─── Navigation ────────────────────────────────────────────────────────────
+
+	/**
+	 * Click the tab identified by its `aria-label` attribute.
+	 *
+	 * @param label  Tab aria-label, e.g. "Design canvas", "Beans editor", "DataMapper"
+	 */
+	async switchToTab(label: string): Promise<void> {
+		const tabsList = await this.getDriver().findElement(By.className(kaotoLocators.EditorTabs.tabsList));
+		await tabsList.findElement(By.xpath(kaotoLocators.EditorTabs.tabByLabel(label))).click();
+	}
+
+	// ─── Assertions ────────────────────────────────────────────────────────────
+
+	/**
+	 * Wait until the topology (Design canvas) is visible — indicates the Design
+	 * tab has fully loaded.
+	 */
+	static async waitForDesignTab(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.KaotoEditor.topology)), timeout, 'Design canvas was not loaded properly!');
+	}
+
+	/**
+	 * Wait until both Beans editor panels are visible.
+	 */
+	static async waitForBeansTab(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.BeansEditor.listView)), timeout, 'Beans "list" view was not loaded properly!');
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.BeansEditor.detailsView)), timeout, 'Beans "details" view was not loaded properly!');
+	}
+
+	/**
+	 * Wait until the DataMapper "how-to" content is visible.
+	 */
+	static async waitForDataMapperTab(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(
+			until.elementLocated(By.className(kaotoLocators.DataMapperEditor.howTo)),
+			timeout,
+			'DataMapper "howTo" content was not loaded properly!',
+		);
+	}
+}

--- a/it-tests/pageObjects/KaotoCanvas.ts
+++ b/it-tests/pageObjects/KaotoCanvas.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractElement, By, until, WebDriver, WebElement } from 'vscode-extension-tester';
+import { kaotoLocators } from './locators';
+
+/**
+ * Page object for Kaoto canvas node interactions.
+ *
+ * Provides helpers for finding nodes by test-id / node-label, triggering
+ * context menus, selecting/deleting steps, and interacting with edges.
+ *
+ * Must be used inside the webview frame.
+ */
+export class KaotoCanvas extends AbstractElement {
+	constructor() {
+		super(By.xpath(`//div[@data-test-id='topology']`));
+	}
+
+	// ─── DSL list ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Click the "DSL list" button to create a new route from the empty canvas.
+	 */
+	static async clickDslListButton(driver: WebDriver): Promise<void> {
+		await (await driver.findElement(By.xpath(kaotoLocators.KaotoCatalog.dslListButton))).click();
+	}
+
+	// ─── Node finders ──────────────────────────────────────────────────────────
+
+	/**
+	 * Find a canvas node in Kaoto 2.4+ by the exact data-testid on its inner <div>.
+	 * In the current DOM the clickable element is a <foreignObject data-nodelabel="…">
+	 * whose child <div> carries the full step path as data-testid
+	 * (e.g. "route.from.steps.0.choice.when.0.steps.0.log").
+	 */
+	static async findNodeByInnerTestId(driver: WebDriver, innerTestId: string, timeout = 5_000): Promise<WebElement> {
+		const xpath = kaotoLocators.KaotoNode.byInnerTestId(innerTestId);
+		await driver.wait(until.elementLocated(By.xpath(xpath)), timeout, `Node with inner test-id '${innerTestId}' was not found in topology`);
+		return driver.findElement(By.xpath(xpath));
+	}
+
+	/**
+	 * Find a canvas node using a data-testid prefix OR data-nodelabel fallback.
+	 * This covers the API change between Kaoto 2.3 (testId) and 2.4+ (nodeLabel).
+	 */
+	static async findNodeByTestIdOrLabel(driver: WebDriver, testIdPrefix: string, nodeLabel: string, timeout = 5_000): Promise<WebElement> {
+		await driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.KaotoNode.byTestIdOrLabel(testIdPrefix, nodeLabel))),
+			timeout,
+			`Node '${nodeLabel}' was not found in topology`,
+		);
+		return driver.findElement(By.xpath(kaotoLocators.KaotoNode.byTestIdOrLabel(testIdPrefix, nodeLabel)));
+	}
+
+	/**
+	 * Find a canvas node by CSS — data-testid prefix OR data-nodelabel.
+	 */
+	static async findNodeByCss(driver: WebDriver, testIdPrefix: string, nodeLabel: string, timeout = 5_000): Promise<WebElement> {
+		const selector = kaotoLocators.KaotoNode.byTestIdPrefixOrNodeLabel(testIdPrefix, nodeLabel);
+		await driver.wait(until.elementLocated(By.css(selector)), timeout, `Node '${nodeLabel}' was not found in topology`);
+		return driver.findElement(By.css(selector));
+	}
+
+	/**
+	 * Wait until a node with the given data-nodelabel is present on the canvas.
+	 */
+	static async waitForNodeByLabel(driver: WebDriver, nodeLabel: string, timeout = 10_000): Promise<void> {
+		await driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.KaotoNode.byTestIdOrLabel(`custom-node__${nodeLabel}`, nodeLabel))),
+			timeout,
+			`'${nodeLabel}' was not found in current topology.`,
+		);
+	}
+
+	/**
+	 * Find the timer/from node (covers Kaoto 2.3 `custom-node__timer` and 2.4+ `custom-node__route.from`).
+	 */
+	static async findTimerOrFromNode(driver: WebDriver, timeout = 5_000): Promise<WebElement> {
+		await driver.wait(until.elementLocated(By.css(kaotoLocators.KaotoNode.timerOrFromNode)), timeout, 'Cannot find the timer/from node');
+		return driver.findElement(By.css(kaotoLocators.KaotoNode.timerOrFromNode));
+	}
+
+	/**
+	 * Find the log node (covers Kaoto 2.3 `custom-node__log` and 2.4+ step-path variant).
+	 */
+	static async findLogNode(driver: WebDriver, timeout = 5_000): Promise<WebElement> {
+		await driver.wait(until.elementLocated(By.css(kaotoLocators.KaotoNode.logNode)), timeout, 'Cannot find the log node');
+		return driver.findElement(By.css(kaotoLocators.KaotoNode.logNode));
+	}
+
+	// ─── Node label text (for settings tests) ─────────────────────────────────
+
+	/**
+	 * Get the label text element of a node by its data-testid.
+	 * Used to verify Node Label setting is applied.
+	 */
+	static async findNodeLabelText(driver: WebDriver, nodeTestId: string, timeout = 10_000): Promise<WebElement> {
+		return driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.KaotoNode.labelText(nodeTestId))),
+			timeout,
+			`Label text for node '${nodeTestId}' was not found`,
+		);
+	}
+
+	// ─── Context menu ──────────────────────────────────────────────────────────
+
+	/**
+	 * Right-click a canvas node and wait for the context menu to appear.
+	 */
+	static async openContextMenu(driver: WebDriver, node: WebElement, timeout = 5_000): Promise<WebElement> {
+		await driver.actions().contextClick(node).perform();
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.KaotoContextMenu.menu)), timeout, 'Cannot find the Kaoto context menu');
+		return driver.findElement(By.className(kaotoLocators.KaotoContextMenu.menu));
+	}
+
+	/**
+	 * Click "Replace" in the node context menu.
+	 */
+	static async clickReplaceInContextMenu(driver: WebDriver): Promise<void> {
+		await (await driver.findElement(By.xpath(kaotoLocators.KaotoContextMenu.replaceItem))).click();
+	}
+
+	/**
+	 * Click "Delete" in the node context menu.
+	 */
+	static async clickDeleteInContextMenu(driver: WebDriver): Promise<void> {
+		await (await driver.findElement(By.css(kaotoLocators.KaotoContextMenu.deleteItem))).click();
+	}
+
+	// ─── Step toolbar ──────────────────────────────────────────────────────────
+
+	/**
+	 * Wait for the step toolbar to appear and click the reset-view button to
+	 * bring all nodes into view before interacting with toolbar actions.
+	 */
+	static async resetView(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.css(kaotoLocators.StepToolbar.resetViewButton)), timeout, 'Cannot find the reset view button');
+		await (await driver.findElement(By.css(kaotoLocators.StepToolbar.resetViewButton))).click();
+	}
+
+	/**
+	 * Wait for the step toolbar and click the delete button for a given step.
+	 *
+	 * @param stepId  The step identifier prefix used in the button's data-testid
+	 *                (e.g. "kaoto-datamapper")
+	 */
+	static async deleteStep(driver: WebDriver, stepId: string, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.StepToolbar.toolbar)), timeout, 'Cannot find the step toolbar');
+		await (await driver.findElement(By.css(kaotoLocators.StepToolbar.deleteButton(stepId)))).click();
+	}
+
+	/**
+	 * Wait for the action-confirmation modal, then click the
+	 * "Delete step and file" button.
+	 */
+	static async confirmDeleteStepAndFile(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.StepToolbar.actionConfirmModal)), timeout, 'Cannot find the modal to confirm deletion');
+		await (await driver.findElement(By.css(kaotoLocators.StepToolbar.confirmDeleteStepAndFile))).click();
+	}
+
+	// ─── Edge / add-step ──────────────────────────────────────────────────────
+
+	/**
+	 * Hover over an edge and return the "Add Step" button element on that edge.
+	 *
+	 * @param edgeSelector  CSS selector for the edge `<g>` element
+	 */
+	static async getAddStepButton(driver: WebDriver, edgeSelector: string, _timeout = 5_000): Promise<WebElement> {
+		const edge = await driver.findElement(By.css(edgeSelector));
+		await driver.actions().move({ origin: edge, duration: 2_000 }).perform();
+		return edge.findElement(By.className(kaotoLocators.KaotoEdge.addStepIcon));
+	}
+
+	// ─── Catalog filter ────────────────────────────────────────────────────────
+
+	/**
+	 * Type a filter term into the catalog filter input and wait for a matching
+	 * tile to appear.
+	 *
+	 * @param driver
+	 * @param term    Text to type into the filter (e.g. "sql", "amqp")
+	 * @param tileTestId  The `data-testid` value of the expected tile (without
+	 *                    the "tile-" prefix), e.g. "sql"
+	 */
+	static async filterCatalogAndSelectTile(driver: WebDriver, term: string, tileTestId: string, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.KaotoCatalog.filterTextInput)), timeout);
+		const textInput = await driver.findElement(By.className(kaotoLocators.KaotoCatalog.filterTextInput));
+		await textInput.click();
+		await textInput.clear();
+		await textInput.sendKeys(term);
+
+		await driver.wait(until.elementLocated(By.css(kaotoLocators.KaotoCatalog.tileByTestId(tileTestId))), timeout, `Cannot find tile for '${tileTestId}'`);
+		await (await driver.findElement(By.css(kaotoLocators.KaotoCatalog.tileByTestId(tileTestId)))).click();
+	}
+}

--- a/it-tests/pageObjects/KaotoEditor.ts
+++ b/it-tests/pageObjects/KaotoEditor.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractElement, By, until, WebDriver } from 'vscode-extension-tester';
+import { kaotoLocators } from './locators';
+
+/**
+ * Page object for the Kaoto webview editor.
+ *
+ * Provides high-level helpers for checking editor state (empty canvas,
+ * topology loaded, property panel) and interacting with the side bar.
+ *
+ * All DOM interactions happen inside the webview frame — callers must have
+ * already switched into the frame before constructing/using this object.
+ */
+export class KaotoEditor extends AbstractElement {
+	constructor() {
+		super(KaotoEditor.locators.KaotoEditor.constructor);
+	}
+
+	// ─── State checks ──────────────────────────────────────────────────────────
+
+	/**
+	 * Wait until the "empty canvas" placeholder is visible (no routes loaded).
+	 */
+	static async waitForEmptyCanvas(driver: WebDriver, timeout = 10_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.KaotoEditor.emptyCanvas)), timeout, 'Empty Kaoto Canvas was not loaded properly');
+	}
+
+	/**
+	 * Wait until the topology (route graph) is visible.
+	 */
+	static async waitForTopology(driver: WebDriver, timeout = 10_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.xpath(kaotoLocators.KaotoEditor.topology)), timeout, 'Kaoto topology was not loaded properly');
+		await driver.sleep(1_000); // stabilize — topology re-renders briefly on macOS CI
+	}
+
+	// ─── Property panel ────────────────────────────────────────────────────────
+
+	/**
+	 * Wait for a node's property panel card to appear.
+	 */
+	static async waitForPropertyPanel(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.KaotoEditor.propertyPanelCard)), timeout, 'Property panel was not opened');
+	}
+
+	/**
+	 * Click the "close side bar" button to dismiss the property panel.
+	 * Returns once the property panel card has disappeared.
+	 */
+	static async closePropertyPanel(driver: WebDriver, timeout = 5_000): Promise<void> {
+		const closeBtn = await driver.findElement(By.xpath(kaotoLocators.KaotoEditor.closeSideBar));
+		await driver.wait(async () => (await closeBtn.isDisplayed()) && (await closeBtn.isEnabled()), timeout, 'Close button is not displayed!');
+		// Small buffer — the button may not react if clicked immediately after appearing
+		await driver.sleep(100);
+		await closeBtn.click();
+	}
+
+	/**
+	 * Assert the property panel card is **not** present.
+	 * Throws if the card is still visible after `timeout` ms.
+	 */
+	static async waitForPropertyPanelClosed(driver: WebDriver, timeout = 5_000): Promise<void> {
+		await driver.sleep(1_000);
+		try {
+			await driver.wait(until.elementLocated(By.className(kaotoLocators.KaotoEditor.propertyPanelCard)), timeout);
+			throw new Error('Property panel was not closed!');
+		} catch (error) {
+			if (error instanceof Error && error.name !== 'TimeoutError') {
+				throw error;
+			}
+		}
+	}
+
+	// ─── Navigation ────────────────────────────────────────────────────────────
+
+	/**
+	 * Click the "Design" tab link inside the DataMapper editor to return to the
+	 * design canvas.
+	 */
+	static async clickDesignTab(driver: WebDriver): Promise<void> {
+		await (await driver.findElement(By.css(kaotoLocators.KaotoDesignTab.link))).click();
+	}
+
+	// ─── Integration name ──────────────────────────────────────────────────────
+
+	/**
+	 * Wait until the integration name appears in the top bar.
+	 */
+	static async waitForIntegrationName(driver: WebDriver, name: string, timeout = 5_000): Promise<void> {
+		await driver.wait(
+			until.elementLocated(By.xpath(kaotoLocators.KaotoEditor.flowsListRouteId(name))),
+			timeout,
+			`Unable to locate integration name '${name}' in top bar!`,
+		);
+	}
+}

--- a/it-tests/pageObjects/index.ts
+++ b/it-tests/pageObjects/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Barrel export for all Kaoto custom page objects.
+ *
+ * Import from here in test files:
+ *   import { KaotoEditor, KaotoCanvas, EditorTabs, CatalogModal, DataMapperEditor } from '../pageObjects';
+ */
+export { KaotoEditor } from './KaotoEditor';
+export { EditorTabs } from './EditorTabs';
+export { KaotoCanvas } from './KaotoCanvas';
+export { CatalogModal } from './CatalogModal';
+export { DataMapperEditor } from './DataMapperEditor';
+export { kaotoLocators, locators } from './locators';

--- a/it-tests/pageObjects/locators.ts
+++ b/it-tests/pageObjects/locators.ts
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Kaoto IT-test custom locator contribution.
+ *
+ * Compiled to `out/pageObjects/locators.js` and registered with ExTester via
+ * `extester.config.json` → `run.customPageObjects`.
+ *
+ * The exported `locators` object follows the `LocatorDiff` shape expected by
+ * `vscode-extension-tester`:  any unknown top-level key is accepted because
+ * `AbstractElement.locators` uses an open intersection type.
+ *
+ * Usage in page-object classes:
+ *   import { AbstractElement } from 'vscode-extension-tester';
+ *   // locators are available at runtime via AbstractElement.locators
+ *
+ * Usage in tests directly:
+ *   import { kaotoLocators } from '../pageObjects/locators';
+ *   By.xpath(kaotoLocators.KaotoEditor.emptyCanvas);
+ */
+
+import { By } from 'vscode-extension-tester';
+import type { LocatorDiff } from 'vscode-extension-tester';
+
+// ─── Typed locator map ────────────────────────────────────────────────────────
+
+/**
+ * All Kaoto-specific CSS/XPath selectors in one place.
+ *
+ * These are plain string values or `By` locators.  The `LocatorDiff` shape
+ * requires the leaf values to be `By` objects; this object is also exported
+ * as `kaotoLocators` (typed with plain strings) for direct use in tests that
+ * prefer string-form XPath.
+ */
+export const kaotoLocators = {
+	/** Main Kaoto webview canvas & editor state */
+	KaotoEditor: {
+		emptyCanvas: `//div[@data-testid='visualization-empty-state']`,
+		topology: `//div[@data-test-id='topology']`,
+		designTabLink: `a[data-testid="design-tab"]`,
+		closeSideBar: `//button[@data-testid='close-side-bar']`,
+		propertyPanelCard: `pf-v6-c-card`,
+		flowsListRouteId: (name: string) => `//span[@data-testid='flows-list-route-id' and contains(., '${name}')]`,
+	},
+
+	/** Editor tab bar (Design / Beans / DataMapper) */
+	EditorTabs: {
+		tabsList: `pf-v6-c-tabs__list`,
+		tabsItemText: `pf-v6-c-tabs__item-text`,
+		activeTabXpath: `//button[@aria-selected='true']`,
+		tabByLabel: (label: string) => `//button[@aria-label='${label}']`,
+	},
+
+	/** Canvas topology nodes */
+	KaotoNode: {
+		/**
+		 * Generic node by data-testid prefix OR data-nodelabel.
+		 * Covers Kaoto 2.3 (<g data-testid="custom-node__*">) and
+		 * Kaoto 2.4+ (<foreignObject data-nodelabel="*">).
+		 */
+		byTestIdOrLabel: (testIdPrefix: string, nodeLabel: string) =>
+			`//*[(name()='g' or name()='foreignObject') and (starts-with(@data-testid,'${testIdPrefix}') or @data-nodelabel='${nodeLabel}')]`,
+		/**
+		 * Kaoto 2.4+ nodes carry the step test-id on an inner <div>, while the
+		 * clickable element is the parent <foreignObject data-nodelabel="…">.
+		 * This locator finds that <foreignObject> by the exact test-id of its child div.
+		 */
+		byInnerTestId: (testId: string) => `//*[name()='foreignObject' and ./div[@data-testid='${testId}']]`,
+		/** Node by exact data-testid (CSS) — g or foreignObject */
+		byTestId: (testId: string) => `g[data-testid="${testId}"],foreignObject[data-testid="${testId}"]`,
+		/** Node where data-testid starts-with prefix (CSS) — g or foreignObject */
+		byTestIdPrefix: (prefix: string) => `g[data-testid^="${prefix}"],foreignObject[data-testid^="${prefix}"]`,
+		/** Node by data-nodelabel (CSS) — g or foreignObject */
+		byNodeLabel: (label: string) => `g[data-nodelabel="${label}"],foreignObject[data-nodelabel="${label}"]`,
+		/** Node label text span (for NodeLabel settings test) */
+		labelText: (testId: string) =>
+			`//*[(name()='g' or name()='foreignObject') and @data-testid='${testId}']//*[contains(@class,'custom-node__label__text')]`,
+		/** Compound selector: testId prefix OR data-nodelabel — CSS form */
+		byTestIdPrefixOrNodeLabel: (prefix: string, label: string) =>
+			`g[data-testid^="${prefix}"],g[data-nodelabel="${label}"],foreignObject[data-testid^="${prefix}"],foreignObject[data-nodelabel="${label}"]`,
+		/**
+		 * Timer / from node — covers Kaoto 2.3 (<g data-testid="custom-node__timer">)
+		 * and Kaoto 2.4+ (<foreignObject data-nodelabel="route.from">).
+		 */
+		timerOrFromNode: `g[data-testid^="custom-node__timer"],g[data-testid="custom-node__route.from"],foreignObject[data-nodelabel="route.from"]`,
+		/**
+		 * Log node — covers Kaoto 2.3 (<g data-testid="custom-node__log">) and
+		 * Kaoto 2.4+ (<foreignObject data-nodelabel="log">).
+		 */
+		logNode: `g[data-testid^="custom-node__log"],g[data-testid="custom-node__route.from.steps.0.log"],foreignObject[data-nodelabel="log"]`,
+	},
+
+	/** Design-tab link inside the DataMapper view */
+	KaotoDesignTab: {
+		link: `a[data-testid="design-tab"]`,
+	},
+
+	/** Kaoto topology context menu */
+	KaotoContextMenu: {
+		menu: `pf-topology-context-menu__c-dropdown__menu`,
+		replaceItem: `//\*[@data-testid='context-menu-item-replace']`,
+		deleteItem: `li[data-testid="context-menu-item-delete"]`,
+	},
+
+	/** Step toolbar (shown when a node is selected) */
+	StepToolbar: {
+		toolbar: `//div[@data-testid='step-toolbar']`,
+		deleteButton: (stepId: string) => `button[data-testid="${stepId}|step-toolbar-button-delete"]`,
+		resetViewButton: `button[id='reset-view']`,
+		actionConfirmModal: `//div[@data-ouia-component-id='ActionConfirmationModal']`,
+		confirmDeleteStepAndFile: `button[data-testid="action-confirmation-modal-btn-del-step-and-file"]`,
+	},
+
+	/** Edge / add-step interactions */
+	KaotoEdge: {
+		addStepIcon: `custom-edge__add-step add-step-icon`,
+	},
+
+	/** Component/step catalog inside the editor */
+	KaotoCatalog: {
+		filterInput: `//input[@placeholder='Filter by name, description or tag']`,
+		filterTextInput: `pf-v6-c-text-input-group__text-input`,
+		tileByTestId: (id: string) => `div[data-testid="tile-${id}"]`,
+		tileHeaderByTestId: (id: string) => `//div[@data-testid='tile-header-${id}']`,
+		dslListButton: `//button[@data-testid='dsl-list-btn']`,
+	},
+
+	/** Catalog modal (opened via toolbar catalog button) */
+	CatalogModal: {
+		catalogButton: `//button[@id='topology-control-bar-catalog-button']`,
+		window: `//div[@data-ouia-component-id='CatalogModal']`,
+		closeButton: `//button[@data-ouia-component-id='CatalogModal-ModalBoxCloseButton']`,
+		listButton: `//button[@id='toggle-layout-button-List']`,
+		galleryButton: `//button[@id='toggle-layout-button-Gallery']`,
+		list: `pf-v6-c-data-list`,
+		gallery: `pf-v6-l-gallery pf-m-gutter`,
+		listItemRow: `pf-v6-c-data-list__item-row`,
+		listItemProvider: `catalog-data-list-item__provider`,
+		providerFilterDropdown: `//button[@data-testid='provider-filter-toggle']`,
+		providerSelectMenu: `providers-select-menu`,
+		providerMenuListItem: `pf-v6-c-menu__list-item`,
+		providerItem: (label: string) => `//li[@data-testid='providers-select-item-${label}']`,
+	},
+
+	/** Beans editor (side panel) */
+	BeansEditor: {
+		listView: `metadata-editor-modal-list-view`,
+		detailsView: `metadata-editor-modal-details-view`,
+	},
+
+	/** DataMapper editor */
+	DataMapperEditor: {
+		howTo: `pf-v6-l-bullseye datamapper-howto`,
+		openEditorButton: `button[title="Click to launch the Kaoto DataMapper editor"]`,
+		attachSchemaButton: (target: string) => `button[data-testid="attach-schema-${target}-button"]`,
+		attachSchemaModal: `//div[@data-testid='attach-schema-modal']`,
+		attachSchemaFileButton: `//button[@data-testid='attach-schema-modal-btn-file']`,
+		attachSchemaAttachButton: `//button[@data-testid='attach-schema-modal-btn-attach']`,
+		sourceFieldByTestId: `//div[starts-with(@data-testid, "node-source-field-shiporder-")] | //div[starts-with(@data-testid, "node-source-fx-shiporder-")]`,
+	},
+} as const;
+
+// ─── LocatorDiff contribution ─────────────────────────────────────────────────
+
+/**
+ * ExTester custom page-objects locator contribution.
+ *
+ * All selectors that require a `By` object at runtime are registered here.
+ * This file is compiled to `out/pageObjects/locators.js` and loaded by
+ * ExTester's `customPageObjects.locatorsPath` option before tests run.
+ *
+ * Page object classes extend `AbstractElement` and call
+ * `MyClass.locators.Kaoto*.*` to access these selectors.
+ */
+export const locators: LocatorDiff['locators'] = {
+	KaotoEditor: {
+		constructor: By.xpath(`//div[@data-testid='visualization-empty-state']`),
+		emptyCanvas: By.xpath(`//div[@data-testid='visualization-empty-state']`),
+		topology: By.xpath(`//div[@data-test-id='topology']`),
+		designTabLink: By.css(`a[data-testid="design-tab"]`),
+		closeSideBar: By.xpath(`//button[@data-testid='close-side-bar']`),
+		propertyPanelCard: By.className(`pf-v6-c-card`),
+	},
+
+	EditorTabs: {
+		constructor: By.className(`pf-v6-c-tabs__list`),
+		tabsList: By.className(`pf-v6-c-tabs__list`),
+		activeTab: By.xpath(`//button[@aria-selected='true']`),
+		tabText: By.className(`pf-v6-c-tabs__item-text`),
+	},
+
+	KaotoContextMenu: {
+		constructor: By.className(`pf-topology-context-menu__c-dropdown__menu`),
+		menu: By.className(`pf-topology-context-menu__c-dropdown__menu`),
+		replaceItem: By.xpath(`//\*[@data-testid='context-menu-item-replace']`),
+		deleteItem: By.css(`li[data-testid="context-menu-item-delete"]`),
+	},
+
+	StepToolbar: {
+		constructor: By.xpath(`//div[@data-testid='step-toolbar']`),
+		toolbar: By.xpath(`//div[@data-testid='step-toolbar']`),
+		resetViewButton: By.css(`button[id='reset-view']`),
+		actionConfirmModal: By.xpath(`//div[@data-ouia-component-id='ActionConfirmationModal']`),
+	},
+
+	KaotoCatalog: {
+		constructor: By.xpath(`//input[@placeholder='Filter by name, description or tag']`),
+		filterInput: By.xpath(`//input[@placeholder='Filter by name, description or tag']`),
+		filterTextInput: By.className(`pf-v6-c-text-input-group__text-input`),
+		dslListButton: By.xpath(`//button[@data-testid='dsl-list-btn']`),
+	},
+
+	CatalogModal: {
+		constructor: By.xpath(`//button[@id='topology-control-bar-catalog-button']`),
+		catalogButton: By.xpath(`//button[@id='topology-control-bar-catalog-button']`),
+		window: By.xpath(`//div[@data-ouia-component-id='CatalogModal']`),
+		closeButton: By.xpath(`//button[@data-ouia-component-id='CatalogModal-ModalBoxCloseButton']`),
+		listButton: By.xpath(`//button[@id='toggle-layout-button-List']`),
+		galleryButton: By.xpath(`//button[@id='toggle-layout-button-Gallery']`),
+		list: By.className(`pf-v6-c-data-list`),
+		gallery: By.className(`pf-v6-l-gallery pf-m-gutter`),
+		listItemRow: By.className(`pf-v6-c-data-list__item-row`),
+		listItemProvider: By.className(`catalog-data-list-item__provider`),
+		providerFilterDropdown: By.xpath(`//button[@data-testid='provider-filter-toggle']`),
+		providerSelectMenu: By.id(`providers-select-menu`),
+		providerMenuListItem: By.className(`pf-v6-c-menu__list-item`),
+	},
+
+	BeansEditor: {
+		constructor: By.className(`metadata-editor-modal-list-view`),
+		listView: By.className(`metadata-editor-modal-list-view`),
+		detailsView: By.className(`metadata-editor-modal-details-view`),
+	},
+
+	DataMapperEditor: {
+		constructor: By.className(`pf-v6-l-bullseye datamapper-howto`),
+		howTo: By.className(`pf-v6-l-bullseye datamapper-howto`),
+		openEditorButton: By.css(`button[title="Click to launch the Kaoto DataMapper editor"]`),
+		attachSchemaModal: By.xpath(`//div[@data-testid='attach-schema-modal']`),
+		attachSchemaFileButton: By.xpath(`//button[@data-testid='attach-schema-modal-btn-file']`),
+		attachSchemaAttachButton: By.xpath(`//button[@data-testid='attach-schema-modal-btn-attach']`),
+		sourceField: By.xpath(
+			`//div[starts-with(@data-testid, "node-source-field-shiporder-")] | //div[starts-with(@data-testid, "node-source-fx-shiporder-")]`,
+		),
+	},
+};

--- a/it-tests/pageObjects/locators.ts
+++ b/it-tests/pageObjects/locators.ts
@@ -49,6 +49,15 @@ import type { LocatorDiff } from 'vscode-extension-tester';
 export const kaotoLocators = {
 	/** Main Kaoto webview canvas & editor state */
 	KaotoEditor: {
+		/**
+		 * Root element the Kaoto editor envelope renders into
+		 * (see `src/webview/KaotoEditorEnvelopeApp.ts`).
+		 *
+		 * Present in the Kaoto webview for every supported file type, and absent from
+		 * both the workbench DOM and any other extension webview (such as "What's New").
+		 * Used to prove that `switchToFrame()` really landed in the Kaoto editor.
+		 */
+		envelopeApp: `#envelope-app`,
 		emptyCanvas: `//div[@data-testid='visualization-empty-state']`,
 		topology: `//div[@data-test-id='topology']`,
 		designTabLink: `a[data-testid="design-tab"]`,
@@ -187,8 +196,47 @@ export const kaotoLocators = {
  * `MyClass.locators.Kaoto*.*` to access these selectors.
  */
 export const locators: LocatorDiff['locators'] = {
+	/**
+	 * Override of the built-in ExTester webview locator.
+	 *
+	 * ExTester ships (`@redhat-developer/locators`, 1.90.0 profile):
+	 *   //div[not(@data-parent-flow-to-element-id)]/iframe[@class='webview ready']
+	 *
+	 * Since VS Code 1.132.0 the webview container always carries
+	 * `data-parent-flow-to-element-id`, empty when there is no parent flow target:
+	 *   <div class="webview-overlay-content" data-parent-flow-to-element-id="">
+	 *
+	 * XPath `not(@attr)` tests attribute *existence*, not its value, so the shipped
+	 * locator matches zero elements. `WebView.switchToFrame()` then silently returns
+	 * without switching, and every webview query afterwards runs against the workbench
+	 * DOM -- surfacing as a `NoSuchElementError` for a perfectly valid app selector.
+	 *
+	 * Measured on VS Code 1.132.0, the container of an editor webview is:
+	 *   <div class="webview-overlay-content"
+	 *        data-parent-flow-to-element-id="webview-editor-element-73e4fa48-...">
+	 *
+	 * The attribute is present and holds the editor element id, so `not(@attr)` -- which
+	 * tests attribute *existence* -- excludes every editor webview and the shipped locator
+	 * matches nothing. `WebView.switchToFrame()` then hits its `if (!view) return;` branch
+	 * and silently does not switch, leaving the driver in the workbench DOM; the failure
+	 * only surfaces later as a `NoSuchElementError` naming a perfectly valid Kaoto selector.
+	 *
+	 * Matching the iframe directly sidesteps the attribute entirely and works on both DOM
+	 * shapes. Upstream added that predicate to exclude the Welcome/walkthrough webview
+	 * (redhat-developer/vscode-extension-tester#1492); dropping it is safe here because
+	 * `it-tests/vscode-settings.json` sets `workbench.startupEditor: none`, so no
+	 * walkthrough is ever open, and ExTester still resolves between multiple matches by
+	 * rect overlap with the editor under test.
+	 *
+	 * Upstream issue: https://github.com/redhat-developer/vscode-extension-tester/issues/2450
+	 */
+	WebView: {
+		iframe: By.css(`iframe.webview.ready`),
+	},
+
 	KaotoEditor: {
 		constructor: By.xpath(`//div[@data-testid='visualization-empty-state']`),
+		envelopeApp: By.css(`#envelope-app`),
 		emptyCanvas: By.xpath(`//div[@data-testid='visualization-empty-state']`),
 		topology: By.xpath(`//div[@data-test-id='topology']`),
 		designTabLink: By.css(`a[data-testid="design-tab"]`),

--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -17,18 +17,14 @@ import {
 	ActivityBar,
 	after,
 	before,
-	By,
 	EditorView,
 	InputBox,
-	Key,
 	ModalDialog,
 	NotificationType,
 	StatusBar,
 	TextSetting,
-	until,
 	VSBrowser,
 	WebDriver,
-	WebElement,
 	WebView,
 	Workbench,
 } from 'vscode-extension-tester';
@@ -36,6 +32,7 @@ import { checkTopologyLoaded, closeEditor, dismissBlockingModal, openAndSwitchTo
 import { join } from 'path';
 import { rmSync } from 'fs';
 import { expect } from 'chai';
+import { CatalogModal } from '../pageObjects';
 
 describe('User Settings', function () {
 	this.timeout(240_000);
@@ -46,28 +43,6 @@ describe('User Settings', function () {
 
 	let driver: WebDriver;
 	let kaotoWebview: WebView;
-
-	const locators = {
-		KaotoView: {
-			catalogButton: By.xpath(`//button[@id='topology-control-bar-catalog-button']`),
-			catalog: {
-				window: By.xpath(`//div[@data-ouia-component-id='CatalogModal']`),
-				list: By.className('pf-v6-c-data-list'),
-				gallery: By.className('pf-v6-l-gallery pf-m-gutter'),
-				listItem: By.className('pf-v6-c-data-list__item-row'),
-				listItemProvider: By.className('catalog-data-list-item__provider'),
-				listButton: By.xpath(`//button[@id='toggle-layout-button-List']`),
-				galleryButton: By.xpath(`//button[@id='toggle-layout-button-Gallery']`),
-				closeButton: By.xpath(`//button[@data-ouia-component-id='CatalogModal-ModalBoxCloseButton']`),
-			},
-			catalogProviderSelector: {
-				dropdown: By.xpath(`//button[@data-testid='provider-filter-toggle']`),
-				menu: By.id('providers-select-menu'),
-				menuItem: By.className('pf-v6-c-menu__list-item'),
-				selector: (label: string) => By.xpath(`//li[@data-testid='providers-select-item-${label}']`),
-			},
-		},
-	};
 
 	before(function () {
 		driver = VSBrowser.instance.driver;
@@ -231,18 +206,19 @@ describe('User Settings', function () {
 			kaotoWebview = (await switchToKaotoFrame(driver, false)).kaotoWebview;
 			await checkTopologyLoaded(driver, 15_000);
 
-			const catalogWindow = await openCatalogInListView();
+			const catalogWindow = await CatalogModal.open(driver, 15_000).then((w) => CatalogModal.switchToListView(driver, w, 10_000));
 
-			const providers = await getCatalogProvidersList(catalogWindow);
+			const providers = await CatalogModal.getProviderNames(driver, catalogWindow);
 			expect(providers).to.not.contain('Red Hat');
 			expect(providers).to.contain('Community');
 
 			// check first component does not contain 'Red Hat' flag
-			const provider = await getFirstCatalogItemProvider(catalogWindow);
+			const provider = await CatalogModal.getFirstItemProvider(catalogWindow);
 			expect(provider).to.not.be.equal('Red Hat');
 
 			// switch catalog window back to gallery view
-			await switchBackCatalogToGalleryViewAndClose(catalogWindow);
+			await CatalogModal.switchToGalleryView(driver, catalogWindow);
+			await CatalogModal.close(catalogWindow);
 		});
 
 		it(`Select 'redhat' catalog and check new components are available`, async function () {
@@ -273,101 +249,23 @@ describe('User Settings', function () {
 			kaotoWebview = (await switchToKaotoFrame(driver, false)).kaotoWebview;
 			await checkTopologyLoaded(driver, 15_000);
 
-			const catalogWindow = await openCatalogInListView();
+			const catalogWindow = await CatalogModal.open(driver, 15_000).then((w) => CatalogModal.switchToListView(driver, w, 10_000));
 
-			const providers = await getCatalogProvidersList(catalogWindow);
+			const providers = await CatalogModal.getProviderNames(driver, catalogWindow);
 			expect(providers).to.contain('Red Hat');
 			expect(providers).to.contain('Community');
 
-			await clickCatalogProviderCheckboxItem(catalogWindow, 'Community'); // uncheck 'Community' provider
+			await CatalogModal.toggleProvider(driver, catalogWindow, 'Community'); // uncheck 'Community' provider
 
 			// check first component contains 'Red Hat' flag
-			const provider = await getFirstCatalogItemProvider(catalogWindow);
+			const provider = await CatalogModal.getFirstItemProvider(catalogWindow);
 			expect(provider).to.be.equal('Red Hat');
 
 			// switch catalog window back to gallery view
-			await switchBackCatalogToGalleryViewAndClose(catalogWindow);
+			await CatalogModal.switchToGalleryView(driver, catalogWindow);
+			await CatalogModal.close(catalogWindow);
 		});
 	});
-
-	async function clickCatalogProviderDropdown(open: boolean, catalogWindow: WebElement) {
-		const dropdown = await catalogWindow.findElement(locators.KaotoView.catalogProviderSelector.dropdown);
-		await dropdown.click();
-		await driver.sleep(1_000); // time to reflect changes in DOM
-
-		if (open) {
-			await driver.wait(until.elementLocated(locators.KaotoView.catalogProviderSelector.menu), 5_000);
-		} else {
-			try {
-				await driver.wait(until.elementLocated(locators.KaotoView.catalogProviderSelector.menu), 5_000);
-			} catch (error) {
-				if (error instanceof Error && error.name !== 'TimeoutError') {
-					throw new Error(error.message);
-				}
-			}
-		}
-	}
-
-	async function clickCatalogProviderCheckboxItem(catalogWindow: WebElement, provider: string) {
-		await clickCatalogProviderDropdown(true, catalogWindow); // open menu
-
-		const menu = await catalogWindow.findElement(locators.KaotoView.catalogProviderSelector.menu);
-		const item = await menu.findElement(locators.KaotoView.catalogProviderSelector.selector(provider));
-		await item.click();
-
-		await clickCatalogProviderDropdown(false, catalogWindow); // close menu
-	}
-
-	async function getCatalogProvidersList(catalogWindow: WebElement): Promise<string[]> {
-		await clickCatalogProviderDropdown(true, catalogWindow); // open menu
-
-		const menu = await catalogWindow.findElement(locators.KaotoView.catalogProviderSelector.menu);
-		const items = await menu.findElements(locators.KaotoView.catalogProviderSelector.menuItem);
-		const labels = await Promise.all(items.map(async (item) => await item.getText()));
-
-		await clickCatalogProviderDropdown(false, catalogWindow); // close menu
-		return labels;
-	}
-
-	async function getFirstCatalogItemProvider(catalogWindow: WebElement): Promise<string> {
-		const listItem = await catalogWindow.findElement(locators.KaotoView.catalog.list).findElement(locators.KaotoView.catalog.listItem);
-		const provider = await listItem.findElement(locators.KaotoView.catalog.listItemProvider).getText();
-		return provider;
-	}
-
-	async function openCatalogInListView(): Promise<WebElement> {
-		// wait for the catalog button to be visible and clickable
-		const catalog = await driver.wait(until.elementLocated(locators.KaotoView.catalogButton), 10_000, 'Catalog button was not located');
-		await driver.wait(until.elementIsVisible(catalog), 10_000, 'Catalog button was not visible');
-		await driver.wait(until.elementIsEnabled(catalog), 10_000, 'Catalog button was not enabled');
-		await catalog.click();
-
-		// wait catalog modal dialog is open
-		await driver.wait(until.elementLocated(locators.KaotoView.catalog.window), 15_000);
-		const catalogWindow = await driver.findElement(locators.KaotoView.catalog.window);
-
-		// switch to list view
-		await catalogWindow.findElement(locators.KaotoView.catalog.listButton).click();
-		await driver.wait(until.elementLocated(locators.KaotoView.catalog.list), 10_000);
-
-		return catalogWindow;
-	}
-
-	async function switchBackCatalogToGalleryViewAndClose(catalogWindow: WebElement): Promise<void> {
-		try {
-			await catalogWindow.findElement(locators.KaotoView.catalog.galleryButton).click();
-			await driver.wait(until.elementLocated(locators.KaotoView.catalog.gallery), 5_000);
-		} catch (error) {
-			// it can happen that because of hover text for list view button
-			// the gallery view button is overlapped and it is not clickable at the moment
-			await driver.actions().sendKeys(Key.ENTER).perform(); // WORKAROUND
-			await catalogWindow.findElement(locators.KaotoView.catalog.galleryButton).click();
-			await driver.wait(until.elementLocated(locators.KaotoView.catalog.gallery), 5_000);
-		}
-
-		// close catalog view
-		await catalogWindow.findElement(locators.KaotoView.catalog.closeButton).click();
-	}
 
 	async function clickCatalogStatusBarItem(): Promise<void> {
 		const statusBar = new StatusBar();

--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActivityBar, after, before, By, ComboSetting, until, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, dismissBlockingModal, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
-import { join } from 'path';
 import { expect } from 'chai';
+import { join } from 'path';
+import { ActivityBar, after, before, ComboSetting, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
+import { KaotoCanvas } from '../pageObjects';
+import { checkTopologyLoaded, closeEditor, dismissBlockingModal, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
 
 describe('User Settings', function () {
 	this.timeout(90_000);
@@ -26,12 +27,6 @@ describe('User Settings', function () {
 
 	let driver: WebDriver;
 	let kaotoWebview: WebView;
-
-	const locators = {
-		TimerComponent: {
-			label: `//*[name()='g' and @data-testid='custom-node__route.from']//*[contains(@class,'custom-node__label__text')]`,
-		},
-	};
 
 	before(async function () {
 		driver = VSBrowser.instance.driver;
@@ -77,7 +72,7 @@ describe('User Settings', function () {
 
 	it(`Check 'id' Node Label is used instead of default 'description'`, async function () {
 		this.timeout(60_000);
-		const timer = await driver.wait(until.elementLocated(By.xpath(locators.TimerComponent.label)), 10_000);
+		const timer = await KaotoCanvas.findNodeLabelText(driver, 'custom-node__route.from', 10_000);
 		const label = await timer.getText();
 
 		expect(label.split('\n')).to.contains('timerID');

--- a/it-tests/views/03_IntegrationsViewNewFile.test.ts
+++ b/it-tests/views/03_IntegrationsViewNewFile.test.ts
@@ -21,10 +21,8 @@ import {
 	afterEach,
 	before,
 	beforeEach,
-	By,
 	EditorView,
 	InputBox,
-	until,
 	ViewControl,
 	ViewPanelActionDropdown,
 	ViewSection,
@@ -41,6 +39,7 @@ import {
 	openResourcesAndWaitForActivation,
 	switchToKaotoFrame,
 } from '../Util';
+import { KaotoCanvas } from '../pageObjects';
 
 describe('Integrations View', function () {
 	this.timeout(240_000);
@@ -177,14 +176,6 @@ describe('Integrations View', function () {
 			await switchToKaotoAndCheckIntegrationType(PIPE_FILE, 'Pipe', 'timer-source');
 		});
 
-		async function checkStepWithNodeLabelPresent(nodeLabel: string, timeout: number = 10_000) {
-			await driver.wait(
-				until.elementLocated(By.xpath(`//*[name()='g' and @data-nodelabel='${nodeLabel}']`)),
-				timeout,
-				`'${nodeLabel}' was not found in current topology.`,
-			);
-		}
-
 		async function switchToKaotoAndCheckIntegrationType(filename: string, type: string, nodeLabel: string): Promise<void> {
 			await driver.wait(
 				async function () {
@@ -195,7 +186,7 @@ describe('Integrations View', function () {
 			);
 
 			const { kaotoWebview } = await switchToKaotoFrame(driver, true);
-			await checkStepWithNodeLabelPresent(nodeLabel);
+			await KaotoCanvas.waitForNodeByLabel(driver, nodeLabel);
 			await kaotoWebview.switchBack();
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "watch": "webpack --env dev",
     "run:webmode": "yarn vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --open-devtools ./resources",
     "test:unit": "yarn build:test:unit && vscode-test",
-    "test:it": "yarn build:test:it && extest setup-and-run --yarn --uninstall_extension --extensions_dir ./test-resources --open_resource './test Fixture with speci@l chars' 'out/**/*.test.js'",
-    "setup:test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources --open_resource './test Fixture with speci@l chars'",
+    "test:it": "yarn build:test:it && extest setup-and-run",
+    "setup:test:it:with-prebuilt-vsix": "yarn build:test:it && extest get-vscode && extest get-chromedriver && extest install-vsix --vsix_file vscode-kaoto-$npm_package_version.vsix --extensions_dir ./test-resources && extest run-tests --uninstall_extension --extensions_dir ./test-resources --open_resource './test Fixture with speci@l chars' --custom_page_objects './out/pageObjects/locators.js'",
     "test:it:with-prebuilt-vsix": "yarn setup:test:it:with-prebuilt-vsix --code_settings ./it-tests/vscode-settings.json 'out/**/*.test.js'",
     "test:it:with-prebuilt-vsix:minikube": "yarn setup:test:it:with-prebuilt-vsix --code_settings ./it-tests/vscode-settings-minikube.json 'out/**/*.test.js'",
     "test:it:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1469

## Problem

ExTester's built-in `WebView.iframe` locator matches zero elements on VS Code 1.132.0, so `switchToFrame()` takes its `if (!view) return;` branch and silently does not switch. The driver stays in the workbench DOM and every webview query afterwards fails naming a perfectly valid Kaoto selector -- which is why this looked like a `.pf-v6-c-tabs__list` PatternFly locator mismatch rather than a frame resolution problem.

The shipped locator is:
```xpath
//div[not(@data-parent-flow-to-element-id)]/iframe[@class='webview ready']
```

but VS Code renders the editor webview container with `data-parent-flow-to-element-id="webview-editor-element-<uuid>"`, and XPath `not(@attr)` tests attribute existence rather than its value, so every editor webview is excluded.

## Solution

- Override the locator through the existing `customPageObjects` contribution with a CSS selector that does not predicate on that attribute
- Harden `switchToKaotoFrame()`: verify that `#envelope-app`, the Kaoto webview root, is reachable after switching, and retry otherwise
- Relax the open-file wait from "tab is active" to "tab exists" - making the Kaoto editor active is now `switchToKaotoFrame()`'s job, where it can be retried and verified

This covers both a silent no-op and a switch into a foreign webview (such as the "What's New" panel), ensuring the suite now reports an honest failure instead of a misleading selector error.

Part of https://github.com/KaotoIO/vscode-kaoto/issues/1466

Upstream issue: https://github.com/redhat-developer/vscode-extension-tester/issues/2450

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded automated coverage for canvas editing, catalog browsing, editor tabs, DataMapper workflows, and property panels.
  * Added reusable test interactions for creating, replacing, deleting, and locating integration steps.
  * Added support for testing catalog list/gallery views and provider filtering.

* **Tests**
  * Improved test reliability by replacing direct UI interactions and fixed delays with reusable waits and page-based actions.
  * Updated test execution configuration and discovery for extension integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->