### PR TITLE
chore(catalog): bump kaoto/camel-catalog to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.12.0
 
+- Upgrade default Camel CLI/Launcher version from 4.20.0 to 4.22.0
 - Add launch config for a simple run of exported Camel (Maven) Application
 - Add `Infrastructure` section into Kaoto view (experimental)
   - list running infrastructure services

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:ui:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.9.11",
+    "@kaoto/camel-catalog": "^0.10.0",
     "@kaoto/kaoto": "2.12.0-RC1",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",

--- a/src/ui-test/vscode-settings-minikube.json
+++ b/src/ui-test/vscode-settings-minikube.json
@@ -18,6 +18,6 @@
     "container.image-push=true",
     "--trait",
     "container.image-pull-policy=IfNotPresent",
-    "--camel-version=4.20.0"
+    "--camel-version=4.22.0"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.9.11":
-  version: 0.9.11
-  resolution: "@kaoto/camel-catalog@npm:0.9.11"
-  checksum: 10/0c078361baba16b2f320c98add1466b5f0f1d697babcda44688a83c9d5542459f5a346d6203d466fa31f5fade6da34d2f6694c1864399eed86dc04d8bce0a165
+"@kaoto/camel-catalog@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@kaoto/camel-catalog@npm:0.10.0"
+  checksum: 10/405b2608960ed1b4e45350ca317add11d3f9a304d4a449af0c35f7f8ead7d8b5f5473add4044bb200a91bea313828403d7f1cf0610ac62b14e4b00a63cd31556
   languageName: node
   linkType: hard
 
@@ -13350,7 +13350,7 @@ __metadata:
   resolution: "vscode-kaoto@workspace:."
   dependencies:
     "@cyclonedx/cdxgen": "npm:12.8.4"
-    "@kaoto/camel-catalog": "npm:^0.9.11"
+    "@kaoto/camel-catalog": "npm:^0.10.0"
     "@kaoto/kaoto": "npm:2.12.0-RC1"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"


### PR DESCRIPTION
This brings also bump of Camel CLI and Camel Launcher to a latest LTS version Camel 4.22.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the default Camel CLI and Launcher version from 4.20.0 to 4.22.0.
  * Updated the Camel catalog to the 0.10.0 release.
  * Updated Kubernetes-based execution settings to use Camel 4.22.0 for improved version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->