### PR TITLE
chore: bump kaoto/camel-catalog to 0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:ui:clean": "rimraf ./test-resources && rimraf ./out && rimraf *.vsix"
   },
   "dependencies": {
-    "@kaoto/camel-catalog": "^0.9.11",
+    "@kaoto/camel-catalog": "^0.10.1",
     "@kaoto/kaoto": "2.12.0-RC1",
     "@kie-tools-core/backend": "10.0.0",
     "@kie-tools-core/editor": "10.0.0",

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CAMEL_VERSION_FALLBACK: string = '4.22.0';
+export const DEFAULT_CAMEL_VERSION_FALLBACK: string = '4.20.0';
 
 /** Minimum camel-jbang version required for the 'camel test' plugin (4.22.0 ships the plugin natively; 4.20 uses a broken JBang shim) */
 export const MIN_CAMEL_VERSION_FOR_TEST: string = '4.22.0';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,10 +1394,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kaoto/camel-catalog@npm:^0.9.11":
-  version: 0.9.11
-  resolution: "@kaoto/camel-catalog@npm:0.9.11"
-  checksum: 10/0c078361baba16b2f320c98add1466b5f0f1d697babcda44688a83c9d5542459f5a346d6203d466fa31f5fade6da34d2f6694c1864399eed86dc04d8bce0a165
+"@kaoto/camel-catalog@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "@kaoto/camel-catalog@npm:0.10.1"
+  checksum: 10/54e46c9c441d49b1eac388f7f8197305bb75f1dcab25a4c168d18bd9f0edc9f2a0d34448c99a8ed2a330373c6680435174497179ea70575289dd8204349553a0
   languageName: node
   linkType: hard
 
@@ -13350,7 +13350,7 @@ __metadata:
   resolution: "vscode-kaoto@workspace:."
   dependencies:
     "@cyclonedx/cdxgen": "npm:12.8.4"
-    "@kaoto/camel-catalog": "npm:^0.9.11"
+    "@kaoto/camel-catalog": "npm:^0.10.1"
     "@kaoto/kaoto": "npm:2.12.0-RC1"
     "@kie-tools-core/backend": "npm:10.0.0"
     "@kie-tools-core/editor": "npm:10.0.0"


### PR DESCRIPTION
- brings Camel Catalog downgrade from 4.22 to 4.20 until Maven Update dependency bug is fixed into upstream and fix back-ported in 4.22.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated the Camel catalog integration to a newer version, providing access to updated catalog definitions.
  - Updated the default fallback Camel version used when no version is specified, ensuring consistent version selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->