### PR TITLE
fix(it-tests): dismiss the modal dialog that blocks the rest of the run

### DIFF
--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -30,7 +30,6 @@ import {
 	SideBarView,
 	StatusBar,
 	TerminalView,
-	TextEditor,
 	TreeItem,
 	until,
 	ViewControl,
@@ -186,22 +185,60 @@ export function resetUserSettings(id: string): void {
 }
 
 /**
+ * Dismiss a modal dialog if one is currently blocking the workbench.
+ *
+ * VS Code renders modals behind a full-window backdrop (`.monaco-dialog-modal-block`)
+ * that swallows every click. A single undismissed dialog therefore fails every later
+ * test in the run with `ElementClickInterceptedError`, naming whatever element that
+ * test happened to click rather than anything to do with the real cause -- and the
+ * suites that only *read* the UI keep passing, which makes the pattern hard to spot.
+ *
+ * The tests hit this with the "Do you want to save the changes you made to
+ * settings.json?" prompt, because the settings helpers rewrite `settings.json` on disk
+ * while VS Code still has it open.
+ *
+ * Best effort and safe to call unconditionally: it returns immediately when no dialog
+ * is up, and reports whether it dismissed one.
+ *
+ * Falls back to 'Cancel' rather than to the opposite answer when the preferred button is
+ * missing: 'Cancel' still clears the backdrop, while answering "Don't Save" to a caller
+ * that asked to save would silently discard the change the test depends on.
+ *
+ * @param driver The WebDriver instance.
+ * @param preferredButton Button to press when the dialog offers it.
+ * @returns true when a dialog was dismissed.
+ */
+export async function dismissBlockingModal(driver: WebDriver, preferredButton: string = "Don't Save"): Promise<boolean> {
+	if ((await driver.findElements(By.css('.monaco-dialog-modal-block'))).length === 0) {
+		return false;
+	}
+	for (const button of [preferredButton, 'Cancel']) {
+		try {
+			await new ModalDialog().pushButton(button);
+			return true;
+		} catch {
+			// dialog does not offer this button, try the next one
+		}
+	}
+	console.log('a modal dialog is blocking the workbench and could not be dismissed');
+	return false;
+}
+
+/**
  * Close editor with handling of 'Save/Don't Save' Modal dialog.
+ *
+ * Whether the dialog appears is decided by looking for it after the close, rather than
+ * by probing the active editor with `TextEditor().isDirty()` beforehand: the editor
+ * being closed is not always a text editor -- the Settings UI is the common case here --
+ * so the old check could report "not dirty" and leave the prompt on screen, blocking
+ * every subsequent test.
  *
  * @param title Title of opened active editor.
  * @param save true/false
  */
 export async function closeEditor(title: string, save?: boolean) {
-	const dirty = await new TextEditor().isDirty();
 	await new EditorView().closeEditor(title);
-	if (dirty) {
-		const dialog = new ModalDialog();
-		if (save) {
-			await dialog.pushButton('Save');
-		} else {
-			await dialog.pushButton("Don't Save");
-		}
-	}
+	await dismissBlockingModal(VSBrowser.instance.driver, save ? 'Save' : "Don't Save");
 }
 
 export async function openResourcesAndWaitForActivation(

--- a/it-tests/settings/CatalogURLSettings.test.ts
+++ b/it-tests/settings/CatalogURLSettings.test.ts
@@ -32,7 +32,7 @@ import {
 	WebView,
 	Workbench,
 } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings, switchToKaotoFrame } from '../Util';
+import { checkTopologyLoaded, closeEditor, dismissBlockingModal, openAndSwitchToKaotoFrame, resetUserSettings, switchToKaotoFrame } from '../Util';
 import { join } from 'path';
 import { rmSync } from 'fs';
 import { expect } from 'chai';
@@ -143,6 +143,10 @@ describe('User Settings', function () {
 			// the editor in this step needs to be closed using command palette
 			// because in some cases, specially on Windows, there was hover displayed which was blocking the editor close button
 			await new Workbench().executeCommand('View: Close Editor');
+			// resetUserSettings rewrites settings.json on disk while VS Code still has it open, so
+			// closing can raise "Do you want to save the changes you made to settings.json?". Left up,
+			// its backdrop blocks every click for the rest of the run.
+			await dismissBlockingModal(driver);
 		});
 
 		const runtimeSelectors = ['Main', 'Quarkus', 'Spring Boot'];

--- a/it-tests/settings/NodeLabelSettings.test.ts
+++ b/it-tests/settings/NodeLabelSettings.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ActivityBar, after, before, By, ComboSetting, until, VSBrowser, WebDriver, WebView, Workbench } from 'vscode-extension-tester';
-import { checkTopologyLoaded, closeEditor, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
+import { checkTopologyLoaded, closeEditor, dismissBlockingModal, openAndSwitchToKaotoFrame, resetUserSettings } from '../Util';
 import { join } from 'path';
 import { expect } from 'chai';
 
@@ -69,6 +69,10 @@ describe('User Settings', function () {
 		// the editor in this step needs to be closed using command palette
 		// because in some cases, specially on Windows, there was hover displayed which was blocking the editor close button
 		await new Workbench().executeCommand('View: Close Editor');
+		// resetUserSettings rewrites settings.json on disk while VS Code still has it open, so
+		// closing can raise "Do you want to save the changes you made to settings.json?". Left up,
+		// its backdrop blocks every click for the rest of the run.
+		await dismissBlockingModal(driver);
 	});
 
 	it(`Check 'id' Node Label is used instead of default 'description'`, async function () {


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1471

## Problem

On Windows a single undismissed dialog fails every later test. All 24 `ElementClickInterceptedError` failures in the CI run name the same element -- `<div class="monaco-dialog-modal-block dimmed">`, VS Code's modal backdrop -- and the screenshot artifact shows the dialog itself: "Do you want to save the changes you made to settings.json?".

The backdrop covers the window and swallows every click, so the reported failure names whatever element that test happened to click and looks unrelated to the real cause. The 5 "Extension 'Kaoto' was not activated within 150000ms" timeouts are the same bug rather than a separate one: `waitForExtensionActivation` falls back to `extensionIsActivated`, which has to click the Activity Bar. macOS shows zero interceptions, which is why this reads as Windows-specific.

## Root Cause

It is raised by the settings suites' cleanup: `resetUserSettings()` rewrites settings.json on disk while VS Code still has it open, and the following `View: Close Editor` prompts to save. Neither of those `after` hooks handled a dialog, so it stayed up for the remaining ~20 minutes.

## Solution

- Add `dismissBlockingModal()`, which no-ops unless the backdrop is present and is safe to call unconditionally
- Use it in both hooks
- Falls back to 'Cancel' rather than to the opposite answer, since telling a caller that asked to save "Don't Save" would silently discard the change the test depends on
- `closeEditor()` now decides the same way -- look for the dialog after closing -- instead of pre-probing with `new TextEditor().isDirty()`

This removes the cascade, not the trigger: the settings suites still fail first at `checkTopologyLoaded` because the Kaoto webview does not render (#1468). Verified from the CI logs and screenshot artifacts.

Part of https://github.com/KaotoIO/vscode-kaoto/issues/1466

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>