### PR TITLE
Fix githubactions:S6505 — add --ignore-scripts to package manager install steps in CI

### DIFF
--- a/.github/workflows/_integration-tests.yaml
+++ b/.github/workflows/_integration-tests.yaml
@@ -83,7 +83,7 @@ jobs:
           enable-qemu: ${{ inputs.enable-qemu && 'true' || 'false' }}
       - name: Install Yarn
         if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
+        run: npm install -g yarn --ignore-scripts
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
         with:
@@ -123,7 +123,7 @@ jobs:
           cache: yarn
       - name: Install Yarn
         if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
+        run: npm install -g yarn --ignore-scripts
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
         with:
@@ -159,7 +159,7 @@ jobs:
           cache: yarn
       - name: Install Yarn
         if: ${{ inputs.install-yarn }}
-        run: npm install -g yarn
+        run: npm install -g yarn --ignore-scripts
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         run: yarn build:vsix
       - name: Generate SBOM
         run: |
-          npm install -g @cyclonedx/cdxgen
+          npm install -g @cyclonedx/cdxgen --ignore-scripts
           cdxgen -o manifest.json
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/main-kaoto.yaml
+++ b/.github/workflows/main-kaoto.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Kaoto build
         working-directory: kaoto
         run: |
-          yarn
+          yarn install --immutable --mode=skip-build
           yarn workspace @kaoto/kaoto run build:lib
       - name: yarn link kaoto
         working-directory: vscode-kaoto


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1502

## What

Resolves SonarCloud rule [githubactions:S6505](https://rules.sonarsource.com/githubactions/RSPEC-6505/) — lifecycle scripts should not run automatically during CI package installation, as a compromised dependency could exploit this to execute arbitrary code in the build environment.

## Changes

- `.github/workflows/_integration-tests.yaml` (3 occurrences): `npm install -g yarn` → `npm install -g yarn --ignore-scripts`
- `.github/workflows/ci.yaml` (1 occurrence): `npm install -g @cyclonedx/cdxgen` → `npm install -g @cyclonedx/cdxgen --ignore-scripts`
- `.github/workflows/main-kaoto.yaml` (1 occurrence): bare `yarn` → `YARN_ENABLE_SCRIPTS=false yarn install` (Yarn v2+ compliant form)