### PR TITLE
fix: generate temp workspace file for unit tests to avoid dirtying tracked file

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,12 +1,31 @@
 import { defineConfig } from '@vscode/test-cli';
 import path from 'path';
 import os from 'os';
+import fs from 'fs';
+
+const projectRoot = path.resolve('.');
+
+// Write a fresh workspace file to a temp path so VS Code never modifies the
+// committed .vscode/test-workspace.code-workspace during test runs.
+// The folders[0].path must be absolute because the file is not relative to .vscode/.
+const tempWorkspace = path.join(os.tmpdir(), 'vscode-kaoto-test-workspace.code-workspace');
+fs.writeFileSync(
+	tempWorkspace,
+	JSON.stringify(
+		{
+			folders: [{ path: path.join(projectRoot, 'test Fixture with speci@l chars') }],
+			settings: {},
+		},
+		null,
+		'\t',
+	),
+);
 
 const launchArgs = process.env.CI ? [] : ['--user-data-dir', path.join(os.tmpdir(), 'vscode-kaoto-test')];
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
-	workspaceFolder: path.resolve('.vscode/test-workspace.code-workspace'),
+	workspaceFolder: tempWorkspace,
 	launchArgs,
 	mocha: {
 		ui: 'tdd',


### PR DESCRIPTION
## Problem

Running `yarn run test:unit` locally modifies the tracked file `.vscode/test-workspace.code-workspace`, leaving it dirty after every test run.

`KaotoCatalogService.test.ts` calls `setSelectedIntegrationCatalog()` and `setSelectedTestCatalog()`, both of which internally call:

```ts
config.update(settingKey, catalog.name, vscode.ConfigurationTarget.Workspace);
```

`ConfigurationTarget.Workspace` writes directly to whichever `.code-workspace` file VS Code holds as its active workspace. Since `@vscode/test-cli` was pointing `workspaceFolder` directly at the committed `.vscode/test-workspace.code-workspace`, those writes dirtied the source-controlled file after every run.

## Fix

Generate a fresh `.code-workspace` file in `os.tmpdir()` at test-runner startup (in `.vscode-test.mjs`) and point `workspaceFolder` at that temp path. The committed `.vscode/test-workspace.code-workspace` becomes a read-only reference that VS Code never opens during tests. OS handles cleanup of the temp file.

## Changes

- `.vscode-test.mjs`: add `fs` import; write temp workspace to `os.tmpdir()` before `defineConfig`; point `workspaceFolder` at the temp path

Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1489
