### PR TITLE
fix(it-tests): edit settings.json as JSON in resetUserSettings

### DIFF
--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -177,11 +177,12 @@ export const storageFolder = process.env.TEST_RESOURCES ? process.env.TEST_RESOU
  */
 export function resetUserSettings(id: string): void {
 	const settingsPath = path.resolve(storageFolder, 'settings', 'User', 'settings.json');
-	const reset = fs
-		.readFileSync(settingsPath, 'utf-8')
-		.replace(new RegExp(`"${id}.*`), '')
-		.replace(/,(?=[^,]*$)/, '');
-	fs.writeFileSync(settingsPath, reset, 'utf-8');
+	const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+	if (!(id in settings)) {
+		return;
+	}
+	delete settings[id];
+	fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 4), 'utf-8');
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1474

## Problem

`resetUserSettings` edited the file as text. ExTester writes settings.json minified onto a single line, which turned two latent defects into reliable corruption:

1. **Greedy regex**: The key regex was greedy with nothing to stop it: "." does not match a newline, but there are no newlines, so `"kaoto.nodeLabel.*` matched from the key to end of file and took every following setting and the closing brace with it.

2. **Unescaped dots**: The dots in the id were unescaped too, so `"kaoto.catalog.url` also matched an unrelated key such as "kaotoXcatalogYurl".

3. **Unconditional comma stripping**: The follow-up replace then stripped the last comma unconditionally -- including when the first replace matched nothing, the common case when the setting was never written.

Once the file is invalid, VS Code reports "Unable to write into user settings" and every later settings write silently fails, while `setUserSettingsDirectly` and `readUserSetting` throw on the same file. One comma was lost per call, so the damage accumulated across a run.

## Solution

Parse, delete the key, re-serialize instead:
- A missing key is then a no-op
- A "." is literal
- The output matches `setUserSettingsDirectly`, which already writes `JSON.stringify(settings, null, 4)`

Part of https://github.com/KaotoIO/vscode-kaoto/issues/1466

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resetting of user settings by reliably removing the selected setting while preserving valid JSON formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->