### PR TITLE
Fix typescript:S107 — suppress constructor parameter count warning in VSCodeKaotoEditorChannelApi

### DIFF
--- a/src/webview/VSCodeKaotoEditorChannelApi.ts
+++ b/src/webview/VSCodeKaotoEditorChannelApi.ts
@@ -50,6 +50,7 @@ export class VSCodeKaotoEditorChannelApi extends DefaultVsCodeKieEditorChannelAp
 	private readonly currentEditedDocument: vscode.TextDocument | VsCodeKieEditorCustomDocument;
 
 	constructor(
+		/* NOSONAR — parameter count is dictated by the parent class DefaultVsCodeKieEditorChannelApiImpl */
 		editor: VsCodeKieEditorController,
 		resourceContentService: ResourceContentService,
 		workspaceApi: VsCodeWorkspaceChannelApiImpl,


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/vscode-kaoto/issues/1508

## What

Adds `/* NOSONAR */` to the constructor of `VSCodeKaotoEditorChannelApi` to suppress SonarCloud rule [typescript:S107](https://rules.sonarsource.com/typescript/RSPEC-107/) (constructor has 8 parameters, max is 7).

## Why not refactor

The 8 parameters are required by the parent class `DefaultVsCodeKieEditorChannelApiImpl` from `@kie-tools-core/vscode-extension` — a third-party library we cannot modify. All 8 must be forwarded to `super()` and TypeScript does not allow any transformation before that call. The suppression is the correct approach until the upstream API changes.