### PR TITLE
fix(it-tests): address CodeRabbit feedback from PR #1479

### DIFF
--- a/it-tests/MavenDependencyUpdate.test.ts
+++ b/it-tests/MavenDependencyUpdate.test.ts
@@ -25,7 +25,6 @@ import {
 	workaroundToRedrawContextualMenu,
 } from './Util';
 import {
-	By,
 	EditorView,
 	VSBrowser,
 	WebDriver,
@@ -274,7 +273,7 @@ describe('Maven dependency update pom.xml', function () {
 		).kaotoWebview;
 
 		// right click on SQL component node
-		const sqlNode = await driver.findElement(By.css('g[data-nodelabel="sql"]'));
+		const sqlNode = await KaotoCanvas.findNodeByCss(driver, 'custom-node__sql', 'sql');
 		await KaotoCanvas.openContextMenu(driver, sqlNode);
 
 		await workaroundToRedrawContextualMenu(kaotoWebview);

--- a/it-tests/Util.ts
+++ b/it-tests/Util.ts
@@ -165,9 +165,6 @@ export async function switchToKaotoFrame(
 	expectedTitle?: string,
 ): Promise<{ kaotoWebview: WebView; kaotoEditor: CustomEditor }> {
 	let kaotoEditor = new CustomEditor();
-	if (checkNotDirty) {
-		assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
-	}
 	let kaotoWebview: WebView = kaotoEditor.getWebView();
 	await driver.wait(
 		async () => {
@@ -177,6 +174,11 @@ export async function switchToKaotoFrame(
 				kaotoWebview = kaotoEditor.getWebView();
 				await kaotoWebview.switchToFrame(10_000);
 				if (await isInsideKaotoWebview(driver)) {
+					if (checkNotDirty) {
+						await kaotoWebview.switchBack();
+						assert.isFalse(await kaotoEditor.isDirty(), 'The Kaoto editor should not be dirty when opening it.');
+						await kaotoWebview.switchToFrame(10_000);
+					}
 					return true;
 				}
 				// Landed in the workbench DOM or in a foreign webview -- get back out and retry.

--- a/it-tests/pageObjects/CatalogModal.ts
+++ b/it-tests/pageObjects/CatalogModal.ts
@@ -102,12 +102,9 @@ export class CatalogModal extends AbstractElement {
 		if (open) {
 			await driver.wait(until.elementLocated(By.id(kaotoLocators.CatalogModal.providerSelectMenu)), timeout);
 		} else {
-			try {
-				await driver.wait(until.elementLocated(By.id(kaotoLocators.CatalogModal.providerSelectMenu)), timeout);
-			} catch (error) {
-				if (error instanceof Error && error.name !== 'TimeoutError') {
-					throw error;
-				}
+			const menu = await driver.findElements(By.id(kaotoLocators.CatalogModal.providerSelectMenu));
+			if (menu.length > 0) {
+				await driver.wait(until.stalenessOf(menu[0]), timeout);
 			}
 		}
 	}

--- a/it-tests/pageObjects/KaotoCanvas.ts
+++ b/it-tests/pageObjects/KaotoCanvas.ts
@@ -178,9 +178,11 @@ export class KaotoCanvas extends AbstractElement {
 	 *
 	 * @param edgeSelector  CSS selector for the edge `<g>` element
 	 */
-	static async getAddStepButton(driver: WebDriver, edgeSelector: string, _timeout = 5_000): Promise<WebElement> {
+	static async getAddStepButton(driver: WebDriver, edgeSelector: string, timeout = 5_000): Promise<WebElement> {
+		await driver.wait(until.elementLocated(By.css(edgeSelector)), timeout);
 		const edge = await driver.findElement(By.css(edgeSelector));
 		await driver.actions().move({ origin: edge, duration: 2_000 }).perform();
+		await driver.wait(until.elementLocated(By.className(kaotoLocators.KaotoEdge.addStepIcon)), timeout);
 		return edge.findElement(By.className(kaotoLocators.KaotoEdge.addStepIcon));
 	}
 


### PR DESCRIPTION
## Summary

Addresses all four open items from https://github.com/KaotoIO/vscode-kaoto/issues/1483 (CodeRabbit feedback deferred from PR #1479).

## Changes

### `it-tests/Util.ts`
Moved the `isDirty()` assertion to _after_ the Kaoto frame is verified (`isInsideKaotoWebview`). Previously it ran against a `new CustomEditor()` before `ensureKaotoEditorIsActive` and before the frame/`#envelope-app` check, meaning it could test the wrong (or no) editor. Now it switches back to the workbench, asserts, then re-enters the frame.

### `it-tests/MavenDependencyUpdate.test.ts`
Replaced the raw `driver.findElement(By.css('g[data-nodelabel="sql"]'))` with `KaotoCanvas.findNodeByCss(driver, 'custom-node__sql', 'sql')`, which covers both Kaoto 2.3 (`data-testid`) and 2.4+ (`data-nodelabel`) attribute shapes and includes a proper wait. Removed now-unused `By` import.

### `it-tests/pageObjects/CatalogModal.ts`
Fixed the `open=false` branch of `toggleProviderDropdown` to wait for the menu element to go **stale** (`until.stalenessOf`) instead of waiting for it to be _located_ (which was identical to the open branch). If the menu isn't in the DOM, the wait is skipped entirely.

### `it-tests/pageObjects/KaotoCanvas.ts`
Wired the `timeout` parameter (was `_timeout`, effectively ignored) through to both underlying waits in `getAddStepButton`: waiting for the edge element and waiting for the add-step icon after hover.

## References

- Closes https://github.com/KaotoIO/vscode-kaoto/issues/1483
- Original staged PR: https://github.com/KaotoIO/vscode-kaoto/pull/1479
- Source PR (djelinek): https://github.com/KaotoIO/vscode-kaoto/pull/1464