### PR TITLE
fix(#1477): fix Citrus 5.x / camel-jbang 4.22 incompatibility in 'camel test'

### DIFF
--- a/it-tests/views/11_TestsViewNewFile.test.ts
+++ b/it-tests/views/11_TestsViewNewFile.test.ts
@@ -27,10 +27,7 @@ import {
 	handleInputPathSelection,
 } from '../Util';
 
-// TODO(#1477): temporarily disabled — Citrus 5.0.0 broke Camel JBang's `camel test`
-// shim (`package org.citrusframework.jbang.cli does not exist`), failing these tests on
-// every branch and OS. Re-enable once #1477 is resolved.
-describe.skip('Tests View', function () {
+describe('Tests View', function () {
 	this.timeout(240_000);
 
 	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars', 'kaoto-view', 'example-tests');

--- a/it-tests/views/12_TestsViewRun.test.ts
+++ b/it-tests/views/12_TestsViewRun.test.ts
@@ -28,10 +28,7 @@ import {
 	waitUntilTerminalHasText,
 } from '../Util';
 
-// TODO(#1477): temporarily disabled — Citrus 5.0.0 broke Camel JBang's `camel test`
-// shim (`package org.citrusframework.jbang.cli does not exist`), failing these tests on
-// every branch and OS. Re-enable once #1477 is resolved.
-describe.skip('Tests View', function () {
+describe('Tests View', function () {
 	this.timeout(240_000);
 
 	const WORKSPACE_FOLDER = join(__dirname, '../../test Fixture with speci@l chars', 'kaoto-view', 'example-tests');
@@ -71,7 +68,7 @@ describe.skip('Tests View', function () {
 			const button = await getTreeItemActionButton(kaotoViewContainer, item as TreeItem, 'Run');
 			await button?.click();
 
-			await waitUntilTerminalHasText(driver, ['myTest.citrus-flow.json', 'Tests finished'], 4_000, 180_000);
+			await waitUntilTerminalHasText(driver, ['myTest.citrus', 'Tests finished'], 4_000, 180_000);
 		});
 	});
 
@@ -89,7 +86,7 @@ describe.skip('Tests View', function () {
 			const button = await getTreeItemActionButton(kaotoViewContainer, item as TreeItem, 'Run: Folder');
 			await button?.click();
 
-			await waitUntilTerminalHasText(driver, ['myFolderTest.citrus-flow.json', 'myFolderTest.citrus.test-flow.json', 'Tests finished'], 4_000, 180_000);
+			await waitUntilTerminalHasText(driver, ['myFolderTest.citrus', 'myFolderTest.citrus.test', 'Tests finished'], 4_000, 180_000);
 		});
 	});
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,9 @@
 // ─── Default Values ──────────────────────────────────────────────────────────
 
-export const DEFAULT_CAMEL_VERSION_FALLBACK: string = '4.20.0';
+export const DEFAULT_CAMEL_VERSION_FALLBACK: string = '4.22.0';
+
+/** Minimum camel-jbang version required for the 'camel test' plugin (4.22.0 ships the plugin natively; 4.20 uses a broken JBang shim) */
+export const MIN_CAMEL_VERSION_FOR_TEST: string = '4.22.0';
 
 // ─── Editor Type ─────────────────────────────────────────────────────────────
 

--- a/src/executors/BaseExecutor.ts
+++ b/src/executors/BaseExecutor.ts
@@ -22,7 +22,7 @@ export abstract class BaseExecutor implements ICamelExecutor {
 			throw new Error(`Executor ${this.config.type} is not available`);
 		}
 
-		const builderConfig = await this.buildCommandBuilderConfig(context);
+		const builderConfig = await this.buildCommandBuilderConfig({ ...context, command });
 		const builder = new CamelCommandBuilder(builderConfig);
 		return builder.buildCommand(command, args, context);
 	}

--- a/src/executors/JBangExecutor.ts
+++ b/src/executors/JBangExecutor.ts
@@ -77,15 +77,28 @@ export class JBangExecutor extends BaseExecutor {
 	 * always considered below the minimum and replaced.
 	 */
 	static enforceMinVersion(version: string, minVersion: string): string {
-		const toSegments = (v: string) => v.split('.').map((s) => parseInt(s, 10) || 0);
+		const toSegments = (v: string): number[] | undefined => {
+			const segments = v.split('.');
+			if (segments.some((s) => !/^\d+$/.test(s))) {
+				return undefined;
+			}
+			return segments.map((s) => Number.parseInt(s, 10));
+		};
 		const cur = toSegments(version);
 		const min = toSegments(minVersion);
+		if (!cur || !min) {
+			return minVersion;
+		}
 		const len = Math.max(cur.length, min.length);
 		for (let i = 0; i < len; i++) {
 			const c = cur[i] ?? 0;
 			const m = min[i] ?? 0;
-			if (c > m) return version;
-			if (c < m) return minVersion;
+			if (c > m) {
+				return version;
+			}
+			if (c < m) {
+				return minVersion;
+			}
 		}
 		return version; // equal
 	}

--- a/src/executors/JBangExecutor.ts
+++ b/src/executors/JBangExecutor.ts
@@ -6,7 +6,7 @@ import { CamelCommandBuilder, CommandBuilderConfig } from './builders/CamelComma
 import { JBangExecutorConfig } from './types/ExecutorConfig';
 import { CommandContext, RuntimeType } from './types/ExecutorTypes';
 import { KaotoCatalogService } from '../services/KaotoCatalogService';
-import { DEFAULT_CAMEL_VERSION_FALLBACK } from '../constants';
+import { DEFAULT_CAMEL_VERSION_FALLBACK, MIN_CAMEL_VERSION_FOR_TEST } from '../constants';
 import { isRedHatBuild } from '../helpers/helpers';
 
 export class JBangExecutor extends BaseExecutor {
@@ -24,7 +24,8 @@ export class JBangExecutor extends BaseExecutor {
 		const resourceUri = context?.cwd ? Uri.file(context.cwd) : undefined;
 		const catalog = await catalogService.getSelectedIntegrationCatalog(resourceUri);
 
-		const cliVersion = catalogService.getCliVersionForJBang(catalog) || DEFAULT_CAMEL_VERSION_FALLBACK;
+		const rawCliVersion = catalogService.getCliVersionForJBang(catalog) || DEFAULT_CAMEL_VERSION_FALLBACK;
+		const cliVersion = context?.command === 'test' ? JBangExecutor.enforceMinVersion(rawCliVersion, MIN_CAMEL_VERSION_FOR_TEST) : rawCliVersion;
 		const runtimeSystemProps = this.getRuntimeSystemProperties(catalogService, catalog);
 
 		return {
@@ -68,6 +69,25 @@ export class JBangExecutor extends BaseExecutor {
 		}
 
 		return properties;
+	}
+
+	/**
+	 * Returns `version` if it is >= `minVersion`, otherwise returns `minVersion`.
+	 * Compares dot-separated numeric segments; non-numeric (e.g. redhat) builds are
+	 * always considered below the minimum and replaced.
+	 */
+	static enforceMinVersion(version: string, minVersion: string): string {
+		const toSegments = (v: string) => v.split('.').map((s) => parseInt(s, 10) || 0);
+		const cur = toSegments(version);
+		const min = toSegments(minVersion);
+		const len = Math.max(cur.length, min.length);
+		for (let i = 0; i < len; i++) {
+			const c = cur[i] ?? 0;
+			const m = min[i] ?? 0;
+			if (c > m) return version;
+			if (c < m) return minVersion;
+		}
+		return version; // equal
 	}
 
 	async isAvailable(): Promise<boolean> {

--- a/src/executors/types/ExecutorTypes.ts
+++ b/src/executors/types/ExecutorTypes.ts
@@ -29,6 +29,8 @@ export type CamelCommand = 'run' | 'export' | 'init' | 'bind' | 'stop' | 'depend
  */
 export interface CommandContext {
 	readonly cwd?: string;
+	/** The Camel command being executed (e.g. 'run', 'test'). Used by executors that need per-command version constraints. */
+	readonly command?: CamelCommand;
 }
 
 /**

--- a/src/test/executors/CamelExecutors.test.ts
+++ b/src/test/executors/CamelExecutors.test.ts
@@ -32,9 +32,14 @@ suite('Executor Implementation Tests', () => {
 				assert.equal(JBangExecutor.enforceMinVersion('3.99.9', '4.22.0'), '4.22.0');
 			});
 
-			test('treats non-numeric segments (e.g. redhat builds) as 0 — below minimum', () => {
+			test('treats non-numeric segments (e.g. redhat builds) as invalid — always replaced with minVersion', () => {
+				// below minimum prefix with non-numeric suffix
 				assert.equal(JBangExecutor.enforceMinVersion('4.20.0.redhat-00019', '4.22.0'), '4.22.0');
 				assert.equal(JBangExecutor.enforceMinVersion('4.18.1.redhat-00019', '4.22.0'), '4.22.0');
+				// equal-to-minimum prefix with non-numeric suffix — still replaced
+				assert.equal(JBangExecutor.enforceMinVersion('4.22.0.redhat-00019', '4.22.0'), '4.22.0');
+				// above-minimum prefix with non-numeric suffix — still replaced
+				assert.equal(JBangExecutor.enforceMinVersion('5.0.0.redhat-00019', '4.22.0'), '4.22.0');
 			});
 		});
 

--- a/src/test/executors/CamelExecutors.test.ts
+++ b/src/test/executors/CamelExecutors.test.ts
@@ -15,6 +15,29 @@ suite('Executor Implementation Tests', () => {
 			});
 		});
 
+		suite('enforceMinVersion', () => {
+			test('returns version when already above minimum', () => {
+				assert.equal(JBangExecutor.enforceMinVersion('4.22.1', '4.22.0'), '4.22.1');
+				assert.equal(JBangExecutor.enforceMinVersion('4.23.0', '4.22.0'), '4.23.0');
+				assert.equal(JBangExecutor.enforceMinVersion('5.0.0', '4.22.0'), '5.0.0');
+			});
+
+			test('returns version when equal to minimum', () => {
+				assert.equal(JBangExecutor.enforceMinVersion('4.22.0', '4.22.0'), '4.22.0');
+			});
+
+			test('returns minVersion when version is below minimum', () => {
+				assert.equal(JBangExecutor.enforceMinVersion('4.20.0', '4.22.0'), '4.22.0');
+				assert.equal(JBangExecutor.enforceMinVersion('4.21.0', '4.22.0'), '4.22.0');
+				assert.equal(JBangExecutor.enforceMinVersion('3.99.9', '4.22.0'), '4.22.0');
+			});
+
+			test('treats non-numeric segments (e.g. redhat builds) as 0 — below minimum', () => {
+				assert.equal(JBangExecutor.enforceMinVersion('4.20.0.redhat-00019', '4.22.0'), '4.22.0');
+				assert.equal(JBangExecutor.enforceMinVersion('4.18.1.redhat-00019', '4.22.0'), '4.22.0');
+			});
+		});
+
 		test('Should have correct configuration', () => {
 			const config = executor.getConfig();
 			assert.equal(config.type, 'jbang');

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/citrus-application.properties
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/folderA/folderAA/test/citrus-application.properties
@@ -1,5 +1,5 @@
 # Camel version used by Citrus
-citrus.camel.jbang.version=4.20.0
+citrus.camel.jbang.version=4.22.0
 
 # Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true

--- a/test Fixture with speci@l chars/kaoto-view/example-tests/test/citrus-application.properties
+++ b/test Fixture with speci@l chars/kaoto-view/example-tests/test/citrus-application.properties
@@ -1,5 +1,5 @@
 # Camel version used by Citrus
-citrus.camel.jbang.version=4.20.0
+citrus.camel.jbang.version=4.22.0
 
 # Enable dump of Camel JBang integration output
 citrus.camel.jbang.dump.integration.output=true


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1477

## Problem

Three Citrus integration tests broke on every branch and OS since 2026-08-04:

- `11_TestsViewNewFile` — `camel test init` failed (file never created)
- `12_TestsViewRun` — `camel test run` failed (terminal never showed expected output)

The failure had nothing to do with this repo. **Citrus 5.0.0** (released 2026-08-04) moved `CitrusJBangMain` from `org.citrusframework.jbang` into `org.citrusframework.jbang.cli`. camel-jbang 4.20 implements `camel test` by fetching a JBang shim from citrusframework/citrus `main` and compiling it at runtime — that shim now imports the new 5.x package, but camel-jbang 4.20 pins citrus-jbang 4.x on its classpath, so the compile fails:

```
CitrusJBang.java:25: error: package org.citrusframework.jbang.cli does not exist
```

### Why bumping DEFAULT_CAMEL_VERSION_FALLBACK was not enough

The `@kaoto/camel-catalog` package hardcodes `cliVersion: "4.20.0"` for all entries. The fallback constant is only used when no catalog is selected — at runtime a catalog is always selected, so `cliVersion=4.20.0` always won.

## Fix

### 1. camel-jbang 4.22 eliminates the problem

camel-jbang 4.22 ships `camel test` as a proper compiled plugin (`camel-jbang-plugin-test`) linked against citrus-jbang 5.x at build time. No more dynamic shim fetch or classpath mismatch.

### 2. Version floor in JBangExecutor

`JBangExecutor` now enforces a minimum `cliVersion` of `4.22.0` when the Camel command being executed is `test`. The `command` is threaded through `CommandContext` → `BaseExecutor` → `buildCommandBuilderConfig` so the executor can apply per-command version constraints without touching any other command paths.

```
// Before (all catalog entries have cliVersion=4.20.0):
jbang -Dcamel.jbang.version=4.20.0 camel@apache/camel test run myTest.citrus.yaml
//  → CitrusJBang.java compile error

// After:
jbang -Dcamel.jbang.version=4.22.0 camel@apache/camel test run myTest.citrus.yaml
//  → native plugin, works
```

### 3. Updated IT test assertions

camel-jbang 4.22's native plugin changed the terminal output: it no longer prints `myTest.citrus-flow.json` paths. It prints the test name in a `CITRUS TEST RESULTS` block:

```
✔ SUCCESS (  7ms) myTest.citrus
Tests finished after 601 ms
```

The `waitUntilTerminalHasText` calls in `12_TestsViewRun` are updated to match.

## Changes

| File | Change |
|------|--------|
| `src/constants.ts` | Bump `DEFAULT_CAMEL_VERSION_FALLBACK` → `4.22.0`; add `MIN_CAMEL_VERSION_FOR_TEST` |
| `src/executors/types/ExecutorTypes.ts` | Add `command?: CamelCommand` to `CommandContext` |
| `src/executors/BaseExecutor.ts` | Spread `command` into context before `buildCommandBuilderConfig` |
| `src/executors/JBangExecutor.ts` | Floor `cliVersion` to `4.22.0` for `test` command; add `enforceMinVersion()` |
| `src/test/executors/CamelExecutors.test.ts` | 4 unit tests for `enforceMinVersion` |
| `it-tests/views/11_TestsViewNewFile.test.ts` | Re-enable previously skipped describe block |
| `it-tests/views/12_TestsViewRun.test.ts` | Re-enable + update terminal text assertions |
| `test/…/citrus-application.properties` (×2) | Bump `citrus.camel.jbang.version` → `4.22.0` |

## CI

All jobs green on the final run (build + ubuntu + macos + windows integration tests):

- Build with released version of Kaoto: ✅ build, ✅ test-ubuntu, ✅ test-macos, ✅ test-windows
- Build with main branch of kaoto: ✅ build, ✅ test-ubuntu

---

_Diagnosed and fixed with the help of [Claude Code](https://claude.com/claude-code)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test commands now enforce a minimum Camel CLI version of 4.22.0.
  * Version handling now supports incomplete or non-numeric version strings more reliably.

* **Bug Fixes**
  * Updated the default Camel CLI version to 4.22.0.
  * Updated test fixtures and terminal-output expectations for current Citrus test names.

* **Tests**
  * Re-enabled Tests View integration tests.
  * Added coverage for Camel CLI version enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->