### PR TITLE
fix: raise IT timeout and add on_retry_command cleanup for Ubuntu and Windows

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -95,12 +95,13 @@ jobs:
       - name: Run Integration Tests
         uses: nick-fields/retry@v4.0.0
         with:
-          timeout_minutes: 30
+          timeout_minutes: 35
           retry_wait_seconds: ${{ inputs.retry-wait-ubuntu }}
           max_attempts: 2
           command: |
             eval $(minikube -p minikube docker-env)
             xvfb-run -a yarn run test:it:with-prebuilt-vsix:minikube
+          on_retry_command: rm -rf "${RUNNER_TEMP}/extest-code"
       - uses: ./.github/actions/upload-test-artifacts
         if: failure()
         with:
@@ -168,12 +169,13 @@ jobs:
       - name: Run Integration Tests
         uses: nick-fields/retry@v4.0.0
         with:
-          timeout_minutes: 30
+          timeout_minutes: 35
           retry_wait_seconds: ${{ inputs.retry-wait-windows }}
           max_attempts: 2
           command: |
             Set-DisplayResolution -Width 1920 -Height 1080 -Force
             yarn run test:it:with-prebuilt-vsix
+          on_retry_command: Remove-Item -Recurse -Force "$env:RUNNER_TEMP\extest-code" -ErrorAction SilentlyContinue
       - uses: ./.github/actions/upload-test-artifacts
         if: failure()
         with:

--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -175,7 +175,7 @@ jobs:
           command: |
             Set-DisplayResolution -Width 1920 -Height 1080 -Force
             yarn run test:it:with-prebuilt-vsix
-          on_retry_command: Remove-Item -Recurse -Force "$env:RUNNER_TEMP\extest-code" -ErrorAction SilentlyContinue
+          on_retry_command: Remove-Item -Recurse -Force "$env:RUNNER_TEMP\extest-code"
       - uses: ./.github/actions/upload-test-artifacts
         if: failure()
         with:


### PR DESCRIPTION
## Summary

Two structural fixes to `.github/workflows/_integration-tests.yaml` for the CI timeout and dirty-retry cascade described in the issue.

### Problem 1 — Suite hits its 30-minute boundary

The Ubuntu suite was finishing at ~28–30 min and getting hard-killed (`Timeout of 1800000ms hit`), losing all failure detail. Raising to 35 minutes gives enough headroom without approaching the 60-min job-level limit.

### Problem 2 — Attempt 2 starts with a stale `extest-code` symlink

`vscode-extension-tester` creates a symlink at `os.tmpdir()/extest-code` pointing to the VS Code binary. When attempt 1 ends abnormally, the symlink is left behind. Attempt 2 finds it, tries to start WebDriver against a dead process, and every test reports `NoSuchSessionError` / `Workbench was not loaded` — producing 0 passing results. macOS already had `on_retry_command: rm -rf "${RUNNER_TEMP}/extest-code"`; Ubuntu and Windows were missing it.

## Changes

| Job | Change |
|---|---|
| Ubuntu | `timeout_minutes: 30 → 35` + `on_retry_command` added |
| macOS | No change (already had both fixes) |
| Windows | `timeout_minutes: 30 → 35` + `on_retry_command` added (PowerShell syntax) |

Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integration-test retries on Ubuntu and Windows can now run for up to 35 minutes.
  * Test retries now clean up temporary test files before restarting.
  * Windows cleanup handles missing temporary directories without interrupting retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->