### PR TITLE
feat: log startup diagnostic info on extension activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ yarn-error.log*
 
 # AI agent delegation run logs
 .bob-runs
+
+# AI agent planning and design docs (local only)
+docs/superpowers/

--- a/src/extension/KaotoOutputChannel.ts
+++ b/src/extension/KaotoOutputChannel.ts
@@ -74,7 +74,7 @@ export class KaotoOutputChannel {
 		this.logInfo(`Extension mode: ${extensionModeLabel}`);
 		this.logInfo(`App host: ${vscode.env.appHost}`);
 		this.logInfo(`Remote: ${remote}`);
-		const osPlatform = process?.platform ?? 'unavailable';
+		const osPlatform = typeof process !== 'undefined' ? process.platform : 'unavailable';
 		this.logInfo(`OS platform: ${osPlatform}`);
 		this.logInfo(`Executor type: ${executorType}`);
 		this.logInfo(`Workspace folders: ${workspaceFolderCount}`);

--- a/src/extension/KaotoOutputChannel.ts
+++ b/src/extension/KaotoOutputChannel.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import * as vscode from 'vscode';
+import { KAOTO_EXECUTOR_TYPE_SETTING_ID } from '../constants';
 
 export class KaotoOutputChannel {
 	private static instance: vscode.OutputChannel;
@@ -41,6 +42,42 @@ export class KaotoOutputChannel {
 		}
 		const errorMsg = error instanceof Error ? error.message : String(error);
 		this.logMessage('ERROR', `${message}\n${errorMsg}`);
+	}
+
+	/**
+	 * Log a structured block of startup diagnostic information.
+	 * All values are privacy-safe: no paths, usernames, or identifiers.
+	 *
+	 * @param context - The VS Code extension context
+	 * @param mode - Pass 'web' when called from the web entry point
+	 */
+	public static logStartupInfo(context: vscode.ExtensionContext, mode?: 'web'): void {
+		let extensionModeLabel: string;
+		if (mode === 'web') {
+			extensionModeLabel = 'web';
+		} else if (context.extensionMode === vscode.ExtensionMode.Development) {
+			extensionModeLabel = 'Development';
+		} else if (context.extensionMode === vscode.ExtensionMode.Test) {
+			extensionModeLabel = 'Test';
+		} else {
+			extensionModeLabel = 'Production';
+		}
+
+		const executorType = vscode.workspace.getConfiguration().get<string>(KAOTO_EXECUTOR_TYPE_SETTING_ID) ?? 'unknown';
+
+		const remote = vscode.env.remoteName ?? 'none';
+		const workspaceFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
+
+		this.logInfo(`Editor app: ${vscode.env.appName}`);
+		this.logInfo(`Editor version: ${vscode.version}`);
+		this.logInfo(`Kaoto version: ${context.extension.packageJSON.version}`);
+		this.logInfo(`Extension mode: ${extensionModeLabel}`);
+		this.logInfo(`App host: ${vscode.env.appHost}`);
+		this.logInfo(`Remote: ${remote}`);
+		const osPlatform = process?.platform ?? 'unavailable';
+		this.logInfo(`OS platform: ${osPlatform}`);
+		this.logInfo(`Executor type: ${executorType}`);
+		this.logInfo(`Workspace folders: ${workspaceFolderCount}`);
 	}
 
 	// Log a formatted message with a timestamp

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -33,6 +33,7 @@ let telemetryService: TelemetryService;
 
 export async function activate(context: vscode.ExtensionContext) {
 	KaotoOutputChannel.logInfo('Kaoto extension is alive.');
+	KaotoOutputChannel.logStartupInfo(context);
 
 	// Initialize executor factory with extension context
 	CamelExecutorFactory.initialize(context);

--- a/src/extension/extensionWeb.ts
+++ b/src/extension/extensionWeb.ts
@@ -28,6 +28,7 @@ let backendProxy: VsCodeBackendProxy;
 
 export async function activate(context: vscode.ExtensionContext) {
 	KaotoOutputChannel.logInfo('Kaoto extension is alive.');
+	KaotoOutputChannel.logStartupInfo(context, 'web');
 
 	const backendI18n = new I18n(backendI18nDefaults, backendI18nDictionaries, vscode.env.language);
 	backendProxy = new VsCodeBackendProxy(context, backendI18n);

--- a/src/test/extension/KaotoOutputChannel.test.ts
+++ b/src/test/extension/KaotoOutputChannel.test.ts
@@ -109,14 +109,14 @@ suite('KaotoOutputChannel - logStartupInfo', function () {
 	test('logs OS platform: unavailable when process is undefined', function () {
 		const context = makeContext(vscode.ExtensionMode.Production);
 
-		// Simulate the webworker environment where process is not polyfilled
-		const originalPlatform = process.platform;
-		Object.defineProperty(process, 'platform', { value: undefined, configurable: true });
+		// Simulate the webworker environment where process global is not defined at all
+		const originalProcess = (globalThis as Record<string, unknown>).process;
+		delete (globalThis as Record<string, unknown>).process;
 
 		try {
 			KaotoOutputChannel.logStartupInfo(context, 'web');
 		} finally {
-			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+			(globalThis as Record<string, unknown>).process = originalProcess;
 		}
 
 		const lines = getInfoLines();

--- a/src/test/extension/KaotoOutputChannel.test.ts
+++ b/src/test/extension/KaotoOutputChannel.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { assert } from 'chai';
+import * as vscode from 'vscode';
+import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';
+import { KAOTO_EXECUTOR_TYPE_SETTING_ID } from '../../constants';
+
+suite('KaotoOutputChannel - logStartupInfo', function () {
+	let appendedLines: string[];
+	let originalAppendLine: (value: string) => void;
+
+	setup(function () {
+		appendedLines = [];
+
+		// Capture all lines written to the output channel
+		const channel = KaotoOutputChannel.getInstance();
+		originalAppendLine = channel.appendLine.bind(channel);
+		channel.appendLine = (line: string) => {
+			appendedLines.push(line);
+		};
+	});
+
+	teardown(async function () {
+		// Restore appendLine
+		const channel = KaotoOutputChannel.getInstance();
+		channel.appendLine = originalAppendLine;
+
+		// Reset executor type setting to avoid leaking into other tests
+		await vscode.workspace.getConfiguration().update(KAOTO_EXECUTOR_TYPE_SETTING_ID, undefined, vscode.ConfigurationTarget.Global);
+	});
+
+	function makeContext(extensionMode: vscode.ExtensionMode): vscode.ExtensionContext {
+		return {
+			extensionMode,
+			extension: {
+				packageJSON: { version: '2.12.0' },
+			},
+		} as unknown as vscode.ExtensionContext;
+	}
+
+	function getInfoLines(): string[] {
+		return appendedLines.filter((l) => l.includes('[INFO]'));
+	}
+
+	function assertContainsField(lines: string[], field: string, value: string): void {
+		const match = lines.find((l) => l.includes(`[INFO] ${field}: ${value}`));
+		assert.isDefined(match, `Expected a line containing "[INFO] ${field}: ${value}" but got:\n${lines.join('\n')}`);
+	}
+
+	test('logs all expected fields in desktop Production mode', async function () {
+		await vscode.workspace.getConfiguration().update(KAOTO_EXECUTOR_TYPE_SETTING_ID, 'jbang', vscode.ConfigurationTarget.Global);
+		const context = makeContext(vscode.ExtensionMode.Production);
+
+		KaotoOutputChannel.logStartupInfo(context);
+
+		const lines = getInfoLines();
+		assertContainsField(lines, 'Editor app', vscode.env.appName);
+		assertContainsField(lines, 'Editor version', vscode.version);
+		assertContainsField(lines, 'Kaoto version', '2.12.0');
+		assertContainsField(lines, 'Extension mode', 'Production');
+		assertContainsField(lines, 'App host', vscode.env.appHost);
+		assertContainsField(lines, 'OS platform', process.platform);
+		assertContainsField(lines, 'Executor type', 'jbang');
+		// Workspace folders is a count — just assert the line exists
+		const wsFolderLine = lines.find((l) => l.includes('[INFO] Workspace folders:'));
+		assert.isDefined(wsFolderLine, 'Expected a "Workspace folders" line');
+	});
+
+	test('logs Extension mode: Development in Development mode', function () {
+		const context = makeContext(vscode.ExtensionMode.Development);
+
+		KaotoOutputChannel.logStartupInfo(context);
+
+		const lines = getInfoLines();
+		assertContainsField(lines, 'Extension mode', 'Development');
+	});
+
+	test('logs Extension mode: Test in Test mode', function () {
+		const context = makeContext(vscode.ExtensionMode.Test);
+
+		KaotoOutputChannel.logStartupInfo(context);
+
+		const lines = getInfoLines();
+		assertContainsField(lines, 'Extension mode', 'Test');
+	});
+
+	test('logs Extension mode: web when mode param is "web"', function () {
+		const context = makeContext(vscode.ExtensionMode.Production);
+
+		KaotoOutputChannel.logStartupInfo(context, 'web');
+
+		const lines = getInfoLines();
+		assertContainsField(lines, 'Extension mode', 'web');
+	});
+
+	test('logs OS platform: unavailable when process is undefined', function () {
+		const context = makeContext(vscode.ExtensionMode.Production);
+
+		// Simulate the webworker environment where process is not polyfilled
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, 'platform', { value: undefined, configurable: true });
+
+		try {
+			KaotoOutputChannel.logStartupInfo(context, 'web');
+		} finally {
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+		}
+
+		const lines = getInfoLines();
+		assertContainsField(lines, 'OS platform', 'unavailable');
+	});
+
+	test('logs Remote: none when remoteName is undefined', function () {
+		const context = makeContext(vscode.ExtensionMode.Production);
+
+		// vscode.env.remoteName is undefined in normal desktop test environment
+		KaotoOutputChannel.logStartupInfo(context);
+
+		const lines = getInfoLines();
+		// remoteName is undefined in test env → expect "none"
+		const remoteLine = lines.find((l) => l.includes('[INFO] Remote:'));
+		assert.isDefined(remoteLine, 'Expected a "Remote" line');
+		assert.isTrue(remoteLine!.includes('Remote: none'), `Expected Remote: none but got: ${remoteLine}`);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new `logStartupInfo` static method to `KaotoOutputChannel` that logs a structured, privacy-safe block of diagnostic fields to the Kaoto Output Channel at extension activation time — on both desktop and web entry points.

## Fields logged

```
[INFO] Editor app: Code
[INFO] Editor version: 1.100.0
[INFO] Kaoto version: 2.12.0
[INFO] Extension mode: Production
[INFO] App host: desktop
[INFO] Remote: none
[INFO] OS platform: linux
[INFO] Executor type: jbang
[INFO] Workspace folders: 1
```

## Privacy

No user-identifying information is logged — no workspace paths, file names, usernames, machine IDs, or session IDs. All values are either VS Code API constants, extension metadata, or aggregate counts.

## Changes

- `src/extension/KaotoOutputChannel.ts` — new `logStartupInfo(context, mode?)` static method
- `src/extension/extension.ts` — call `logStartupInfo(context)` at desktop activation start
- `src/extension/extensionWeb.ts` — call `logStartupInfo(context, 'web')` at web activation start
- `src/test/extension/KaotoOutputChannel.test.ts` — 5 unit tests covering all mode variants and remote fallback

Closes https://github.com/KaotoIO/vscode-kaoto/issues/1362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added privacy-safe startup diagnostics for desktop and web extension activation.
  - Startup logs now provide helpful environment details, including editor and extension versions, platform, remote connection status, execution mode, executor configuration, and workspace count.
  - Diagnostics are recorded in an organized format while excluding identifying information and credentials.

- **Documentation**
  - Added design and implementation documentation describing the startup diagnostics and privacy safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->