### PR TITLE
refactor(test): use handleTaskEnd and await refresh() for deterministic DeploymentsProvider tests

### DIFF
--- a/src/test/views/DeploymentsProvider.test.ts
+++ b/src/test/views/DeploymentsProvider.test.ts
@@ -93,11 +93,11 @@ suite('DeploymentsProvider — port guard (NO_PORT = -1 is skipped)', function (
 		assert.deepStrictEqual(releasePortCalls, [], 'releasePort must not be called for NO_PORT');
 	});
 
-	test('releasePort IS called exactly once when a task ends with a valid port', async function () {
+	test('releasePort IS called exactly once when a task ends with a valid port', function () {
 		const { portManager, releasePortCalls } = makePortManager(false);
 		const provider = new DeploymentsProvider(portManager);
 
-		await provider.handleTaskEnd(makeCamelTaskDef(8080));
+		provider.handleTaskEnd(makeCamelTaskDef(8080));
 
 		provider.dispose();
 		assert.deepStrictEqual(releasePortCalls, [8080], 'releasePort must be called exactly once for a valid port');

--- a/src/test/views/DeploymentsProvider.test.ts
+++ b/src/test/views/DeploymentsProvider.test.ts
@@ -16,7 +16,7 @@
 import { assert } from 'chai';
 import { DeploymentsProvider, PortFileKey } from '../../views/providers/DeploymentsProvider';
 import { PortManager } from '../../helpers/PortManager';
-import { CamelTask } from '../../tasks/CamelTask';
+import { CamelTask, CamelTaskDefinition } from '../../tasks/CamelTask';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -45,6 +45,11 @@ function makePortManager(reachable: boolean): {
 	};
 
 	return { portManager, releasePortCalls, waitForPortReachableCalls };
+}
+
+/** Builds a minimal CamelTaskDefinition for use with handleTaskEnd. */
+function makeCamelTaskDef(port: number): CamelTaskDefinition {
+	return { type: 'camel', label: 'test-task', port };
 }
 
 // ─── PortFileKey ─────────────────────────────────────────────────────────────
@@ -78,32 +83,24 @@ suite('DeploymentsProvider — port guard (NO_PORT = -1 is skipped)', function (
 		assert.isTrue(8080 > 0, 'a real port must pass the port > 0 guard');
 	});
 
-	test('releasePort is NOT called when a task ends with NO_PORT (-1)', async function () {
+	test('releasePort is NOT called when a task ends with NO_PORT (-1)', function () {
 		const { portManager, releasePortCalls } = makePortManager(false);
 		const provider = new DeploymentsProvider(portManager);
+
+		provider.handleTaskEnd(makeCamelTaskDef(CamelTask.NO_PORT));
+
 		provider.dispose();
-
-		// Simulate the guarded logic from onDidEndTaskProcess
-		const port: number = CamelTask.NO_PORT; // -1
-		if (/* def.type === 'camel' && */ port > 0) {
-			portManager.releasePort(port);
-		}
-
 		assert.deepStrictEqual(releasePortCalls, [], 'releasePort must not be called for NO_PORT');
 	});
 
-	test('releasePort IS called when a task ends with a valid port', function () {
+	test('releasePort IS called exactly once when a task ends with a valid port', async function () {
 		const { portManager, releasePortCalls } = makePortManager(false);
 		const provider = new DeploymentsProvider(portManager);
+
+		await provider.handleTaskEnd(makeCamelTaskDef(8080));
+
 		provider.dispose();
-
-		// Simulate the guarded logic from onDidEndTaskProcess
-		const port = 8080;
-		if (port > 0) {
-			portManager.releasePort(port);
-		}
-
-		assert.deepStrictEqual(releasePortCalls, [8080]);
+		assert.deepStrictEqual(releasePortCalls, [8080], 'releasePort must be called exactly once for a valid port');
 	});
 });
 
@@ -117,10 +114,7 @@ suite('DeploymentsProvider — ports are NOT released on transient poll failures
 		portManager.getUsedPorts().add(8080);
 
 		const provider = new DeploymentsProvider(portManager);
-		provider.refresh();
-
-		// Allow the async refresh to settle
-		await new Promise((r) => setTimeout(r, 20));
+		await provider.refresh();
 
 		provider.dispose();
 
@@ -141,8 +135,7 @@ suite('DeploymentsProvider — ports are NOT released on transient poll failures
 
 		try {
 			const provider = new DeploymentsProvider(portManager);
-			provider.refresh();
-			await new Promise((r) => setTimeout(r, 20));
+			await provider.refresh();
 			provider.dispose();
 
 			assert.deepStrictEqual(releasePortCalls, [], 'releasePort must NOT be called on a fetch error');
@@ -162,8 +155,7 @@ suite('DeploymentsProvider — reachability poll uses 3-second timeout', functio
 		portManager.getUsedPorts().add(8080);
 
 		const provider = new DeploymentsProvider(portManager);
-		provider.refresh();
-		await new Promise((r) => setTimeout(r, 20));
+		await provider.refresh();
 		provider.dispose();
 
 		assert.isTrue(

--- a/src/views/providers/DeploymentsProvider.ts
+++ b/src/views/providers/DeploymentsProvider.ts
@@ -54,17 +54,12 @@ export class DeploymentsProvider implements TreeDataProvider<TreeItem> {
 				const ready = await this.waitForIntegrationReady(def.port);
 				if (ready) {
 					console.log(`[DeploymentsProvider] Camel integration running on port ${def.port}`);
-					this.refresh();
+					void this.refresh();
 				}
 			}
 		});
 		tasks.onDidEndTaskProcess((e) => {
-			const def = e.execution.task.definition as CamelTaskDefinition;
-			if (def.type === 'camel' && def.port > 0) {
-				console.log(`[DeploymentsProvider] Task ended on port ${def.port}`);
-				this.portManager.releasePort(def.port);
-				this.refresh();
-			}
+			this.handleTaskEnd(e.execution.task.definition as CamelTaskDefinition);
 		});
 	}
 
@@ -72,9 +67,18 @@ export class DeploymentsProvider implements TreeDataProvider<TreeItem> {
 		this.stopAutoRefresh();
 	}
 
-	refresh(): void {
+	/** Exposed for testing: handles task-end events — releases the port and triggers a refresh. */
+	handleTaskEnd(def: CamelTaskDefinition): void {
+		if (def.type === 'camel' && def.port > 0) {
+			console.log(`[DeploymentsProvider] Task ended on port ${def.port}`);
+			this.portManager.releasePort(def.port);
+			void this.refresh();
+		}
+	}
+
+	refresh(): Promise<void> {
 		console.log('[DeploymentsProvider] Refreshing data...');
-		void this.updateData();
+		return this.updateData();
 	}
 
 	getTreeItem(element: TreeItem): TreeItem {


### PR DESCRIPTION
## Summary

Addresses CodeRabbit feedback from #1485.

### Changes

#### `src/views/providers/DeploymentsProvider.ts`

- Extract `handleTaskEnd(def: CamelTaskDefinition)` public method that encapsulates the task-end guard and port-release logic; the `onDidEndTaskProcess` listener now delegates to it.
- Change `refresh()` to return `Promise<void>` (was void-discarding `updateData()`). The two fire-and-forget call sites inside the class are marked with `void`.

#### `src/test/views/DeploymentsProvider.test.ts`

- Task-end tests now call `provider.handleTaskEnd(makeCamelTaskDef(port))` directly and assert through the injected `PortManager`, instead of reproducing the guard logic inline. The guard-focused constant tests are preserved.
- All `await new Promise((r) => setTimeout(r, 20))` timing delays replaced with `await provider.refresh()`, making test completion deterministic.
- Import `CamelTaskDefinition`; add `makeCamelTaskDef` helper.
