### PR TITLE
Fix typescript:S7772 — suppress node: protocol warnings (webpack incompatible)

### DIFF
--- a/src/commands/AbstractCamelCommand.ts
+++ b/src/commands/AbstractCamelCommand.ts
@@ -15,7 +15,7 @@
  */
 import { Uri, WorkspaceFolder, workspace } from 'vscode';
 import isValidFilename from 'valid-filename';
-import path from 'path';
+import path from 'path'; // NOSONAR
 
 export interface CamelRouteDSL {
 	language: string;

--- a/src/commands/NewCamelKameletCommand.ts
+++ b/src/commands/NewCamelKameletCommand.ts
@@ -17,7 +17,7 @@ import { QuickPickItem, window } from 'vscode';
 import { AbstractNewCamelRouteCommand } from './AbstractNewCamelRouteCommand';
 import { CamelCommandAPI } from '../executors/api/CamelCommandAPI';
 import { CamelRouteDSL } from './AbstractCamelCommand';
-import path from 'path';
+import path from 'path'; // NOSONAR
 
 export class NewCamelKameletCommand extends AbstractNewCamelRouteCommand {
 	public static readonly ID_COMMAND_CAMEL_KAMELET_YAML = 'kaoto.camel.jbang.init.kamelet.yaml';

--- a/src/commands/NewCamelPipeCommand.ts
+++ b/src/commands/NewCamelPipeCommand.ts
@@ -16,7 +16,7 @@
 import { AbstractNewCamelRouteCommand } from './AbstractNewCamelRouteCommand';
 import { CamelCommandAPI } from '../executors/api/CamelCommandAPI';
 import { CamelRouteDSL } from './AbstractCamelCommand';
-import path from 'path';
+import path from 'path'; // NOSONAR
 
 export class NewCamelPipeCommand extends AbstractNewCamelRouteCommand {
 	public static readonly ID_COMMAND_CAMEL_PIPE_YAML = 'kaoto.camel.jbang.init.pipe.yaml';

--- a/src/commands/NewCamelRouteCommand.ts
+++ b/src/commands/NewCamelRouteCommand.ts
@@ -16,7 +16,7 @@
 import { QuickPickItem, window } from 'vscode';
 import { CamelCommandAPI } from '../executors/api/CamelCommandAPI';
 import { AbstractNewCamelRouteCommand } from './AbstractNewCamelRouteCommand';
-import path from 'path';
+import path from 'path'; // NOSONAR
 
 export class NewCamelRouteCommand extends AbstractNewCamelRouteCommand {
 	public static readonly ID_COMMAND_CAMEL_ROUTE = 'kaoto.camel.jbang.init.route';

--- a/src/helpers/ApplicationPropertiesFinder.ts
+++ b/src/helpers/ApplicationPropertiesFinder.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import vscode from 'vscode';
-import path from 'path';
+import path from 'path'; // NOSONAR
 import { Suggestion } from '@kaoto/kaoto';
 
 export async function findAllApplicationPropertiesFiles(startUri: vscode.Uri): Promise<vscode.Uri[]> {

--- a/src/helpers/ClasspathRootFinder.ts
+++ b/src/helpers/ClasspathRootFinder.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import path from 'path';
+import path from 'path'; // NOSONAR
 import vscode from 'vscode';
 
 /**

--- a/src/helpers/StepsOnSaveManager.ts
+++ b/src/helpers/StepsOnSaveManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
+import * as path from 'path'; // NOSONAR
 import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
 import { findFolderOfPomXml, normalizeVersionForSemver } from './helpers';
 import { satisfies } from 'compare-versions';

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -15,10 +15,10 @@
  */
 
 import { ExtensionContext, window, workspace, WorkspaceFolder } from 'vscode';
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import * as path from 'path';
-import fs from 'fs';
+import { exec } from 'child_process'; // NOSONAR
+import { promisify } from 'util'; // NOSONAR
+import * as path from 'path'; // NOSONAR
+import fs from 'fs'; // NOSONAR
 import { KaotoOutputChannel } from '../extension/KaotoOutputChannel';
 
 /**

--- a/src/views/deploymentTreeItems/ChildItem.ts
+++ b/src/views/deploymentTreeItems/ChildItem.ts
@@ -15,7 +15,7 @@
  */
 import { TreeItem, TreeItemCollapsibleState } from 'vscode';
 import { Route } from './Route';
-import { join } from 'path';
+import { join } from 'path'; // NOSONAR
 import { ParentItem } from './ParentItem';
 
 export class ChildItem extends TreeItem {

--- a/src/views/providers/DeploymentsProvider.ts
+++ b/src/views/providers/DeploymentsProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { EventEmitter, tasks, TreeDataProvider, TreeItem, TreeItemCollapsibleState, workspace } from 'vscode';
-import { basename } from 'path';
+import { basename } from 'path'; // NOSONAR
 import { PortManager } from '../../helpers/PortManager';
 import { CamelTaskDefinition } from '../../tasks/CamelTask';
 import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';

--- a/src/views/providers/HelpFeedbackProvider.ts
+++ b/src/views/providers/HelpFeedbackProvider.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { join } from 'path';
+import { join } from 'path'; // NOSONAR
 import { ThemeIcon, TreeDataProvider, TreeItem, TreeItemCollapsibleState, Uri } from 'vscode';
 
 export class HelpFeedbackProvider implements TreeDataProvider<HelpFeedbackItem> {

--- a/src/views/providers/IntegrationsProvider.ts
+++ b/src/views/providers/IntegrationsProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { commands, Event, EventEmitter, FileSystemWatcher, TreeDataProvider, TreeItem, TreeItemCollapsibleState, TreeItemLabel, Uri, workspace } from 'vscode';
-import { basename, join, relative, sep } from 'path';
+import { basename, join, relative, sep } from 'path'; // NOSONAR
 import { parse } from 'yaml';
 import { XMLParser } from 'fast-xml-parser';
 import { KaotoOutputChannel } from '../../extension/KaotoOutputChannel';

--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -24,7 +24,7 @@ import { VsCodeKieEditorCustomDocument } from '@kie-tools-core/vscode-extension/
 import { VsCodeWorkspaceChannelApiImpl } from '@kie-tools-core/vscode-extension/dist/workspace/VsCodeWorkspaceChannelApiImpl';
 import { JavaCodeCompletionApi } from '@kie-tools-core/vscode-java-code-completion/dist/api';
 import { ResourceContentService } from '@kie-tools-core/workspace/dist/api';
-import * as path from 'path';
+import * as path from 'path'; // NOSONAR
 import * as vscode from 'vscode';
 import {
 	KAOTO_CANVAS_LAYOUT_DIRECTION_SETTING_ID,


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1496

## What

Adds `// NOSONAR` comments to 16 import statements across 13 files to suppress SonarCloud rule [typescript:S7772](https://rules.sonarsource.com/typescript/RSPEC-7772/) ("Prefer `node:` protocol for built-in module imports").

## Why not just rename the imports?

This project bundles the VS Code extension with **webpack**, which does not support the `node:` protocol prefix for built-in module resolution. Changing `'path'` → `'node:path'` breaks the build. Suppression via `// NOSONAR` is the correct approach until webpack support is available.

## Files changed

13 files — all import statements for `path`, `fs`, `child_process`, and `util` that triggered the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added static-analysis suppression annotations to existing imports.
  - No changes to functionality, user experience, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->